### PR TITLE
Correct Lion name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The table below shows systems that have successfully passed tests for creating a
 | **OS X Yosemite** | 10.10 | ✅ |
 | **OS X Mavericks** | 10.9 | ❌ |
 | **OS X Mountain Lion** | 10.8 | ✅ |
-| **Mac OS X Lion** | 10.7 | ✅ |
+| **OS X Lion** | 10.7 | ✅ |
 
 ---
 


### PR DESCRIPTION
~~"Mac OS X Lion" should read "OS X Lion"; see https://en.wikipedia.org/wiki/OS_X_Lion~~

Mea culpa! "Mac OS X Lion" was correct: https://github.com/Kruszoneq/macUSB/pull/2#issuecomment-3678567148 .