### PR TITLE
Allow large external drives

### DIFF
--- a/macUSB/Features/Analysis/AnalysisLogic.swift
+++ b/macUSB/Features/Analysis/AnalysisLogic.swift
@@ -42,6 +42,9 @@ final class AnalysisLogic: ObservableObject {
 
     @Published var isCapacitySufficient: Bool = false
     @Published var capacityCheckFinished: Bool = false
+    
+    // Setting: Allow big USB drives
+    @Published var showLargeExternalDrives: Bool = true
 
     // Computed: true only when app has recognized a supported system and can proceed normally
     var isRecognizedAndSupported: Bool {
@@ -603,7 +606,7 @@ final class AnalysisLogic: ObservableObject {
 
     func refreshDrives() {
         let currentSelectedURL = selectedDrive?.url
-        let foundDrives = USBDriveLogic.enumerateAvailableDrives()
+        let foundDrives = USBDriveLogic.enumerateAvailableDrives(includeLargeDrives: showLargeExternalDrives)
         self.availableDrives = foundDrives
         if let currentURL = currentSelectedURL {
             if let stillConnectedDrive = foundDrives.first(where: { $0.url == currentURL }) {

--- a/macUSB/Features/Analysis/SystemAnalysisView.swift
+++ b/macUSB/Features/Analysis/SystemAnalysisView.swift
@@ -311,6 +311,20 @@ struct SystemAnalysisView: View {
             
             VStack(alignment: .leading, spacing: 10) {
                 Text("Wybierz docelowy dysk USB:").font(.subheadline)
+                
+                HStack {
+                    Toggle(isOn: $logic.showLargeExternalDrives) {
+                        Text(String(localized: "Pokaż duże dyski zewnętrzne")).font(.caption)
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .onChange(of: logic.showLargeExternalDrives) { _ in
+                        logic.refreshDrives()
+                    }
+                    Spacer()
+                }
+                .padding(.vertical, 4)
+                
                 if logic.availableDrives.isEmpty {
                     HStack {
                         Image(systemName: "externaldrive.badge.xmark").font(.title2).foregroundColor(.red).frame(width: 32)

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -4529,6 +4529,58 @@
         }
       }
     },
+    "Pokaż duże dyski zewnętrzne" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Große externe Laufwerke anzeigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show large external drives"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar unidades externas grandes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les disques externes volumineux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大きな外部ドライブを表示"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar unidades externas grandes"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показать большие внешние накопители"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示大型外部驱动器"
+          }
+        }
+      }
+    },
     "Polski 🇵🇱" : {
       "localizations" : {
         "de" : {

--- a/macUSB/Shared/Services/USBDriveLogic.swift
+++ b/macUSB/Shared/Services/USBDriveLogic.swift
@@ -17,13 +17,54 @@ struct USBDriveLogic {
             return "unknown"
         } ?? "unknown"
     }
+    
+    /// Checks if a volume is a network  drive
+    static func isNetworkVolume(_ url: URL) -> Bool {
+        return url.withUnsafeFileSystemRepresentation { ptr in
+            guard let ptr = ptr else { return true }
+            var stat = statfs()
+            if statfs(ptr, &stat) == 0 {
+                var raw = stat.f_mntfromname
+                let mntFrom = withUnsafePointer(to: &raw) {
+                    $0.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) {
+                        String(cString: $0)
+                    }
+                }
+                let networkPrefixes = ["smb://", "afp://", "nfs://", "cifs://", "webdav://", "ftp://"]
+                if networkPrefixes.contains(where: { mntFrom.lowercased().hasPrefix($0) }) {
+                    return true
+                }
+                if !mntFrom.hasPrefix("/dev/") {
+                    return true
+                }
+            }
+            return false
+        } ?? true
+    }
+    
+    /// Checks if a volume is a virtual disk image rather than a physical drive
+    static func isVirtualDiskImage(_ url: URL) -> Bool {
+        return url.withUnsafeFileSystemRepresentation { ptr in
+            guard let ptr = ptr else { return true }
+            var stat = statfs()
+            if statfs(ptr, &stat) == 0 {
+                let mountPath = url.path.lowercased()
+                if mountPath.contains(".dmg") || mountPath.contains("disk image") {
+                    return true
+                }
+            }
+            return false
+        } ?? true
+    }
 
-    /// Enumerates removable, non-internal mounted volumes and returns them as USBDrive models.
-    static func enumerateAvailableDrives() -> [USBDrive] {
+    /// Enumerates external USB drives (including SSDs/HDDs) while excluding internal drives and network volumes.
+    /// - Parameter includeLargeDrives: If true, includes external SSDs/HDDs (ejectable). If false, only shows removable USB sticks.
+    static func enumerateAvailableDrives(includeLargeDrives: Bool = true) -> [USBDrive] {
         let keys: [URLResourceKey] = [
             .volumeNameKey,
             .volumeIsRemovableKey,
             .volumeIsInternalKey,
+            .volumeIsEjectableKey,
             .volumeTotalCapacityKey
         ]
         guard let urls = FileManager.default.mountedVolumeURLs(
@@ -32,15 +73,41 @@ struct USBDriveLogic {
         ) else { return [] }
 
         let drives: [USBDrive] = urls.compactMap { url -> USBDrive? in
+            if isNetworkVolume(url) {
+                return nil
+            }
+            
+            if isVirtualDiskImage(url) {
+                return nil
+            }
+            
             guard let v = try? url.resourceValues(forKeys: Set(keys)),
-                  let isRemovable = v.volumeIsRemovable, isRemovable,
-                  let isInternal = v.volumeIsInternal, !isInternal,
+                  let isInternal = v.volumeIsInternal,
+                  !isInternal,
                   let name = v.volumeName else {
                 return nil
             }
+            
+            let isRemovable = v.volumeIsRemovable ?? false
+            let isEjectable = v.volumeIsEjectable ?? false
+            
+            let deviceName = getBSDName(from: url)
+            guard deviceName != "unknown" && deviceName.hasPrefix("disk") else {
+                return nil
+            }
+            
+            if !includeLargeDrives {
+                guard isRemovable else {
+                    return nil
+                }
+            } else {
+                if !isRemovable && !isEjectable {
+                    // Accept external drives with valid BSD name even if not marked removable/ejectable
+                }
+            }
+            
             let totalCapacity = Int64(v.volumeTotalCapacity ?? 0)
             let size = ByteCountFormatter.string(fromByteCount: totalCapacity, countStyle: .file)
-            let deviceName = getBSDName(from: url)
             return USBDrive(name: name, device: deviceName, size: size, url: url)
         }
         return drives


### PR DESCRIPTION
I use an SSD connected via a SATA to USB adapter to create install images, as it is significantly faster than a USB flash drive.
Previously, MacUSB did not display such drives, so I added a small feature to make them visible.

The option can be enabled or disabled by the user and automatically filters out irrelevant volumes such as network drives or mounted disk images.

Thanks for this awesome app!