### PR TITLE
Detect and display USB drive speed in UI

### DIFF
--- a/macUSB/Features/Analysis/AnalysisLogic.swift
+++ b/macUSB/Features/Analysis/AnalysisLogic.swift
@@ -79,7 +79,9 @@ final class AnalysisLogic: ObservableObject {
             guard !bsd.isEmpty && bsd != "unknown" else { return nil }
             let totalCapacity = Int64(v.volumeTotalCapacity ?? 0)
             let size = ByteCountFormatter.string(fromByteCount: totalCapacity, countStyle: .file)
-            return USBDrive(name: name, device: bsd, size: size, url: url)
+            let whole = USBDriveLogic.wholeDiskName(from: bsd)
+            let speed = USBDriveLogic.detectUSBSpeed(forBSDName: whole)
+            return USBDrive(name: name, device: bsd, size: size, url: url, usbSpeed: speed)
         }
         return candidates
     }

--- a/macUSB/Features/Installation/UniversalInstallationView.swift
+++ b/macUSB/Features/Installation/UniversalInstallationView.swift
@@ -88,6 +88,29 @@ struct UniversalInstallationView: View {
                         .padding().frame(maxWidth: .infinity, alignment: .leading)
                         .background(Color.blue.opacity(0.1)).cornerRadius(8)
                     }
+
+                    if let drive = targetDrive, drive.usbSpeed == .usb2 {
+                        HStack(alignment: .center) {
+                            Image(systemName: "externaldrive.fill")
+                                .font(.title2)
+                                .foregroundColor(.orange)
+                                .frame(width: 32)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Wybrano nośnik USB 2.0")
+                                    .font(.headline)
+                                    .foregroundColor(.orange)
+                                Text("Wybrany nośnik pracuje w starszym standardzie przesyłu danych. Proces tworzenia instalatora może potrwać kilkanaście minut")
+                                    .font(.subheadline)
+                                    .foregroundColor(.orange.opacity(0.8))
+                            }
+                            Spacer()
+                        }
+                        .padding()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.orange.opacity(0.1))
+                        .cornerRadius(8)
+                        .transition(.opacity)
+                    }
                     
                     // RAMKA: Przebieg
                     HStack(alignment: .top) {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -8223,6 +8223,58 @@
         }
       }
     },
+    "Wybrano nośnik USB 2.0" : {
+          "localizations" : {
+            "de" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "USB 2.0-Laufwerk ausgewählt"
+              }
+            },
+            "en" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "USB 2.0 drive selected"
+              }
+            },
+            "es" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Unidad USB 2.0 seleccionada"
+              }
+            },
+            "fr" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Lecteur USB 2.0 sélectionné"
+              }
+            },
+            "ja" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "USB 2.0ドライブが選択されました"
+              }
+            },
+            "pt-BR" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Unidade USB 2.0 selecionada"
+              }
+            },
+            "ru" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Выбран накопитель USB 2.0"
+              }
+            },
+            "zh-Hans" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "已选择 USB 2.0 驱动器"
+              }
+            }
+          }
+        },
     "Wybrany dysk USB" : {
       "localizations" : {
         "de" : {
@@ -8327,6 +8379,58 @@
         }
       }
     },
+    "Wybrany nośnik pracuje w starszym standardzie przesyłu danych. Proces tworzenia instalatora może potrwać kilkanaście minut" : {
+          "localizations" : {
+            "de" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Das ausgewählte Laufwerk verwendet einen älteren Datenübertragungsstandard. Die Erstellung des Installers kann einige Minuten dauern."
+              }
+            },
+            "en" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "The selected drive operates on an older data transfer standard. The installer creation process may take several minutes."
+              }
+            },
+            "es" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "La unidad seleccionada utiliza un estándar de transferencia de datos más antiguo. El proceso de creación del instalador puede tardar varios minutos."
+              }
+            },
+            "fr" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Le lecteur sélectionné utilise une norme de transfert de données plus ancienne. La création de l'installateur peut prendre plusieurs minutes."
+              }
+            },
+            "ja" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "選択されたドライブは古いデータ転送規格を使用しています。インストーラの作成には十数分かかる場合があります。"
+              }
+            },
+            "pt-BR" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "A unidade selecionada usa um padrão de transferência de dados mais antigo. O processo de criação do instalador pode levar vários minutos."
+              }
+            },
+            "ru" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "Выбранный накопитель использует устаревший стандарт передачи данных. Процесс создания установщика может занять несколько минут."
+              }
+            },
+            "zh-Hans" : {
+              "stringUnit" : {
+                "state" : "translated",
+                "value" : "所选驱动器使用的是较旧的数据传输标准。安装程序创建过程可能需要几分钟。"
+              }
+            }
+          }
+        },
     "Wybrany system nie jest wspierany przez aplikację" : {
       "comment" : "Generic unsupported system message",
       "localizations" : {

--- a/macUSB/Shared/Models/Models.swift
+++ b/macUSB/Shared/Models/Models.swift
@@ -7,6 +7,18 @@ enum SidebarItem: Hashable {
     case info
 }
 
+/// Wykryty standard/wersja USB dla nośnika
+enum USBPortSpeed: String, Equatable {
+    case usb2 = "USB 2.0"
+    case usb3 = "USB 3.0"
+    case usb31 = "USB 3.1"
+    case usb32 = "USB 3.2"
+    case usb4 = "USB 4.0"
+    case unknown = "USB"
+
+    var isUSB2: Bool { self == .usb2 }
+}
+
 // Struktura pomocnicza dla dysków USB
 struct USBDrive: Hashable, Identifiable {
     let id = UUID()
@@ -14,9 +26,23 @@ struct USBDrive: Hashable, Identifiable {
     let device: String  // np. disk2s1
     let size: String    // np. 16 GB
     let url: URL
+    let usbSpeed: USBPortSpeed?
+    
+    init(name: String, device: String, size: String, url: URL, usbSpeed: USBPortSpeed? = nil) {
+        self.name = name
+        self.device = device
+        self.size = size
+        self.url = url
+        self.usbSpeed = usbSpeed
+    }
     
     // Format wyświetlania: disk1s1 - 16GB - SANDISK
     var displayName: String {
-        "\(device) - \(size) - \(name)"
+        let speedText = usbSpeed?.rawValue ?? "USB"
+        return "\(device) - \(size) - \(speedText) - \(name)"
     }
+    
+    /// Czy nośnik pracuje w standardzie USB 2.0
+    var isUSB2: Bool { usbSpeed?.isUSB2 == true }
 }
+


### PR DESCRIPTION
Added detection of USB port speed for drives using IOKit and updated the USBDrive model to include speed information. The UI now warns users when a USB 2.0 drive is selected, with localized messages. This helps users understand potential delays when using slower drives.