### PR TITLE
Add language menu to main menu and play result sound once

### DIFF
--- a/macUSB/App/macUSBApp.swift
+++ b/macUSB/App/macUSBApp.swift
@@ -104,6 +104,42 @@ struct macUSBApp: App {
                         menuState.enableExternalDrives()
                     }
                 }
+                Divider()
+                Menu(String(localized: "Język")) {
+                    Button {
+                        languageManager.currentLanguage = "auto"
+                    } label: {
+                        Label(String(localized: "Automatycznie"), systemImage: languageManager.isAuto ? "checkmark" : "")
+                    }
+                    Divider()
+                    Button { languageManager.currentLanguage = "pl" } label: {
+                        Label("Polski", systemImage: languageManager.currentLanguage == "pl" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "en" } label: {
+                        Label("English", systemImage: languageManager.currentLanguage == "en" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "de" } label: {
+                        Label("Deutsch", systemImage: languageManager.currentLanguage == "de" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "fr" } label: {
+                        Label("Français", systemImage: languageManager.currentLanguage == "fr" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "es" } label: {
+                        Label("Español", systemImage: languageManager.currentLanguage == "es" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "pt-BR" } label: {
+                        Label("Português (BR)", systemImage: languageManager.currentLanguage == "pt-BR" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "ru" } label: {
+                        Label("Русский", systemImage: languageManager.currentLanguage == "ru" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "zh-Hans" } label: {
+                        Label("简体中文", systemImage: languageManager.currentLanguage == "zh-Hans" ? "checkmark" : "")
+                    }
+                    Button { languageManager.currentLanguage = "ja" } label: {
+                        Label("日本語", systemImage: languageManager.currentLanguage == "ja" ? "checkmark" : "")
+                    }
+                }
             }
             CommandMenu(String(localized: "Narzędzia")) {
                 Button(String(localized: "Otwórz Narzędzie dyskowe")) {
@@ -122,41 +158,6 @@ struct macUSBApp: App {
                             }
                         }
                     }
-                }
-            }
-            CommandMenu(String(localized: "Język")) {
-                Button {
-                    languageManager.currentLanguage = "auto"
-                } label: {
-                    Label(String(localized: "Automatycznie"), systemImage: languageManager.isAuto ? "checkmark" : "")
-                }
-                Divider()
-                Button { languageManager.currentLanguage = "pl" } label: {
-                    Label("Polski", systemImage: languageManager.currentLanguage == "pl" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "en" } label: {
-                    Label("English", systemImage: languageManager.currentLanguage == "en" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "de" } label: {
-                    Label("Deutsch", systemImage: languageManager.currentLanguage == "de" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "fr" } label: {
-                    Label("Français", systemImage: languageManager.currentLanguage == "fr" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "es" } label: {
-                    Label("Español", systemImage: languageManager.currentLanguage == "es" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "pt-BR" } label: {
-                    Label("Português (BR)", systemImage: languageManager.currentLanguage == "pt-BR" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "ru" } label: {
-                    Label("Русский", systemImage: languageManager.currentLanguage == "ru" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "zh-Hans" } label: {
-                    Label("简体中文", systemImage: languageManager.currentLanguage == "zh-Hans" ? "checkmark" : "")
-                }
-                Button { languageManager.currentLanguage = "ja" } label: {
-                    Label("日本語", systemImage: languageManager.currentLanguage == "ja" ? "checkmark" : "")
                 }
             }
             CommandGroup(replacing: .windowList) { }

--- a/macUSB/Features/Finish/FinishUSBView.swift
+++ b/macUSB/Features/Finish/FinishUSBView.swift
@@ -11,6 +11,7 @@ struct FinishUSBView: View {
     @State private var isCleaning: Bool = true
     @State private var cleanupSuccess: Bool = false
     @State private var cleanupErrorMessage: String? = nil
+    @State private var didPlayResultSound: Bool = false
     
     private var isSnowLeopard: Bool {
         let lower = systemName.lowercased()
@@ -206,7 +207,7 @@ struct FinishUSBView: View {
                 window.styleMask.remove(.resizable)
             }
         )
-        .onAppear { performCleanupWithDelay() }
+        .onAppear { playResultSoundOnce(); performCleanupWithDelay() }
     }
     
     // --- LOGIKA ---
@@ -230,6 +231,27 @@ struct FinishUSBView: View {
                     self.cleanupErrorMessage = errorMsg
                     self.isCleaning = false
                 }
+            }
+        }
+    }
+    
+    // --- DŹWIĘK WYNIKU ---
+    func playResultSoundOnce() {
+        // Zabezpieczenie przed wielokrotnym odtworzeniem
+        if didPlayResultSound { return }
+        didPlayResultSound = true
+        
+        if didFail {
+            // Dźwięk niepowodzenia
+            if let failSound = NSSound(named: NSSound.Name("Basso")) {
+                failSound.play()
+            }
+        } else {
+            // Dźwięk sukcesu (jak w instalatorach pkg)
+            if let successSound = NSSound(named: NSSound.Name("Glass")) {
+                successSound.play()
+            } else if let hero = NSSound(named: NSSound.Name("Hero")) {
+                hero.play()
             }
         }
     }


### PR DESCRIPTION
Moved the language selection menu from a CommandMenu to a submenu in the main menu for better accessibility. Added logic in FinishUSBView to play a result sound (success or failure) only once when the view appears, preventing multiple sound plays.