### PR TITLE
Add issue templates and update support section in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: "Bug Report"
+description: "Report a technical issue or error in macUSB."
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide the following technical details to allow for accurate reproduction and diagnosis of the issue.
+  - type: checkboxes
+    id: version_check
+    attributes:
+      label: "Application Version"
+      options:
+        - label: "I confirm that I am using the latest available version of macUSB."
+          required: true
+  - type: input
+    id: host_os_version
+    attributes:
+      label: "Host OS Version"
+      description: "The version of macOS currently running macUSB."
+      placeholder: "e.g., macOS Sequoia 15.1"
+    validations:
+      required: true
+  - type: input
+    id: target_os_version
+    attributes:
+      label: "Target OS Version"
+      description: "The version of macOS/OS X you are attempting to prepare."
+      placeholder: "e.g., Mac OS X Tiger 10.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: file_format
+    attributes:
+      label: "File Format"
+      description: "Select the format of the source installer file."
+      multiple: true
+      options:
+        - ".dmg"
+        - ".app"
+        - ".iso"
+        - ".cdr"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: installer_source
+    attributes:
+      label: "Installer Source and Link"
+      description: "Specify where the installer file was obtained. Provide a direct link if possible."
+      placeholder: "e.g., Mist, Internet Archive (include URL)"
+    validations:
+      required: true
+  - type: textarea
+    id: detailed_description
+    attributes:
+      label: "Detailed Description of the Issue"
+      description: "Provide a comprehensive explanation of the error. Specify the exact stage where the process fails."
+      placeholder: "Example: After selecting the .dmg file, the application stays on the scanning screen for 5 minutes and then returns 'Analysis error'..."
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        ### Screenshots
+        Attach images of the error or the application window by dragging and dropping them below.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: "Feature Request"
+description: "Suggest a new idea or improvement for macUSB."
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to propose new features or improvements. Please be specific about the technical benefits of your suggestion.
+  - type: textarea
+    id: feature_description
+    attributes:
+      label: "Feature Description"
+      description: "A clear and concise description of the proposed feature."
+      placeholder: "Example: Add a system notification or a sound alert once the process of creating the bootable drive is finished."
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: "Motivation and Use Case"
+      description: "Why is this feature needed? What problem does it solve for users of macUSB?"
+      placeholder: "Example: This would allow the user to work on other tasks and be immediately informed when the USB drive is ready to be unplugged."
+    validations:
+      required: true
+  - type: textarea
+    id: implementation_ideas
+    attributes:
+      label: "Possible Implementation"
+      description: "Do you have any technical ideas on how this could be implemented? (Optional)"
+      placeholder: "Mention specific commands, libraries, or methods if applicable."
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -110,13 +110,12 @@ The application interface automatically adapts to the system language:
 
 ## 🛠️ Support & Bug Reports
 
-If you encounter any issues, please report them via [GitHub Issues](https://github.com/Kruszoneq/macUSB/issues). To help me replicate and fix the bug faster, please include the following details:
+Any technical issues or suggestions for new features should be reported via [GitHub Issues](https://github.com/Kruszoneq/macUSB/issues). To simplify the diagnostic process and expedite issue handling, it is highly recommended to use the available reporting templates whenever possible:
 
-* **Description of the issue:** What happened and at what stage?
-* **Screenshot:** An image of the error or the application window is highly helpful for diagnosis.
-* **Host OS Version:** Which macOS version are you running macUSB on (e.g., macOS Sequoia 15.1)?
-* **Target OS Version:** Which system are you trying to prepare (e.g., Mac OS X Tiger 10.4)?
-* **Installer Source & LINK:** Where did the installer file come from (e.g., Mist, Internet Archive)? **If possible, please provide a link to the source** – this allows me to download the exact same image and test it on my end.
+* **Bug Report**: Recommended for reporting technical errors. If possible, details such as **Host OS Version**, **Target OS Version**, file format (e.g., **.dmg**, **.app**), and the installer source and link should be provided.
+* **Feature Request**: Recommended for suggesting new ideas or improvements for the application.
+
+Including screenshots of the error or the application window is highly helpful and allows for a faster analysis of the reported issue.
 
 ---
 


### PR DESCRIPTION
Introduced new GitHub issue templates for bug reports and feature requests to standardize and streamline user feedback. Updated the README support section to reference these templates and clarify the recommended information to include when reporting issues or suggesting features.