### PR TITLE
feat: expand localization and add external media permission reset flow

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -194,6 +194,8 @@ Inputs and file selection:
 Menu icon mapping (current):
 - `Opcje` → `Pomiń analizowanie pliku`: `doc.text.magnifyingglass`
 - `Opcje` → `Włącz obsługę zewnętrznych dysków twardych`: `externaldrive.badge.plus`
+- `Opcje` → `Resetuj uprawnienia dostępu do dysków zewnętrznych`: `arrow.clockwise.circle`
+- reset action runs `tccutil reset SystemPolicyRemovableVolumes <bundleID>` and shows an app-branded success/failure alert.
 - `Opcje` → `Język`: `globe`
 - `Opcje` → notifications item uses dynamic label/icon:
 - enabled: `Powiadomienia włączone` + `bell.and.waves.left.and.right`
@@ -201,7 +203,7 @@ Menu icon mapping (current):
 - `Narzędzia` → `Otwórz Narzędzie dyskowe`: `externaldrive`
 - `Narzędzia` → `Status helpera`: `info.circle`
 - `Narzędzia` → `Napraw helpera`: `wrench.and.screwdriver`
-- `Narzędzia` → `Ustawienia działania w tle…`: `gearshape` (same group as helper actions; no divider between `Napraw helpera` and settings action).
+- `Narzędzia` → `Ustawienia działania w tle…`: `gearshape` (same group as helper actions; no divider between `Napraw helpera` and background-settings action).
 
 Progress indicators:
 - Inline progress uses `ProgressView().controlSize(.small)` next to status text.
@@ -286,18 +288,19 @@ Practical rules:
 - Translations in `Localizable.xcstrings` must match the real UI context where the phrase appears (button, alert title, warning body, progress status, etc.); avoid overly literal translation when it harms clarity, tone, or UX.
 - Immutable product slogan rule: the phrase `Tworzenie bootowalnych dysków USB z systemem macOS oraz OS X nigdy nie było takie proste!` is the app’s official slogan and must remain unchanged verbatim in this exact form.
 - Use `Text("...")` with Polish strings; SwiftUI treats these as localization keys.
+- All user-facing strings returned or stored as `String` (for example computed properties, variables, alerts, status labels, menu labels) must use `String(localized:)` instead of hardcoded literals, to keep full translation compatibility.
 - Helper sends stable technical localization keys (for example `helper.workflow.prepare_source.title`) in XPC progress events.
 - Installation UI renders helper stage/status with `Text(LocalizedStringKey(...))`, so helper progress text follows app locale from SwiftUI environment.
 - Non-`Text` runtime labels (for example speed/debug metrics text) must use `String(localized:)` with localized format keys (currently `Szybkość zapisu: %d MB/s`, `Szybkość zapisu: - MB/s`, and `Przekopiowane dane: %.1f GB`).
 - Keep helper key anchors in `macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift` (`HelperWorkflowLocalizationExtractionAnchors`) synchronized with emitted keys to keep String Catalog extraction stable.
-- Every helper localization key must be translated in all supported app languages (`pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`).
+- Every helper localization key must be translated in all supported app languages (`pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`, `it`, `uk`, `vi`, `tr`).
 Use `String(localized: "...")` when:
 - The string is not a `Text` literal.
 - The string is assigned to a variable before being shown.
 - You want to force string extraction into the `.xcstrings` file.
 
 Supported languages are defined in `LanguageManager.supportedLanguages`:
-- `pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`
+- `pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`, `it`, `uk`, `vi`, `tr`
 
 The language selection logic:
 - `LanguageManager` stores the user’s selection in `selected_language_v2`.
@@ -738,7 +741,7 @@ Current effective build configuration snapshot:
 1. Add/adjust key constants and `presentation(for:)` mapping in `HelperWorkflowLocalizationKeys`.
 2. Keep `HelperWorkflowLocalizationExtractionAnchors.anchoredValues` synchronized with all runtime helper keys.
 3. Update helper stage definitions in `macUSBHelper/main.swift` to use those keys.
-4. Add translations in `Localizable.xcstrings` for all supported languages (`pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`) for both title and status keys.
+4. Add translations in `Localizable.xcstrings` for all supported languages (`pl`, `en`, `de`, `ja`, `fr`, `es`, `pt-BR`, `zh-Hans`, `ru`, `it`, `uk`, `vi`, `tr`) for both title and status keys.
 5. Build and verify runtime in at least EN + PL to ensure no raw key or source-language fallback appears.
 
 ### 11.10 Logging and observability for helper path
@@ -790,6 +793,7 @@ Minimal runbook for day-to-day diagnostics and release safety:
 - Recovery/status quick-check:
 - If service is enabled but XPC fails: run `Napraw helpera` (it resets client connection and re-validates registration).
 - If status is `requiresApproval`: open system settings from helper alert and approve background item.
+- If write access to external USB media is denied: run `Opcje` → `Resetuj uprawnienia dostępu do dysków zewnętrznych`, then retry installer creation so macOS can request permission again.
 - You can manually open Background Items settings from `Narzędzia` → `Ustawienia działania w tle…`.
 
 ---

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -368,6 +368,10 @@
 				"pt-BR",
 				"zh-Hans",
 				ru,
+				it,
+				uk,
+				vi,
+				tr,
 			);
 			mainGroup = 0F94F49C2EDE3E510019F69A;
 			minimizedProjectReferenceProxies = 1;

--- a/macUSB/Features/Finish/FinishUSBView.swift
+++ b/macUSB/Features/Finish/FinishUSBView.swift
@@ -74,19 +74,19 @@ struct FinishUSBView: View {
         return .green
     }
     private var primaryResultTitle: String {
-        if isCancelledResult { return "Przerwano" }
-        if isFailedResult { return "Niepowodzenie!" }
-        return "Sukces!"
+        if isCancelledResult { return String(localized: "Przerwano") }
+        if isFailedResult { return String(localized: "Niepowodzenie!") }
+        return String(localized: "Sukces!")
     }
     private var primaryResultSubtitle: String {
-        if isCancelledResult { return "Proces został zatrzymany przez użytkownika" }
-        if isFailedResult { return "Spróbuj ponownie od początku" }
-        return "Nośnik został przygotowany poprawnie"
+        if isCancelledResult { return String(localized: "Proces został zatrzymany przez użytkownika") }
+        if isFailedResult { return String(localized: "Spróbuj ponownie od początku") }
+        return String(localized: "Nośnik został przygotowany poprawnie")
     }
     private var summaryTitleText: String {
-        if isCancelledResult { return "Tworzenie nośnika zostało przerwane" }
-        if isFailedResult { return "Tworzenie instalatora nie powiodło się" }
-        return "Utworzono instalator systemu"
+        if isCancelledResult { return String(localized: "Tworzenie nośnika zostało przerwane") }
+        if isFailedResult { return String(localized: "Tworzenie instalatora nie powiodło się") }
+        return String(localized: "Utworzono instalator systemu")
     }
     
     var body: some View {

--- a/macUSB/Features/Installation/CreatorHelperLogic.swift
+++ b/macUSB/Features/Installation/CreatorHelperLogic.swift
@@ -395,7 +395,7 @@ extension UniversalInstallationView {
                     domain: "macUSB",
                     code: code,
                     userInfo: [
-                        NSLocalizedDescriptionKey: "Brak uprawnien do zapisu na wybranym nosniku USB. Zezwol aplikacji macUSB na dostep do Woluminow wymiennych w Ustawieniach systemowych > Prywatnosc i ochrona, a nastepnie sprobuj ponownie."
+                        NSLocalizedDescriptionKey: String(localized: "Brak uprawnień do zapisu na wybranym nośniku USB. Zresetuj uprawnienia aplikacji w menu Opcje → Resetuj uprawnienia dostępu do dysków zewnętrznych, a następnie spróbuj ponownie.")
                     ]
                 )
             }

--- a/macUSB/Info.plist
+++ b/macUSB/Info.plist
@@ -6,16 +6,19 @@
 	<string>macUSBIcon</string>
 	<key>CFBundleLocalizations</key>
 	<array>
+		<string>pl</string>
 		<string>en</string>
-		<string>Polish</string>
-		<string>fr</string>
-		<string>zh_CN</string>
 		<string>de</string>
-		<string>it</string>
 		<string>ja</string>
-		<string>Russian</string>
-		<string>Spanish</string>
-		<string>Portuguese</string>
+		<string>fr</string>
+		<string>es</string>
+		<string>pt-BR</string>
+		<string>zh-Hans</string>
+		<string>ru</string>
+		<string>it</string>
+		<string>uk</string>
+		<string>vi</string>
+		<string>tr</string>
 	</array>
 </dict>
 </plist>

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -1,13171 +1,20517 @@
 {
-  "sourceLanguage" : "pl",
-  "strings" : {
-    "" : {
-
-    },
-    "• Do utworzenia instalatora potrzebny jest nośnik USB o pojemności minimum 16 GB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Zum Erstellen des Installers ist ein USB-Laufwerk mit mindestens 16 GB erforderlich"
+  "sourceLanguage": "pl",
+  "strings": {
+    "": {},
+    "• Do utworzenia instalatora potrzebny jest nośnik USB o pojemności minimum 16 GB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Zum Erstellen des Installers ist ein USB-Laufwerk mit mindestens 16 GB erforderlich"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A USB drive with a minimum capacity of 16 GB is required to create the installer"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A USB drive with a minimum capacity of 16 GB is required to create the installer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Se requiere una memoria USB con una capacidad mínima de 16 GB para crear el instalador"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Se requiere una memoria USB con una capacidad mínima de 16 GB para crear el instalador"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Une clé USB d'une capacité minimale de 16 Go est requise pour créer l'installateur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Une clé USB d'une capacité minimale de 16 Go est requise pour créer l'installateur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• インストーラを作成するには、最低16GBの容量を持つUSBメモリが必要です"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Per creare il programma di installazione è necessaria un'unità USB con una capacità minima di 16 GB"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• É necessário um pen drive com capacidade mínima de 16 GB para criar o instalador"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• インストーラを作成するには、最低16GBの容量を持つUSBメモリが必要です"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Для создания установщика требуется USB-накопитель емкостью не менее 16 ГБ"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• É necessário um pen drive com capacidade mínima de 16 GB para criar o instalador"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 创建安装程序需要至少 16 GB 容量的 U 盘"
-          }
-        }
-      }
-    },
-    "• Dozwolone formaty plików to .dmg, .iso, .cdr oraz .app" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Zulässige Dateiformate sind .dmg, .iso, .cdr und .app"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Для создания установщика требуется USB-накопитель емкостью не менее 16 ГБ"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Allowed file formats are .dmg, .iso, .cdr, and .app"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Yükleyiciyi oluşturmak için minimum 16 GB kapasiteli bir USB sürücüsüne ihtiyacınız vardır"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Los formatos de archivo permitidos son .dmg, .iso, .cdr y .app"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Для створення інсталятора потрібен USB-накопичувач мінімальним об’ємом 16 ГБ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Les formats de fichiers autorisés sont .dmg, .iso, .cdr et .app"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Để tạo bộ cài đặt, bạn cần có ổ USB có dung lượng tối thiểu 16 GB"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 許可されるファイル形式は .dmg, .iso, .cdr および .app です"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 创建安装程序需要至少 16 GB 容量的 U 盘"
+          }
+        }
+      }
+    },
+    "• Dozwolone formaty plików to .dmg, .iso, .cdr oraz .app": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Zulässige Dateiformate sind .dmg, .iso, .cdr und .app"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Os formatos de arquivo permitidos são .dmg, .iso, .cdr e .app"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Allowed file formats are .dmg, .iso, .cdr, and .app"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Допустимые форматы файлов: .dmg, .iso, .cdr и .app"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Los formatos de archivo permitidos son .dmg, .iso, .cdr y .app"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 允许的文件格式为 .dmg, .iso, .cdr 和 .app"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Les formats de fichiers autorisés sont .dmg, .iso, .cdr et .app"
           }
-        }
-      }
-    },
-    "• Nośnik USB zostanie odpowiednio sformatowany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Das USB-Laufwerk wird entsprechend formatiert"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• I formati di file consentiti sono .dmg, .iso, .cdr e .app"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The USB drive will be formatted appropriately"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 許可されるファイル形式は .dmg, .iso, .cdr および .app です"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La unidad USB se formateara adecuadamente"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Os formatos de arquivo permitidos são .dmg, .iso, .cdr e .app"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Le support USB sera formate de maniere appropriee"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Допустимые форматы файлов: .dmg, .iso, .cdr и .app"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USBドライブは適切にフォーマットされます"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• İzin verilen dosya biçimleri .dmg, .iso, .cdr ve .app'tir"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A unidade USB sera formatada adequadamente"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Дозволені формати файлів: .dmg, .iso, .cdr і .app"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USB-накопитель будет отформатирован соответствующим образом"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Các định dạng tệp được phép là .dmg, .iso, .cdr và .app"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USB 驱动器将被正确格式化"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 允许的文件格式为 .dmg, .iso, .cdr 和 .app"
           }
         }
       }
     },
-    "• Nośnik USB zostanie sformatowany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Das USB-Laufwerk wird formatiert"
+    "• Nośnik USB zostanie odpowiednio sformatowany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Das USB-Laufwerk wird entsprechend formatiert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The USB drive will be formatted"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The USB drive will be formatted appropriately"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La unidad USB se formateara"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La unidad USB se formateara adecuadamente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Le support USB sera formate"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Le support USB sera formate de maniere appropriee"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USBドライブはフォーマットされます"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'unità USB verrà formattata in modo appropriato"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A unidade USB sera formatada"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USBドライブは適切にフォーマットされます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USB-накопитель будет отформатирован"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A unidade USB sera formatada adequadamente"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USB 驱动器将被格式化"
-          }
-        }
-      }
-    },
-    "• Obraz instalacyjny zostanie przywrócony" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Das Installations-Image wird wiederhergestellt"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB-накопитель будет отформатирован соответствующим образом"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The installation image will be restored"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB sürücüsü uygun şekilde biçimlendirilecektir"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La imagen de instalacion se restaurara"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB-накопичувач буде відформатовано належним чином"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• L image d installation sera restauree"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Ổ USB sẽ được định dạng phù hợp"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• インストールイメージが復元されます"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB 驱动器将被正确格式化"
+          }
+        }
+      }
+    },
+    "• Nośnik USB zostanie sformatowany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Das USB-Laufwerk wird formatiert"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A imagem de instalacao sera restaurada"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The USB drive will be formatted"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Образ установки будет восстановлен"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La unidad USB se formateara"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 安装镜像将被恢复"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Le support USB sera formate"
           }
-        }
-      }
-    },
-    "• Obraz systemu zostanie przywrócony" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Das System-Image wird wiederhergestellt"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'unità USB verrà formattata"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The system image will be restored"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USBドライブはフォーマットされます"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La imagen del sistema se restaurara"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A unidade USB sera formatada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• L image systeme sera restauree"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB-накопитель будет отформатирован"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• システムイメージが復元されます"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB sürücüsü formatlanacak"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A imagem do sistema sera restaurada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB-накопичувач буде відформатовано"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Образ системы будет восстановлен"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Ổ USB sẽ được định dạng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 系统镜像将被恢复"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB 驱动器将被格式化"
           }
         }
       }
     },
-    "• Obraz z systemem zostanie skopiowany i zweryfikowany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Das System-Image wird kopiert und verifiziert"
+    "• Obraz instalacyjny zostanie przywrócony": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Das Installations-Image wird wiederhergestellt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The system image will be copied and verified"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The installation image will be restored"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La imagen del sistema se copiara y verificara"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La imagen de instalacion se restaurara"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• L image systeme sera copiee et verifiee"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L image d installation sera restauree"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• システムイメージがコピーされ、検証されます"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'immagine di installazione verrà ripristinata"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A imagem do sistema sera copiada e verificada"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• インストールイメージが復元されます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Образ системы будет скопирован и проверен"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A imagem de instalacao sera restaurada"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 系统镜像将被复制并验证"
-          }
-        }
-      }
-    },
-    "• Pliki instalacyjne zostaną skopiowane" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Installationsdateien werden kopiert"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Образ установки будет восстановлен"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Installation files will be copied"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Kurulum görüntüsü geri yüklenecek"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Se copiaran los archivos de instalacion"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Буде відновлено інсталяційний образ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Les fichiers d installation seront copies"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Hình ảnh cài đặt sẽ được khôi phục"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• インストールファイルがコピーされます"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 安装镜像将被恢复"
+          }
+        }
+      }
+    },
+    "• Obraz systemu zostanie przywrócony": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Das System-Image wird wiederhergestellt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Os arquivos de instalacao serao copiados"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The system image will be restored"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Установочные файлы будут скопированы"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La imagen del sistema se restaurara"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 安装文件将被复制"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L image systeme sera restauree"
           }
-        }
-      }
-    },
-    "• Pliki systemowe zostaną przygotowane" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Systemdateien werden vorbereitet"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'immagine del sistema verrà ripristinata"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• System files will be prepared"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• システムイメージが復元されます"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Se prepararan los archivos del sistema"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A imagem do sistema sera restaurada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Les fichiers systeme seront prepares"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Образ системы будет восстановлен"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• システムファイルが準備されます"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Sistem görüntüsü geri yüklenecektir"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Os arquivos do sistema serao preparados"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Образ системи буде відновлено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Системные файлы будут подготовлены"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Hình ảnh hệ thống sẽ được khôi phục"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 系统文件将被准备"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 系统镜像将被恢复"
           }
         }
       }
     },
-    "• Pliki tymczasowe zostaną automatycznie usunięte" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Temporäre Dateien werden automatisch gelöscht"
+    "• Obraz z systemem zostanie skopiowany i zweryfikowany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Das System-Image wird kopiert und verifiziert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Temporary files will be automatically deleted"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The system image will be copied and verified"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Los archivos temporales se eliminarán automáticamente"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La imagen del sistema se copiara y verificara"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Les fichiers temporaires seront automatiquement supprimés"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L image systeme sera copiee et verifiee"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 一時ファイルは自動的に削除されます"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'immagine con il sistema verrà copiata e verificata"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Arquivos temporários serão excluídos automaticamente"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• システムイメージがコピーされ、検証されます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Временные файлы будут автоматически удалены"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A imagem do sistema sera copiada e verificada"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 临时文件将被自动删除"
-          }
-        }
-      }
-    },
-    "• Podłącz nośnik USB do docelowego komputera Mac" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Schließen Sie das USB-Laufwerk an den Ziel-Mac an"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Образ системы будет скопирован и проверен"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Connect the USB drive to the target Mac computer"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Sistemdeki görüntü kopyalanacak ve doğrulanacak"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Conecte la memoria USB al Mac de destino"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Зображення з системою буде скопійовано та перевірено"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Connectez la clé USB au Mac cible"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Hình ảnh với hệ thống sẽ được sao chép và xác minh"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USBメモリを対象のMacに接続します"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 系统镜像将被复制并验证"
+          }
+        }
+      }
+    },
+    "• Pliki instalacyjne zostaną skopiowane": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Installationsdateien werden kopiert"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Conecte o pen drive ao Mac de destino"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Installation files will be copied"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Подключите USB-накопитель к целевому компьютеру Mac"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Se copiaran los archivos de instalacion"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 将 U 盘连接到目标 Mac 电脑"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Les fichiers d installation seront copies"
           }
-        }
-      }
-    },
-    "• Struktura instalatora zostanie sfinalizowana" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Die Struktur des Installers wird finalisiert"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• I file di installazione verranno copiati"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The installer structure will be finalized"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• インストールファイルがコピーされます"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La estructura del instalador se finalizara"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Os arquivos de instalacao serao copiados"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• La structure de l installateur sera finalisee"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Установочные файлы будут скопированы"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• インストーラ構成が最終処理されます"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Kurulum dosyaları kopyalanacak"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• A estrutura do instalador sera finalizada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Інсталяційні файли будуть скопійовані"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Структура установщика будет финализирована"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Các tập tin cài đặt sẽ được sao chép"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 安装器结构将被完成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 安装文件将被复制"
           }
         }
       }
     },
-    "• Uruchom komputer trzymając przycisk Option (⌥)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Starten Sie den Computer mit gedrückter Optionstaste (⌥)"
+    "• Pliki systemowe zostaną przygotowane": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Systemdateien werden vorbereitet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Start the computer while holding the Option (⌥) key"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• System files will be prepared"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Inicie el ordenador manteniendo pulsada la tecla Opción (⌥)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Se prepararan los archivos del sistema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Démarrez l'ordinateur en maintenant la touche Option (⌥)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Les fichiers systeme seront prepares"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Option (⌥) キーを押しながらコンピュータを起動します"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Verranno preparati i file di sistema"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Inicie o computador mantendo pressionada a tecla Option (⌥)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• システムファイルが準備されます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Загрузите компьютер, удерживая клавишу Option (⌥)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Os arquivos do sistema serao preparados"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 按住 Option (⌥) 键启动电脑"
-          }
-        }
-      }
-    },
-    "• Wybierz instalator systemu macOS lub OS X z listy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Wählen Sie den macOS- oder OS X-Installer aus der Liste"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Системные файлы будут подготовлены"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Select the macOS or OS X installer from the list"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Sistem dosyaları hazırlanacak"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Seleccione el instalador de macOS u OS X de la lista"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Системні файли будуть підготовлені"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Sélectionnez l'installateur macOS ou OS X dans la liste"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Các tập tin hệ thống sẽ được chuẩn bị"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• リストからmacOSまたはOS Xのインストーラを選択します"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 系统文件将被准备"
+          }
+        }
+      }
+    },
+    "• Pliki tymczasowe zostaną automatycznie usunięte": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Temporäre Dateien werden automatisch gelöscht"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Selecione o instalador do macOS ou OS X na lista"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Temporary files will be automatically deleted"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Выберите установщик macOS или OS X из списка"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Los archivos temporales se eliminarán automáticamente"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 从列表中选择 macOS 或 OS X 安装程序"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Les fichiers temporaires seront automatiquement supprimés"
           }
-        }
-      }
-    },
-    "• Wybrany plik musi zawierać instalator systemu macOS lub Mac OS X" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Die ausgewählte Datei muss einen macOS- oder Mac OS X-Installer enthalten"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• I file temporanei verranno automaticamente eliminati"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• The selected file must contain a macOS or Mac OS X installer"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 一時ファイルは自動的に削除されます"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• El archivo seleccionado debe contener un instalador de macOS o Mac OS X"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Arquivos temporários serão excluídos automaticamente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Le fichier sélectionné doit contenir un installateur macOS ou Mac OS X"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Временные файлы будут автоматически удалены"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 選択したファイルにはmacOSまたはMac OS Xインストーラが含まれている必要があります"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Geçici dosyalar otomatik olarak silinecek"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• O arquivo selecionado deve conter um instalador do macOS ou Mac OS X"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Тимчасові файли будуть видалені автоматично"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Выбранный файл должен содержать установщик macOS или Mac OS X"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Các tập tin tạm thời sẽ tự động bị xóa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 所选文件必须包含 macOS 或 Mac OS X 安装程序"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 临时文件将被自动删除"
           }
         }
       }
     },
-    "• Wymagane jest co najmniej 15 GB wolnego miejsca na dysku twardym" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Es sind mindestens 15 GB freier Festplattenspeicher erforderlich"
+    "• Podłącz nośnik USB do docelowego komputera Mac": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Schließen Sie das USB-Laufwerk an den Ziel-Mac an"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• At least 15 GB of free hard drive space is required"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Connect the USB drive to the target Mac computer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Se requieren al menos 15 GB de espacio libre en el disco duro"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Conecte la memoria USB al Mac de destino"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Au moins 15 Go d'espace libre sur le disque dur sont requis"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Connectez la clé USB au Mac cible"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• ハードドライブに少なくとも15GBの空き容量が必要です"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Collega l'unità USB al Mac di destinazione"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• É necessário pelo menos 15 GB de espaço livre no disco rígido"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USBメモリを対象のMacに接続します"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Требуется не менее 15 ГБ свободного места на жестком диске"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Conecte o pen drive ao Mac de destino"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 需要至少 15 GB 的硬盘可用空间"
-          }
-        }
-      }
-    },
-    "• Zalecane jest użycie dysku w standardzie USB 3.0 lub szybszym" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Die Verwendung eines USB 3.0-Laufwerks (oder schneller) wird empfohlen"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Подключите USB-накопитель к целевому компьютеру Mac"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Using a USB 3.0 or faster drive is recommended"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB sürücüsünü hedef Mac'e bağlayın"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Se recomienda usar una memoria USB 3.0 o más rápida"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Підключіть USB-накопичувач до цільового Mac"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• L'utilisation d'une clé USB 3.0 ou plus rapide est recommandée"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Kết nối ổ USB với máy Mac mục tiêu"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• USB 3.0以上の高速なドライブの使用を推奨します"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 将 U 盘连接到目标 Mac 电脑"
+          }
+        }
+      }
+    },
+    "• Struktura instalatora zostanie sfinalizowana": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Die Struktur des Installers wird finalisiert"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Recomenda-se o uso de um pen drive USB 3.0 ou mais rápido"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The installer structure will be finalized"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• Рекомендуется использовать накопитель USB 3.0 или быстрее"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La estructura del instalador se finalizara"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "• 建议使用 USB 3.0 或更快的驱动器"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La structure de l installateur sera finalisee"
           }
-        }
-      }
-    },
-    "Aby uruchomić helper systemowy, aplikacja musi znajdować się w katalogu Applications." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um den System-Helper auszufuhren, muss sich die App im Ordner Applications befinden."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• La struttura dell'installatore sarà finalizzata"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To run the system helper, the app must be located in the Applications folder."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• インストーラ構成が最終処理されます"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para ejecutar el helper del sistema, la aplicacion debe estar en la carpeta Aplicaciones."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• A estrutura do instalador sera finalizada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour executer l outil auxiliaire systeme, l application doit se trouver dans le dossier Applications."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Структура установщика будет финализирована"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムヘルパーを実行するには、アプリがApplicationsフォルダに配置されている必要があります。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Kurulumcu yapısı tamamlanacak"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para executar o helper do sistema, o aplicativo deve estar na pasta Aplicativos."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Буде завершено структуру інсталятора"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чтобы запустить системный helper, приложение должно находиться в папке Applications."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Cấu trúc trình cài đặt sẽ được hoàn thiện"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要运行系统辅助工具，应用必须位于Applications文件夹中。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 安装器结构将被完成"
           }
         }
       }
     },
-    "Aby uruchomić instalator z nośnika USB na Macu z PowerPC, niezbędne jest wpisanie komendy w konsoli Open Firmware. Pełna instrukcja obsługi znajduje się na stronie internetowej aplikacji." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um den Installer von einem USB-Laufwerk auf einem PowerPC-Mac zu starten, müssen Sie einen Befehl in der Open Firmware-Konsole eingeben. Eine vollständige Anleitung finden Sie auf der Website der Anwendung."
+    "• Uruchom komputer trzymając przycisk Option (⌥)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Starten Sie den Computer mit gedrückter Optionstaste (⌥)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To boot the installer from a USB drive on a PowerPC Mac, you must enter a command in the Open Firmware console. Full instructions are available on the application's website."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Start the computer while holding the Option (⌥) key"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para arrancar el instalador desde una memoria USB en un Mac con PowerPC, es necesario introducir un comando en la consola de Open Firmware. Las instrucciones completas están disponibles en el sitio web de la aplicación."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Inicie el ordenador manteniendo pulsada la tecla Opción (⌥)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour démarrer l'installateur à partir d'une clé USB sur un Mac PowerPC, vous devez saisir une commande dans la console Open Firmware. Les instructions complètes sont disponibles sur le site web de l'application."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Démarrez l'ordinateur en maintenant la touche Option (⌥)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PowerPC MacでUSBドライブからインストーラを起動するには、Open Firmwareコンソールでコマンドを入力する必要があります。詳しい手順はアプリケーションのウェブサイトをご覧ください。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Avvia il computer tenendo premuto il pulsante Opzione (⌥)."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para inicializar o instalador de um pen drive USB em um Mac PowerPC, é necessário inserir um comando no console do Open Firmware. As instruções completas estão disponíveis no site do aplicativo."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Option (⌥) キーを押しながらコンピュータを起動します"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чтобы запустить установщик с USB-накопителя на Mac с PowerPC, необходимо ввести команду в консоли Open Firmware. Полная инструкция доступна на веб-сайте приложения."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Inicie o computador mantendo pressionada a tecla Option (⌥)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要在 PowerPC Mac 上从 USB 驱动器启动安装程序，必须在 Open Firmware 控制台中输入命令。完整说明可在应用程序网站上找到。"
-          }
-        }
-      }
-    },
-    "Aby używać helpera uprzywilejowanego, przenieś aplikację macUSB do katalogu Applications i uruchom ją ponownie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um den privilegierten Helper zu verwenden, verschiebe die macUSB-App in den Ordner Applications und starte sie erneut."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Загрузите компьютер, удерживая клавишу Option (⌥)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To use the privileged helper, move the macUSB app to the Applications folder and launch it again."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Seçenek (⌥) düğmesini basılı tutarak bilgisayarınızı başlatın"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para usar el helper con privilegios, mueve la app macUSB a la carpeta Aplicaciones y vuelve a iniciarla."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Запустіть комп’ютер, утримуючи кнопку Option (⌥)."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour utiliser l outil auxiliaire privilegie, deplacez l application macUSB dans le dossier Applications puis relancez-la."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Khởi động máy tính của bạn bằng cách giữ nút Tùy chọn (⌥)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "特権ヘルパーを使用するには、macUSBアプリをApplicationsフォルダに移動して再起動してください。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 按住 Option (⌥) 键启动电脑"
+          }
+        }
+      }
+    },
+    "• Wybierz instalator systemu macOS lub OS X z listy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Wählen Sie den macOS- oder OS X-Installer aus der Liste"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para usar o helper privilegiado, mova o app macUSB para a pasta Aplicativos e inicie-o novamente."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Select the macOS or OS X installer from the list"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Чтобы использовать привилегированный helper, переместите приложение macUSB в папку Applications и запустите его снова."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Seleccione el instalador de macOS u OS X de la lista"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要使用特权辅助工具，请将 macUSB 应用移动到Applications文件夹并重新启动。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Sélectionnez l'installateur macOS ou OS X dans la liste"
           }
-        }
-      }
-    },
-    "Aby zmienić język interfejsu we wszystkich elementach aplikacji (w tym menu i przyciskach), wymagany jest restart. Kliknij poniżej, aby uruchomić aplikację ponownie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um die Oberflächensprache in allen Elementen der Anwendung (einschließlich Menüs und Schaltflächen) zu ändern, ist ein Neustart erforderlich. Klicken Sie unten, um die Anwendung neu zu starten."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Seleziona il programma di installazione di macOS o OS X dall'elenco"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To change the interface language in all application elements (including menus and buttons), a restart is required. Click below to restart the application."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• リストからmacOSまたはOS Xのインストーラを選択します"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para cambiar el idioma de la interfaz en todos los elementos de la aplicación (incluidos menús y botones), es necesario reiniciar. Haga clic a continuación para reiniciar la aplicación."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Selecione o instalador do macOS ou OS X na lista"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour changer la langue de l'interface dans tous les éléments de l'application (y compris les menus et les boutons), un redémarrage est nécessaire. Cliquez ci-dessous pour redémarrer l'application."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Выберите установщик macOS или OS X из списка"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションのすべての要素（メニューやボタンを含む）でインターフェース言語を変更するには、再起動が必要です。以下をクリックしてアプリケーションを再起動してください。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Listeden macOS veya OS X yükleyicisini seçin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para alterar o idioma da interface em todos os elementos do aplicativo (incluindo menus e botões), é necessário reiniciar. Clique abaixo para reiniciar o aplicativo."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Виберіть програму встановлення macOS або OS X зі списку"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для изменения языка интерфейса во всех элементах приложения (включая меню и кнопки) требуется перезапуск. Нажмите ниже, чтобы перезапустить приложение."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Chọn trình cài đặt macOS hoặc OS X từ danh sách"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要更改所有应用程序元素（包括菜单和按钮）中的界面语言，需要重启。点击下方以重启应用程序。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 从列表中选择 macOS 或 OS X 安装程序"
           }
         }
       }
     },
-    "Aktualnie uruchomiona wersja: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktuell ausgeführte Version: %@"
+    "• Wybrany plik musi zawierać instalator systemu macOS lub Mac OS X": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Die ausgewählte Datei muss einen macOS- oder Mac OS X-Installer enthalten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currently running version: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• The selected file must contain a macOS or Mac OS X installer"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión actualmente en ejecución: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• El archivo seleccionado debe contener un instalador de macOS o Mac OS X"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version actuellement utilisée : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Le fichier sélectionné doit contenir un installateur macOS ou Mac OS X"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在実行中のバージョン: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Il file selezionato deve contenere il programma di installazione di macOS o Mac OS X"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão em execução no momento: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 選択したファイルにはmacOSまたはMac OS Xインストーラが含まれている必要があります"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Текущая запущенная версия: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• O arquivo selecionado deve conter um instalador do macOS ou Mac OS X"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当前运行版本：%@"
-          }
-        }
-      }
-    },
-    "Analiza nie została wykonana - wybór użytkownika" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyse nicht durchgeführt - Benutzerauswahl"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Выбранный файл должен содержать установщик macOS или Mac OS X"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysis not performed - user choice"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Seçilen dosya macOS veya Mac OS X yükleyicisini içermelidir"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Análisis no realizado - elección del usuario"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Вибраний файл має містити програму встановлення macOS або Mac OS X"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyse non effectuée - choix de l'utilisateur"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Tệp được chọn phải chứa trình cài đặt macOS hoặc Mac OS X"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析は実行されませんでした - ユーザーの選択"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 所选文件必须包含 macOS 或 Mac OS X 安装程序"
+          }
+        }
+      }
+    },
+    "• Wymagane jest co najmniej 15 GB wolnego miejsca na dysku twardym": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Es sind mindestens 15 GB freier Festplattenspeicher erforderlich"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Análise não realizada - escolha do usuário"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• At least 15 GB of free hard drive space is required"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анализ не выполнен - выбор пользователя"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Se requieren al menos 15 GB de espacio libre en el disco duro"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析未执行 - 用户选择"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Au moins 15 Go d'espace libre sur le disque dur sont requis"
           }
-        }
-      }
-    },
-    "Analizowanie" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysieren"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Sono necessari almeno 15 GB di spazio libero su disco rigido"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyzing"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• ハードドライブに少なくとも15GBの空き容量が必要です"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analizando"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• É necessário pelo menos 15 GB de espaço livre no disco rígido"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyse en cours"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Требуется не менее 15 ГБ свободного места на жестком диске"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析中"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• En az 15 GB boş sabit disk alanı gereklidir"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analisando"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Потрібно щонайменше 15 ГБ вільного місця на жорсткому диску"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анализ"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Cần có ít nhất 15 GB dung lượng ổ cứng trống"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在分析"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 需要至少 15 GB 的硬盘可用空间"
           }
         }
       }
     },
-    "Analizuj" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysieren"
+    "• Zalecane jest użycie dysku w standardzie USB 3.0 lub szybszym": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Die Verwendung eines USB 3.0-Laufwerks (oder schneller) wird empfohlen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyze"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Using a USB 3.0 or faster drive is recommended"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analizar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Se recomienda usar una memoria USB 3.0 o más rápida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyser"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• L'utilisation d'une clé USB 3.0 ou plus rapide est recommandée"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Si consiglia di utilizzare un'unità USB 3.0 o più veloce"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analisar"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB 3.0以上の高速なドライブの使用を推奨します"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анализировать"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Recomenda-se o uso de um pen drive USB 3.0 ou mais rápido"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析"
-          }
-        }
-      }
-    },
-    "Automatycznie" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatisch"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Рекомендуется использовать накопитель USB 3.0 или быстрее"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auto"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• USB 3.0 veya daha hızlı bir sürücü kullanılması önerilir"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Рекомендовано використовувати накопичувач USB 3.0 або швидший"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automatique"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Nên sử dụng ổ USB 3.0 hoặc nhanh hơn"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 建议使用 USB 3.0 或更快的驱动器"
+          }
+        }
+      }
+    },
+    "Aby uruchomić helper systemowy, aplikacja musi znajdować się w katalogu Applications.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um den System-Helper auszufuhren, muss sich die App im Ordner Applications befinden."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Automático"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To run the system helper, the app must be located in the Applications folder."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Автоматически"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para ejecutar el helper del sistema, la aplicacion debe estar en la carpeta Aplicaciones."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自动"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour executer l outil auxiliaire systeme, l application doit se trouver dans le dossier Applications."
           }
-        }
-      }
-    },
-    "Bieżący przebieg operacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktueller Fortschritt des Vorgangs"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per eseguire l'helper di sistema, l'applicazione deve trovarsi nella directory Applicazioni."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Current operation progress"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムヘルパーを実行するには、アプリがApplicationsフォルダに配置されている必要があります。"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progreso actual de la operacion"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para executar o helper do sistema, o aplicativo deve estar na pasta Aplicativos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progression actuelle de l operation"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтобы запустить системный helper, приложение должно находиться в папке Applications."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "現在の処理進行状況"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem yardımcısını çalıştırmak için uygulamanın Uygulamalar dizininde bulunması gerekir."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Progresso atual da operacao"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щоб запустити системний помічник, програма має бути розташована в каталозі Applications."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Текущий ход операции"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Để chạy trình trợ giúp hệ thống, ứng dụng phải được đặt trong thư mục Ứng dụng."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "当前操作进度"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要运行系统辅助工具，应用必须位于Applications文件夹中。"
           }
         }
       }
     },
-    "BŁĄD" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FEHLER"
+    "Aby uruchomić instalator z nośnika USB na Macu z PowerPC, niezbędne jest wpisanie komendy w konsoli Open Firmware. Pełna instrukcja obsługi znajduje się na stronie internetowej aplikacji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um den Installer von einem USB-Laufwerk auf einem PowerPC-Mac zu starten, müssen Sie einen Befehl in der Open Firmware-Konsole eingeben. Eine vollständige Anleitung finden Sie auf der Website der Anwendung."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERROR"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To boot the installer from a USB drive on a PowerPC Mac, you must enter a command in the Open Firmware console. Full instructions are available on the application's website."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERROR"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para arrancar el instalador desde una memoria USB en un Mac con PowerPC, es necesario introducir un comando en la consola de Open Firmware. Las instrucciones completas están disponibles en el sitio web de la aplicación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERREUR"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour démarrer l'installateur à partir d'une clé USB sur un Mac PowerPC, vous devez saisir une commande dans la console Open Firmware. Les instructions complètes sont disponibles sur le site web de l'application."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラー"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per eseguire l'installer da un'unità USB su un Mac con PowerPC, è necessario inserire il comando nella console Open Firmware. Il manuale utente completo è disponibile sul sito Web dell'applicazione."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "BŁĄD"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPC MacでUSBドライブからインストーラを起動するには、Open Firmwareコンソールでコマンドを入力する必要があります。詳しい手順はアプリケーションのウェブサイトをご覧ください。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRO"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para inicializar o instalador de um pen drive USB em um Mac PowerPC, é necessário inserir um comando no console do Open Firmware. As instruções completas estão disponíveis no site do aplicativo."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ОШИБКА"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтобы запустить установщик с USB-накопителя на Mac с PowerPC, необходимо ввести команду в консоли Open Firmware. Полная инструкция доступна на веб-сайте приложения."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "错误"
-          }
-        }
-      }
-    },
-    "Błąd analizy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysefehler"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyiciyi PowerPC'li bir Mac'teki bir USB sürücüsünden çalıştırmak için, Açık Firmware konsoluna komutu girmeniz gerekir. Tam kullanım kılavuzu uygulamanın web sitesinde bulunabilir."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analysis Error"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щоб запустити програму встановлення з USB-накопичувача на Mac з PowerPC, необхідно ввести команду в консолі Open Firmware. Повний посібник користувача можна знайти на веб-сайті програми."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de análisis"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Để chạy trình cài đặt từ ổ USB trên máy Mac có PowerPC, cần nhập lệnh trong bảng điều khiển Open Firmware. Hướng dẫn sử dụng đầy đủ có thể được tìm thấy trên trang web của ứng dụng."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur d'analyse"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要在 PowerPC Mac 上从 USB 驱动器启动安装程序，必须在 Open Firmware 控制台中输入命令。完整说明可在应用程序网站上找到。"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析エラー"
+        }
+      }
+    },
+    "Aby używać helpera uprzywilejowanego, przenieś aplikację macUSB do katalogu Applications i uruchom ją ponownie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um den privilegierten Helper zu verwenden, verschiebe die macUSB-App in den Ordner Applications und starte sie erneut."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro de análise"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To use the privileged helper, move the macUSB app to the Applications folder and launch it again."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка анализа"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para usar el helper con privilegios, mueve la app macUSB a la carpeta Aplicaciones y vuelve a iniciarla."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "分析错误"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour utiliser l outil auxiliaire privilegie, deplacez l application macUSB dans le dossier Applications puis relancez-la."
           }
-        }
-      }
-    },
-    "Błąd czyszczenia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bereinigungsfehler"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per utilizzare l'assistente privilegiato, sposta l'applicazione macUSB nella directory Applicazioni e riavviala."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cleanup Error"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特権ヘルパーを使用するには、macUSBアプリをApplicationsフォルダに移動して再起動してください。"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de limpieza"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para usar o helper privilegiado, mova o app macUSB para a pasta Aplicativos e inicie-o novamente."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur de nettoyage"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Чтобы использовать привилегированный helper, переместите приложение macUSB в папку Applications и запустите его снова."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "クリーンアップエラー"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayrıcalıklı yardımcıyı kullanmak için macUSB uygulamasını Uygulamalar dizinine taşıyın ve yeniden başlatın."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro de limpeza"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щоб скористатися привілейованим помічником, перемістіть програму macUSB у каталог Applications і перезапустіть її."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка очистки"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Để sử dụng trình trợ giúp đặc quyền, hãy di chuyển ứng dụng macUSB vào thư mục Ứng dụng và khởi động lại nó."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "清理错误"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要使用特权辅助工具，请将 macUSB 应用移动到Applications文件夹并重新启动。"
           }
         }
       }
     },
-    "Błąd połączenia z helperem: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verbindungsfehler mit dem Helper: %@"
+    "Aby zmienić język interfejsu we wszystkich elementach aplikacji (w tym menu i przyciskach), wymagany jest restart. Kliknij poniżej, aby uruchomić aplikację ponownie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um die Oberflächensprache in allen Elementen der Anwendung (einschließlich Menüs und Schaltflächen) zu ändern, ist ein Neustart erforderlich. Klicken Sie unten, um die Anwendung neu zu starten."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper connection error: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To change the interface language in all application elements (including menus and buttons), a restart is required. Click below to restart the application."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error de conexión con el helper: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para cambiar el idioma de la interfaz en todos los elementos de la aplicación (incluidos menús y botones), es necesario reiniciar. Haga clic a continuación para reiniciar la aplicación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur de connexion avec le helper : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour changer la langue de l'interface dans tous les éléments de l'application (y compris les menus et les boutons), un redémarrage est nécessaire. Cliquez ci-dessous pour redémarrer l'application."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper との接続エラー: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È necessario un riavvio per modificare la lingua dell'interfaccia in tutti gli elementi dell'applicazione (inclusi menu e pulsanti). Fare clic di seguito per riavviare l'applicazione."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Błąd połączenia z helperem: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションのすべての要素（メニューやボタンを含む）でインターフェース言語を変更するには、再起動が必要です。以下をクリックしてアプリケーションを再起動してください。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro de conexão com o helper: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para alterar o idioma da interface em todos os elementos do aplicativo (incluindo menus e botões), é necessário reiniciar. Clique abaixo para reiniciar o aplicativo."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка соединения с helper: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для изменения языка интерфейса во всех элементах приложения (включая меню и кнопки) требуется перезапуск. Нажмите ниже, чтобы перезапустить приложение."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 helper 的连接错误：%@"
-          }
-        }
-      }
-    },
-    "Błąd: Nie wybrano dysku." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler: Kein Laufwerk ausgewählt."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm uygulama öğelerindeki (menüler ve düğmeler dahil) arayüz dilini değiştirmek için yeniden başlatma gerekir. Uygulamayı yeniden başlatmak için aşağıya tıklayın."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: No drive selected."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Щоб змінити мову інтерфейсу в усіх елементах програми (включно з меню та кнопками), потрібен перезапуск. Натисніть нижче, щоб перезапустити програму."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error: No se ha seleccionado ningún disco."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cần phải khởi động lại để thay đổi ngôn ngữ giao diện trong tất cả các thành phần ứng dụng (bao gồm menu và nút). Nhấp vào bên dưới để khởi động lại ứng dụng."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur : Aucun disque sélectionné."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要更改所有应用程序元素（包括菜单和按钮）中的界面语言，需要重启。点击下方以重启应用程序。"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラー: ドライブが選択されていません。"
+        }
+      }
+    },
+    "Aktualnie uruchomiona wersja: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktuell ausgeführte Version: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro: Nenhuma unidade selecionada."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currently running version: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка: Диск не выбран."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión actualmente en ejecución: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "错误：未选择驱动器。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version actuellement utilisée : %@"
           }
-        }
-      }
-    },
-    "Brak dostępnych aktualizacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine Updates verfügbar"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione attualmente in esecuzione: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No updates available"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在実行中のバージョン: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No hay actualizaciones disponibles"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão em execução no momento: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune mise à jour disponible"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текущая запущенная версия: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "利用可能なアップデートはありません"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şu anda çalışan sürüm: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma atualização disponível"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поточна версія: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет доступных обновлений"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản hiện đang chạy: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无可用更新"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前运行版本：%@"
           }
         }
       }
     },
-    "Brak połączenia XPC z helperem" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keine XPC-Verbindung zum Helper"
+    "Analiza nie została wykonana - wybór użytkownika": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse nicht durchgeführt - Benutzerauswahl"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No XPC connection to helper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysis not performed - user choice"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sin conexión XPC con el helper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análisis no realizado - elección del usuario"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune connexion XPC au helper"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse non effectuée - choix de l'utilisateur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper への XPC 接続がありません"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'analisi non è stata eseguita - selezione dell'utente"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak połączenia XPC z helperem"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析は実行されませんでした - ユーザーの選択"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem conexão XPC com o helper"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Análise não realizada - escolha do usuário"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет XPC-соединения с helper"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Анализ не выполнен - выбор пользователя"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未与 helper 建立 XPC 连接"
-          }
-        }
-      }
-    },
-    "Cały proces może potrwać kilka minut." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der gesamte Vorgang kann einige Minuten dauern."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiz yapılmadı - kullanıcı seçimi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The entire process may take a few minutes."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аналіз не проводився - вибір користувача"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo el proceso puede tardar unos minutos."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phân tích chưa được thực hiện - lựa chọn của người dùng"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'ensemble du processus peut prendre quelques minutes."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析未执行 - 用户选择"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すべての処理には数分かかる場合があります。"
+        }
+      }
+    },
+    "Analizowanie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysieren"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todo o processo pode levar alguns minutos."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyzing"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Весь процесс может занять несколько минут."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizando"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "整个过程可能需要几分钟。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse en cours"
           }
-        }
-      }
-    },
-    "Co teraz?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Was jetzt?"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizzando"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "What now?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析中"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Y ahora qué?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analisando"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Et maintenant ?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Анализ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次はどうする？"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiz ediliyor"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "E agora?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аналізуючи"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Что теперь?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phân tích"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "现在做什么？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在分析"
           }
         }
       }
     },
-    "Czy chcesz włączyć powiadomienia?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchtest du Benachrichtigungen aktivieren?"
+    "Analizuj": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do you want to enable notifications?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyze"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Quieres habilitar las notificaciones?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voulez-vous activer les notifications ?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyser"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知を有効にしますか？"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizzare"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deseja ativar as notificações?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хотите включить уведомления?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analisar"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是否要启用通知？"
-          }
-        }
-      }
-    },
-    "Czy na pewno chcesz przerwać pracę?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Möchten Sie den Vorgang wirklich abbrechen?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Анализировать"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Are you sure you want to abort the operation?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiz et"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Seguro que desea abortar la operación?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аналізуйте"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voulez-vous vraiment annuler l'opération ?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phân tích"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本当に操作を中止しますか？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析"
           }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza de que deseja abortar a operação?"
+        }
+      }
+    },
+    "Automatycznie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы уверены, что хотите прервать операцию?"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您确定要中止操作吗？"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
-        }
-      }
-    },
-    "Czy przerwać tworzenie nośnika?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Moechten Sie die Erstellung des USB-Mediums abbrechen?"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatique"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop creating the USB media?"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automaticamente"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Interrumpir la creacion del medio USB?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrompre la creation du support USB ?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automático"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメディアの作成を中断しますか？"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматически"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czy przerwać tworzenie nośnika?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otomatik"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interromper a criacao da midia USB?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Автоматично"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Прервать создание USB-носителя?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tự động"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要停止创建 USB 介质吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
           }
         }
       }
     },
-    "Czyszczenie plików tymczasowych" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bereinigen temporärer Dateien"
+    "Bieżący przebieg operacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktueller Fortschritt des Vorgangs"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cleaning temporary files"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current operation progress"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpiando archivos temporales"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Progreso actual de la operacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettoyage des fichiers temporaires"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Progression actuelle de l operation"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時ファイルを削除中"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Corso attuale dell'operazione"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpando arquivos temporários"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の処理進行状況"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистка временных файлов"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Progresso atual da operacao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在清理临时文件"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Текущий ход операции"
           }
-        }
-      }
-    },
-    "Dalsze działanie aplikacji zostało zablokowane. Aby zacząć od nowa, uruchom ponownie aplikację." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der weitere Betrieb der Anwendung wurde blockiert. Starten Sie die Anwendung neu, um von vorne zu beginnen."
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyonun mevcut gidişatı"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Further operation of the application has been blocked. To start over, restart the application."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поточний хід операції"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se ha bloqueado el funcionamiento posterior de la aplicación. Para empezar de nuevo, reinicie la aplicación."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình hoạt động hiện tại"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fonctionnement ultérieur de l'application a été bloqué. Pour recommencer, redémarrez l'application."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "当前操作进度"
+          }
+        }
+      }
+    },
+    "BŁĄD": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "FEHLER"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションのそれ以上の操作はブロックされました。最初からやり直すには、アプリケーションを再起動してください。"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERROR"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A operação posterior do aplicativo foi bloqueada. Para recomeçar, reinicie o aplicativo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERROR"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дальнейшая работа приложения заблокирована. Чтобы начать заново, перезапустите приложение."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERREUR"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用程序的进一步操作已被阻止。要重新开始，请重启应用程序。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERRORE"
           }
-        }
-      }
-    },
-    "Dalsze działanie aplikacji zostanie zablokowane" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der weitere Betrieb der Anwendung wird blockiert"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Further operation of the application will be blocked"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "BŁĄD"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se bloqueará el funcionamiento posterior de la aplicación"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERRO"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le fonctionnement ultérieur de l'application sera bloqué"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ОШИБКА"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションのそれ以上の操作はブロックされます"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HATA"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A operação posterior do aplicativo será bloqueada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ПОМИЛКА"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Дальнейшая работа приложения будет заблокирована"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SAI LẦM"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用程序的进一步操作将被阻止"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误"
           }
         }
       }
     },
-    "DEBUG" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+    "Błąd analizy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysefehler"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analysis Error"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de análisis"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur d'analyse"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore di analisi"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析エラー"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro de análise"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка анализа"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DEBUG"
-          }
-        }
-      }
-    },
-    "Deutsch" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analiz hatası"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка аналізу"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi phân tích"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分析错误"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        }
+      }
+    },
+    "Błąd czyszczenia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigungsfehler"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleanup Error"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de limpieza"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deutsch"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de nettoyage"
           }
-        }
-      }
-    },
-    "Dla wybranego obrazu zostanie pominięta weryfikacja wersji. Aplikacja wymusi rozpoznanie pliku jako „Mac OS X Tiger 10.4”, aby umożliwić jego zamontowanie i zapis na USB. Czy chcesz kontynuować?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Versionsüberprüfung wird für das ausgewählte Abbild übersprungen. Die Anwendung erzwingt die Erkennung der Datei als „Mac OS X Tiger 10.4“, um das Mounten und Schreiben auf USB zu ermöglichen. Möchten Sie fortfahren?"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore di pulizia"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version verification will be skipped for the selected image. The application will force recognition of the file as “Mac OS X Tiger 10.4” to enable mounting and writing to USB. Do you want to continue?"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリーンアップエラー"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se omitirá la verificación de la versión para la imagen seleccionada. La aplicación forzará el reconocimiento del archivo como \"Mac OS X Tiger 10.4\" para permitir su montaje y escritura en el USB. ¿Desea continuar?"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro de limpeza"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La vérification de la version sera ignorée pour l'image sélectionnée. L'application forcera la reconnaissance du fichier comme « Mac OS X Tiger 10.4 » pour permettre son montage et son écriture sur USB. Voulez-vous continuer ?"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка очистки"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたイメージのバージョン確認はスキップされます。アプリケーションはファイルを「Mac OS X Tiger 10.4」として強制的に認識させ、マウントおよびUSBへの書き込みを可能にします。続けますか？"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temizleme hatası"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A verificação de versão será ignorada para a imagem selecionada. O aplicativo forçará o reconhecimento do arquivo como \"Mac OS X Tiger 10.4\" para permitir a montagem e gravação no USB. Deseja continuar?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка очищення"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка версии для выбранного образа будет пропущена. Приложение принудительно распознает файл как «Mac OS X Tiger 10.4», чтобы разрешить его монтирование и запись на USB. Вы хотите продолжить?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi dọn dẹp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将跳过所选镜像的版本验证。应用程序将强制识别该文件为 “Mac OS X Tiger 10.4”，以允许挂载并写入 USB。您想继续吗？"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理错误"
           }
         }
       }
     },
-    "Dostępna aktualizacja!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update verfügbar!"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update available!"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Actualización disponible!"
+    "Błąd połączenia z helperem: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindungsfehler mit dem Helper: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mise à jour disponible !"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper connection error: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートが利用可能です！"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error de conexión con el helper: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atualização disponível!"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur de connexion avec le helper : %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступно обновление!"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore di connessione all'assistente: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新可用！"
-          }
-        }
-      }
-    },
-    "Dostępna jest nowa wersja: %@. Zalecamy aktualizację!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine neue Version ist verfügbar: %@. Wir empfehlen ein Update!"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper との接続エラー: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A new version is available: %@. We recommend updating!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Błąd połączenia z helperem: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hay una nueva versión disponible: %@. ¡Recomendamos actualizar!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro de conexão com o helper: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une nouvelle version est disponible : %@. Nous vous recommandons de mettre à jour !"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка соединения с helper: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "新しいバージョンが利用可能です: %@。アップデートをお勧めします！"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıya bağlanırken hata oluştu: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uma nova versão está disponível: %@. Recomendamos a atualização!"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка підключення до помічника: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Доступна новая версия: %@. Рекомендуем обновить!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi kết nối với người trợ giúp: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有新版本可用：%@。建议更新！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 helper 的连接错误：%@"
           }
         }
       }
     },
-    "Działanie przerwane przez użytkownika. Możesz zacząć od początku." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang vom Benutzer abgebrochen. Sie können von vorne beginnen."
+    "Błąd: Nie wybrano dysku.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler: Kein Laufwerk ausgewählt."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation interrupted by user. You can start over."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: No drive selected."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operación interrumpida por el usuario. Puedes empezar de nuevo."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error: No se ha seleccionado ningún disco."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opération interrompue par l'utilisateur. Vous pouvez recommencer."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erreur : Aucun disque sélectionné."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ユーザーによって操作が中断されました。最初からやり直せます。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore: nessun disco selezionato."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operação interrompida pelo usuário. Você pode recomeçar."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー: ドライブが選択されていません。"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Операция прервана пользователем. Вы можете начать сначала."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erro: Nenhuma unidade selecionada."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作被用户中断。您可以重新开始。"
-          }
-        }
-      }
-    },
-    "Eksportuj logi diagnostyczne" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnoseprotokolle exportieren"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка: Диск не выбран."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export diagnostic logs"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hata: Disk seçilmedi."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar registros de diagnóstico"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помилка: диск не вибрано."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporter les journaux de diagnostic"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lỗi: Không có đĩa nào được chọn."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断ログをエクスポート"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "错误：未选择驱动器。"
+          }
+        }
+      }
+    },
+    "Brak dostępnych aktualizacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Updates verfügbar"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar logs de diagnóstico"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No updates available"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Экспорт журналов диагностики"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No hay actualizaciones disponibles"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导出诊断日志"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune mise à jour disponible"
           }
-        }
-      }
-    },
-    "Eksportuj logi diagnostyczne..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diagnoseprotokolle exportieren..."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun aggiornamento disponibile"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Export diagnostic logs..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用可能なアップデートはありません"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar registros de diagnóstico..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhuma atualização disponível"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exporter les journaux de diagnostic..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет доступных обновлений"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断ログをエクスポート..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncelleme yok"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exportar logs de diagnóstico..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає оновлень"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Экспорт журналов диагностики..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có bản cập nhật nào"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "导出诊断日志..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无可用更新"
           }
         }
       }
     },
-    "English" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+    "Brak połączenia XPC z helperem": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine XPC-Verbindung zum Helper"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No XPC connection to helper"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin conexión XPC con el helper"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune connexion XPC au helper"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna connessione XPC all'helper"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "English"
-          }
-        }
-      }
-    },
-    "Español" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper への XPC 接続がありません"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak połączenia XPC z helperem"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sem conexão XPC com o helper"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет XPC-соединения с helper"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıyla XPC bağlantısı yok"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає підключення XPC до помічника"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có kết nối XPC với người trợ giúp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Español"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未与 helper 建立 XPC 连接"
           }
         }
       }
     },
-    "Etapy tworzenia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellungsschritte"
+    "Cały proces może potrwać kilka minut.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der gesamte Vorgang kann einige Minuten dauern."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation stages"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The entire process may take a few minutes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etapas de creación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo el proceso puede tardar unos minutos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Étapes de création"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'ensemble du processus peut prendre quelques minutes."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成ステージ"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'intero processo potrebbe richiedere alcuni minuti."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etapas de criação"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべての処理には数分かかる場合があります。"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Этапы создания"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todo o processo pode levar alguns minutos."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建阶段"
-          }
-        }
-      }
-    },
-    "Français" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Весь процесс может занять несколько минут."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm süreç birkaç dakika sürebilir."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Весь процес може зайняти кілька хвилин."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toàn bộ quá trình có thể mất một vài phút."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "整个过程可能需要几分钟。"
+          }
+        }
+      }
+    },
+    "Co teraz?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Was jetzt?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What now?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Y ahora qué?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Français"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et maintenant ?"
           }
-        }
-      }
-    },
-    "Helper działa poprawnie" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper funktioniert korrekt"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E adesso?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper is working correctly"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次はどうする？"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper funciona correctamente"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "E agora?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire fonctionne correctement"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что теперь?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーは正常に動作しています"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şimdi ne olacak?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper esta funcionando corretamente"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "що тепер"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper работает корректно"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bây giờ thì sao?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具运行正常"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "现在做什么？"
           }
         }
       }
     },
-    "Helper jest już usunięty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper ist bereits entfernt"
+    "Czy chcesz włączyć powiadomienia?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchtest du Benachrichtigungen aktivieren?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper is already removed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do you want to enable notifications?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper ya esta eliminado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Quieres habilitar las notificaciones?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire est deja supprime"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voulez-vous activer les notifications ?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーはすでに削除されています"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vuoi attivare le notifiche?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper ja foi removido"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知を有効にしますか？"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper уже удален"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deseja ativar as notificações?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具已被移除"
-          }
-        }
-      }
-    },
-    "Helper nie jest gotowy do pracy." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Helper ist nicht bereit."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Хотите включить уведомления?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper is not ready."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildirimleri açmak istiyor musunuz?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper no esta listo."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Бажаєте ввімкнути сповіщення?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire n est pas pret."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có muốn bật thông báo không?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーの準備ができていません。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "是否要启用通知？"
           }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper nao esta pronto."
+        }
+      }
+    },
+    "Czy na pewno chcesz przerwać pracę?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Möchten Sie den Vorgang wirklich abbrechen?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper не готов к работе."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Are you sure you want to abort the operation?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具尚未就绪。"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Seguro que desea abortar la operación?"
           }
-        }
-      }
-    },
-    "Helper nie zwrócił identyfikatora zadania." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Helper hat keine Workflow-ID zurückgegeben."
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voulez-vous vraiment annuler l'opération ?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper did not return a workflow identifier."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sei sicuro di voler smettere di lavorare?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper no devolvió un identificador de flujo de trabajo."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本当に操作を中止しますか？"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le helper n a pas renvoyé d identifiant de workflow."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tem certeza de que deseja abortar a operação?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper がワークフロー識別子を返しませんでした。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы уверены, что хотите прервать операцию?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper nie zwrócił identyfikatora zadania."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışmayı bırakmak istediğinizden emin misiniz?"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper não retornou um identificador de workflow."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ви впевнені, що хочете припинити роботу?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper не вернул идентификатор рабочего процесса."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn có chắc chắn muốn ngừng làm việc không?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper 未返回工作流标识符。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您确定要中止操作吗？"
           }
         }
       }
     },
-    "Helper odpowiada poprawnie (uid=%@, euid=%@, pid=%@)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper antwortet korrekt (uid=%@, euid=%@, pid=%@)"
+    "Czy przerwać tworzenie nośnika?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Moechten Sie die Erstellung des USB-Mediums abbrechen?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper is responding correctly (uid=%@, euid=%@, pid=%@)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop creating the USB media?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper responde correctamente (uid=%@, euid=%@, pid=%@)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¿Interrumpir la creacion del medio USB?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le helper répond correctement (uid=%@, euid=%@, pid=%@)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompre la creation du support USB ?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper は正常に応答しています (uid=%@, euid=%@, pid=%@)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompere la creazione del supporto?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper odpowiada poprawnie (uid=%@, euid=%@, pid=%@)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメディアの作成を中断しますか？"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper está respondendo corretamente (uid=%@, euid=%@, pid=%@)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy przerwać tworzenie nośnika?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper отвечает корректно (uid=%@, euid=%@, pid=%@)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interromper a criacao da midia USB?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper 响应正常 (uid=%@, euid=%@, pid=%@)"
-          }
-        }
-      }
-    },
-    "Helper wymaga zatwierdzenia w Ustawieniach systemowych." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Helper erfordert eine Freigabe in den Systemeinstellungen."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прервать создание USB-носителя?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper requires approval in System Settings."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ortam oluşturma işlemi durdurulsun mu?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper requiere aprobacion en Ajustes del sistema."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перервати створення носія?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire necessite une autorisation dans les reglages systeme."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dừng quá trình tạo bộ cài trên USB?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーはシステム設定での承認が必要です。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要停止创建 USB 介质吗？"
+          }
+        }
+      }
+    },
+    "Czyszczenie plików tymczasowych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigen temporärer Dateien"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper requer aprovacao nos Ajustes do Sistema."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleaning temporary files"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для helper требуется подтверждение в системных настройках."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpiando archivos temporales"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具需要在系统设置中批准。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyage des fichiers temporaires"
           }
-        }
-      }
-    },
-    "Helper został usunięty" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper wurde entfernt"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulizia dei file temporanei"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper has been removed"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時ファイルを削除中"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper se ha eliminado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpando arquivos temporários"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire a ete supprime"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистка временных файлов"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーが削除されました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçici dosyaları temizleme"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper foi removido"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очищення тимчасових файлів"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper удален"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Làm sạch các tập tin tạm thời"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具已移除"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在清理临时文件"
           }
         }
       }
     },
-    "Helper został zarejestrowany, ale wymaga zatwierdzenia przez użytkownika." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Helper wurde registriert, erfordert jedoch eine Freigabe durch den Benutzer."
+    "Dalsze działanie aplikacji zostało zablokowane. Aby zacząć od nowa, uruchom ponownie aplikację.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der weitere Betrieb der Anwendung wurde blockiert. Starten Sie die Anwendung neu, um von vorne zu beginnen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper was registered, but requires user approval."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Further operation of the application has been blocked. To start over, restart the application."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El helper se registro, pero requiere aprobacion del usuario."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se ha bloqueado el funcionamiento posterior de la aplicación. Para empezar de nuevo, reinicie la aplicación."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L outil auxiliaire a ete enregistre, mais necessite une approbation de l utilisateur."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fonctionnement ultérieur de l'application a été bloqué. Pour recommencer, redémarrez l'application."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーは登録されましたが、ユーザーの承認が必要です。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'ulteriore funzionamento dell'applicazione è stato bloccato. Per ricominciare, riavviare l'applicazione."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O helper foi registrado, mas requer aprovacao do usuario."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションのそれ以上の操作はブロックされました。最初からやり直すには、アプリケーションを再起動してください。"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper зарегистрирован, но требует подтверждения пользователя."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A operação posterior do aplicativo foi bloqueada. Para recomeçar, reinicie o aplicativo."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具已注册，但需要用户批准。"
-          }
-        }
-      }
-    },
-    "helper.workflow.catalina_cleanup.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten des Speicherplatzes fuer die finale Installer-Struktur."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дальнейшая работа приложения заблокирована. Чтобы начать заново, перезапустите приложение."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing space for the final installer structure."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamanın daha fazla çalışması engellendi. Yeniden başlamak için uygulamayı yeniden başlatın."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion del espacio para la estructura final del instalador."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подальшу роботу програми заблоковано. Щоб почати заново, перезапустіть програму."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation de l'espace pour la structure finale de l'installateur."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoạt động tiếp theo của ứng dụng đã bị chặn. Để bắt đầu lại, hãy khởi động lại ứng dụng."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最終的なインストーラ構成のための領域を準備しています。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序的进一步操作已被阻止。要重新开始，请重启应用程序。"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowywanie miejsca na finalną strukturę instalatora."
+        }
+      }
+    },
+    "Dalsze działanie aplikacji zostanie zablokowane": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der weitere Betrieb der Anwendung wird blockiert"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao do espaco para a estrutura final do instalador."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Further operation of the application will be blocked"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка места для финальной структуры установщика."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se bloqueará el funcionamiento posterior de la aplicación"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在为最终安装器结构准备空间。"
-          }
-        }
-      }
-    },
-    "helper.workflow.catalina_cleanup.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten der Installer-Struktur"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le fonctionnement ultérieur de l'application sera bloqué"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing installer structure"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'ulteriore funzionamento dell'applicazione verrà bloccato"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion de la estructura del instalador"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションのそれ以上の操作はブロックされます"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation de la structure de l'installateur"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A operação posterior do aplicativo será bloqueada"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラ構成の準備"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дальнейшая работа приложения будет заблокирована"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowanie struktury instalatora"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamanın daha fazla çalışması engellenecek"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao da estrutura do instalador"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подальша робота програми буде заблокована"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка структуры установщика"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoạt động tiếp theo của ứng dụng sẽ bị chặn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "准备安装器结构"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用程序的进一步操作将被阻止"
           }
         }
       }
     },
-    "helper.workflow.catalina_copy.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vervollstaendigen der finalen Struktur der Installer-App."
+    "DEBUG": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completing the final installer app structure."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completando la estructura final de la app del instalador."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisation de la structure finale de l'application d'installation."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラAppの最終構成を整えています。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uzupełnianie finalnej struktury aplikacji instalatora."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conclusao da estrutura final do app instalador."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершение финальной структуры приложения установщика."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在补全安装器应用的最终结构。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
           }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HATA AYIKLAMA"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НАЛАШТУВАННЯ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GỠ LỖI"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEBUG"
+          }
+        }
+      }
+    },
+    "Deutsch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deutsch"
+          }
+        }
+      }
+    },
+    "Dla wybranego obrazu zostanie pominięta weryfikacja wersji. Aplikacja wymusi rozpoznanie pliku jako „Mac OS X Tiger 10.4”, aby umożliwić jego zamontowanie i zapis na USB. Czy chcesz kontynuować?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Versionsüberprüfung wird für das ausgewählte Abbild übersprungen. Die Anwendung erzwingt die Erkennung der Datei als „Mac OS X Tiger 10.4“, um das Mounten und Schreiben auf USB zu ermöglichen. Möchten Sie fortfahren?"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version verification will be skipped for the selected image. The application will force recognition of the file as “Mac OS X Tiger 10.4” to enable mounting and writing to USB. Do you want to continue?"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se omitirá la verificación de la versión para la imagen seleccionada. La aplicación forzará el reconocimiento del archivo como \"Mac OS X Tiger 10.4\" para permitir su montaje y escritura en el USB. ¿Desea continuar?"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La vérification de la version sera ignorée pour l'image sélectionnée. L'application forcera la reconnaissance du fichier comme « Mac OS X Tiger 10.4 » pour permettre son montage et son écriture sur USB. Voulez-vous continuer ?"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il controllo della versione verrà ignorato per l'immagine selezionata. L'applicazione forzerà il riconoscimento del file come \"Mac OS X Tiger 10.4\" per consentirne il montaggio e il salvataggio sull'USB. Vuoi continuare?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたイメージのバージョン確認はスキップされます。アプリケーションはファイルを「Mac OS X Tiger 10.4」として強制的に認識させ、マウントおよびUSBへの書き込みを可能にします。続けますか？"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A verificação de versão será ignorada para a imagem selecionada. O aplicativo forçará o reconhecimento do arquivo como \"Mac OS X Tiger 10.4\" para permitir a montagem e gravação no USB. Deseja continuar?"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка версии для выбранного образа будет пропущена. Приложение принудительно распознает файл как «Mac OS X Tiger 10.4», чтобы разрешить его монтирование и запись на USB. Вы хотите продолжить?"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen disk imajı için sürüm doğrulaması atlanacaktır. Uygulama, USB’ye bağlanıp yazılabilmesi için dosyanın “Mac OS X Tiger 10.4” olarak tanınmasını zorlayacaktır. Devam etmek istiyor musunuz?"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для вибраного зображення перевірку версій буде обійдено. Програма примусово розпізнає файл як \"Mac OS X Tiger 10.4\", щоб його можна було підключити та зберегти на USB. Ви хочете продовжити?"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Việc kiểm tra phiên bản sẽ được bỏ qua đối với hình ảnh đã chọn. Ứng dụng sẽ buộc tập tin phải được nhận dạng là \"Mac OS X Tiger 10.4\" để cho phép gắn và lưu vào USB. Bạn có muốn tiếp tục không?"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将跳过所选镜像的版本验证。应用程序将强制识别该文件为 “Mac OS X Tiger 10.4”，以允许挂载并写入 USB。您想继续吗？"
+          }
+        }
+      }
+    },
+    "Dostępna aktualizacja!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update verfügbar!"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update available!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Actualización disponible!"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour disponible !"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento disponibile!"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートが利用可能です！"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização disponível!"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступно обновление!"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncelleme mevcut!"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступне оновлення!"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cập nhật có sẵn!"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新可用！"
+          }
+        }
+      }
+    },
+    "Dostępna jest nowa wersja: %@. Zalecamy aktualizację!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine neue Version ist verfügbar: %@. Wir empfehlen ein Update!"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A new version is available: %@. We recommend updating!"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hay una nueva versión disponible: %@. ¡Recomendamos actualizar!"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une nouvelle version est disponible : %@. Nous vous recommandons de mettre à jour !"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È disponibile una nuova versione: %@. Ti consigliamo di aggiornare!"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいバージョンが利用可能です: %@。アップデートをお勧めします！"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uma nova versão está disponível: %@. Recomendamos a atualização!"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступна новая версия: %@. Рекомендуем обновить!"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni bir sürüm mevcut: %@. Güncellemenizi öneririz!"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Доступна нова версія: %@. Рекомендуємо оновити!"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã có phiên bản mới: %@. Chúng tôi khuyên bạn nên cập nhật!"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有新版本可用：%@。建议更新！"
+          }
+        }
+      }
+    },
+    "Działanie przerwane przez użytkownika. Możesz zacząć od początku.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang vom Benutzer abgebrochen. Sie können von vorne beginnen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation interrupted by user. You can start over."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operación interrumpida por el usuario. Puedes empezar de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opération interrompue par l'utilisateur. Vous pouvez recommencer."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operazione interrotta dall'utente. Puoi ricominciare da capo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ユーザーによって操作が中断されました。最初からやり直せます。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operação interrompida pelo usuário. Você pode recomeçar."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операция прервана пользователем. Вы можете начать сначала."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem kullanıcı tarafından kesintiye uğradı. Yeniden başlayabilirsiniz."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операцію перервано користувачем. Ви можете почати спочатку."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoạt động bị gián đoạn bởi người dùng. Bạn có thể bắt đầu lại."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作被用户中断。您可以重新开始。"
+          }
+        }
+      }
+    },
+    "Eksportuj logi diagnostyczne": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnoseprotokolle exportieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export diagnostic logs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros de diagnóstico"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter les journaux de diagnostic"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esportare i log diagnostici"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断ログをエクスポート"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar logs de diagnóstico"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспорт журналов диагностики"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teşhis günlüklerini dışa aktar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Експорт журналів діагностики"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xuất nhật ký chẩn đoán"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出诊断日志"
+          }
+        }
+      }
+    },
+    "Eksportuj logi diagnostyczne...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diagnoseprotokolle exportieren..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export diagnostic logs..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar registros de diagnóstico..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exporter les journaux de diagnostic..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esporta registri diagnostici..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断ログをエクスポート..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar logs de diagnóstico..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Экспорт журналов диагностики..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanılama günlüklerini dışa aktar..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Експорт журналів діагностики..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xuất nhật ký chẩn đoán..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "导出诊断日志..."
+          }
+        }
+      }
+    },
+    "English": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
+          }
+        }
+      }
+    },
+    "Español": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Español"
+          }
+        }
+      }
+    },
+    "Etapy tworzenia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellungsschritte"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation stages"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapas de creación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Étapes de création"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fasi della creazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成ステージ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etapas de criação"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Этапы создания"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yaratılış aşamaları"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Етапи створення"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Các giai đoạn sáng tạo"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建阶段"
+          }
+        }
+      }
+    },
+    "Français": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Français"
+          }
+        }
+      }
+    },
+    "Helper działa poprawnie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper funktioniert korrekt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper is working correctly"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper funciona correctamente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire fonctionne correctement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante funziona correttamente"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーは正常に動作しています"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper esta funcionando corretamente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper работает корректно"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı düzgün çalışıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник працює правильно"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trình trợ giúp hoạt động bình thường"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具运行正常"
+          }
+        }
+      }
+    },
+    "Helper jest już usunięty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper ist bereits entfernt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper is already removed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper ya esta eliminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire est deja supprime"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante è già stato rimosso"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーはすでに削除されています"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper ja foi removido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper уже удален"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı zaten kaldırıldı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник уже видалений"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp đã bị xóa"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具已被移除"
+          }
+        }
+      }
+    },
+    "Helper nie jest gotowy do pracy.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Helper ist nicht bereit."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper is not ready."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper no esta listo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire n est pas pret."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante non è pronto per il lavoro."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーの準備ができていません。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper nao esta pronto."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper не готов к работе."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı çalışmaya hazır değil."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник не готовий до роботи."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp chưa sẵn sàng làm việc."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具尚未就绪。"
+          }
+        }
+      }
+    },
+    "Helper nie zwrócił identyfikatora zadania.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Helper hat keine Workflow-ID zurückgegeben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper did not return a workflow identifier."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper no devolvió un identificador de flujo de trabajo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le helper n a pas renvoyé d identifiant de workflow."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante non ha restituito l'ID dell'attività."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper がワークフロー識別子を返しませんでした。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper nie zwrócił identyfikatora zadania."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper não retornou um identificador de workflow."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper не вернул идентификатор рабочего процесса."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı görev kimliğini döndürmedi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник не повернув ідентифікатор завдання."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp không trả lại ID nhiệm vụ."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper 未返回工作流标识符。"
+          }
+        }
+      }
+    },
+    "Helper odpowiada poprawnie (uid=%@, euid=%@, pid=%@)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper antwortet korrekt (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper is responding correctly (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper responde correctamente (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le helper répond correctement (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'helper risponde correttamente (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper は正常に応答しています (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper odpowiada poprawnie (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper está respondendo corretamente (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper отвечает корректно (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı doğru yanıt veriyor (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник відповідає правильно (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp phản hồi chính xác (uid=%@, euid=%@, pid=%@)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper 响应正常 (uid=%@, euid=%@, pid=%@)"
+          }
+        }
+      }
+    },
+    "Helper wymaga zatwierdzenia w Ustawieniach systemowych.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Helper erfordert eine Freigabe in den Systemeinstellungen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper requires approval in System Settings."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper requiere aprobacion en Ajustes del sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire necessite une autorisation dans les reglages systeme."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante richiede l'approvazione nelle Impostazioni di sistema."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーはシステム設定での承認が必要です。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper requer aprovacao nos Ajustes do Sistema."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для helper требуется подтверждение в системных настройках."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcının Sistem Ayarlarında onaylanması gerekiyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник вимагає схвалення в налаштуваннях системи."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp yêu cầu phê duyệt trong Cài đặt hệ thống."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具需要在系统设置中批准。"
+          }
+        }
+      }
+    },
+    "Helper został usunięty": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper wurde entfernt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper has been removed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper se ha eliminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire a ete supprime"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante è stato rimosso"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーが削除されました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper foi removido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper удален"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı kaldırıldı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічника видалено"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp đã bị xóa"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具已移除"
+          }
+        }
+      }
+    },
+    "Helper został zarejestrowany, ale wymaga zatwierdzenia przez użytkownika.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Helper wurde registriert, erfordert jedoch eine Freigabe durch den Benutzer."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper was registered, but requires user approval."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El helper se registro, pero requiere aprobacion del usuario."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L outil auxiliaire a ete enregistre, mais necessite une approbation de l utilisateur."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante è stato registrato ma richiede l'approvazione dell'utente."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーは登録されましたが、ユーザーの承認が必要です。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O helper foi registrado, mas requer aprovacao do usuario."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper зарегистрирован, но требует подтверждения пользователя."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı kaydedildi ancak kullanıcı onayı gerekiyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник зареєстрований, але потребує схвалення користувача."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp đã được đăng ký nhưng cần có sự chấp thuận của người dùng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具已注册，但需要用户批准。"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_cleanup.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten des Speicherplatzes fuer die finale Installer-Struktur."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing space for the final installer structure."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion del espacio para la estructura final del instalador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation de l'espace pour la structure finale de l'installateur."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione dello spazio per la struttura dell'installatore finale."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終的なインストーラ構成のための領域を準備しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowywanie miejsca na finalną strukturę instalatora."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao do espaco para a estrutura final do instalador."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка места для финальной структуры установщика."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nihai kurulumcu yapısı için alan hazırlanıyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка місця для остаточної конструкції інсталятора."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuẩn bị không gian cho cấu trúc trình cài đặt cuối cùng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在为最终安装器结构准备空间。"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_cleanup.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten der Installer-Struktur"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing installer structure"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion de la estructura del instalador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation de la structure de l'installateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione della struttura dell'installatore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラ構成の準備"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowanie struktury instalatora"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao da estrutura do instalador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка структуры установщика"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurulum yapısının hazırlanması"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка структури інсталятора"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuẩn bị cấu trúc trình cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "准备安装器结构"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_copy.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vervollstaendigen der finalen Struktur der Installer-App."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completing the final installer app structure."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completando la estructura final de la app del instalador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation de la structure finale de l'application d'installation."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completamento della struttura finale dell'app di installazione."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラAppの最終構成を整えています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uzupełnianie finalnej struktury aplikacji instalatora."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conclusao da estrutura final do app instalador."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение финальной структуры приложения установщика."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Son yükleyici uygulama yapısının tamamlanması."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершення остаточної структури програми встановлення."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoàn thành cấu trúc ứng dụng cài đặt cuối cùng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在补全安装器应用的最终结构。"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_copy.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren der Dateien auf das Installationsmedium"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copying files to installer media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de archivos al medio de instalacion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copie des fichiers vers le support d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia dei file sul supporto di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールメディアへのファイルコピー"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiowanie plików na nośnik instalacyjny"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia de arquivos para a midia de instalacao"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копирование файлов на установочный носитель"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyaları yükleyici ortamına kopyalama"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювання файлів на інсталяційний носій"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sao chép tập tin vào phương tiện cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将文件复制到安装介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_xattr.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisieren der Dateiberechtigungen des Installers."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing installer file permissions."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacion de los permisos de archivos del instalador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation des autorisations des fichiers de l'installateur."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizzazione delle autorizzazioni del file di installazione."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラファイルの権限を最終調整しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizowanie uprawnień plików instalatora."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacao das permissoes dos arquivos do instalador."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Финализация прав доступа к файлам установщика."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici dosyası izinleri sonlandırılıyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершення дозволів файлу інсталятора."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang hoàn tất quyền truy cập tệp trình cài đặt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成安装器文件权限设置。"
+          }
+        }
+      }
+    },
+    "helper.workflow.catalina_xattr.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwenden von Dateiberechtigungen fuer den Installer"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applying installer file permissions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicacion de permisos de archivos del instalador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application des autorisations des fichiers de l'installateur"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applicazione delle autorizzazioni del file di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラファイル権限の適用"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nadawanie uprawnień plikom instalatora"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aplicacao das permissoes de arquivos do instalador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применение прав доступа к файлам установщика"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici dosyası izinlerini uygulama"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосування дозволів файлу інсталятора"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áp dụng quyền đối với tệp trình cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用安装器文件权限"
+          }
+        }
+      }
+    },
+    "helper.workflow.cleanup_temp.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen temporaerer Dateien, um Speicherplatz freizugeben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Removing temporary files to free up space."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eliminacion de archivos temporales para liberar espacio."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suppression des fichiers temporaires pour liberer de l'espace."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rimozione di file temporanei per liberare spazio."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空き容量を確保するため一時ファイルを削除しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuwanie tymczasowych plików w celu zwolnienia miejsca."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remocao de arquivos temporarios para liberar espaco."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Удаление временных файлов для освобождения места."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yer açmak için geçici dosyaları kaldırma."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Видалення тимчасових файлів, щоб звільнити місце."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xóa các tập tin tạm thời để giải phóng dung lượng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在删除临时文件以释放空间。"
+          }
+        }
+      }
+    },
+    "helper.workflow.cleanup_temp.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufraeumen temporaerer Dateien"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cleaning up temporary files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpieza de archivos temporales"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nettoyage des fichiers temporaires"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pulizia dei file temporanei"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時ファイルの整理"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Porządkowanie plików tymczasowych"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limpeza de arquivos temporarios"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очистка временных файлов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçici dosyaları temizleme"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очищення тимчасових файлів"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dọn dẹp các tập tin tạm thời"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在清理临时文件"
+          }
+        }
+      }
+    },
+    "helper.workflow.createinstallmedia.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopieren der Installationsdateien auf das ausgewaehlte USB-Medium."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copying installer files to the selected USB media."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiado de los archivos del instalador al medio USB seleccionado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copie des fichiers d'installation sur le support USB selectionne."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia dei file di installazione sul supporto USB selezionato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したUSBメディアへインストーラファイルをコピーしています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiowanie plików instalatora na wybrany nośnik USB."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia dos arquivos do instalador para a midia USB selecionada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копирование файлов установщика на выбранный USB-носитель."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici dosyaları seçilen USB ortamına kopyalanıyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювання файлів інсталятора на вибраний носій USB."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sao chép tập tin cài đặt vào phương tiện USB đã chọn."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在将安装器文件复制到所选 USB 介质。"
+          }
+        }
+      }
+    },
+    "helper.workflow.createinstallmedia.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen des Installationsmediums"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating installation media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creacion del medio de instalacion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation du support d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione del supporto di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールメディアの作成"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tworzenie nośnika instalacyjnego"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criacao da midia de instalacao"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание установочного носителя"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurulum medyası oluşturma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення інсталяційного носія"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo phương tiện cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建安装介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.finalize.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisieren des Vorgangs und Vorbereiten der Zusammenfassung."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizing the operation and preparing a summary."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacion de la operacion y preparacion del resumen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation de l'operation et preparation du resume."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizzare l'operazione e preparare una sintesi."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "処理を完了し、概要を準備しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizowanie operacji i przygotowywanie podsumowania."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacao da operacao e preparacao do resumo."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение операции и подготовка итогов."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyonun sonuçlandırılması ve özetin hazırlanması."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершення операції та підготовка резюме."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoàn thiện hoạt động và chuẩn bị một bản tóm tắt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成操作并准备摘要。"
+          }
+        }
+      }
+    },
+    "helper.workflow.finalize.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abschliessen des Vorgangs"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finishing the process"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacion del proceso"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalisation du processus"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fine del processo"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "処理の完了"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakończenie procesu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizacao do processo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение процесса"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Süreci bitirme"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершення процесу"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết thúc quá trình"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在完成流程"
+          }
+        }
+      }
+    },
+    "helper.workflow.imagescan.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ueberpruefen des Installationsabbilds vor dem Schreiben."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifying the installer image before writing."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificacion de la imagen de instalacion antes de la grabacion."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verification de l'image d'installation avant l'ecriture."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificare l'immagine del programma di installazione prima di scrivere."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書き込み前にインストーライメージを検証しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weryfikowanie obrazu instalacyjnego przed zapisem."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificacao da imagem de instalacao antes da gravacao."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка установочного образа перед записью."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yazmadan önce yükleyici görüntüsünün doğrulanması."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірка образу інсталятора перед записом."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xác minh hình ảnh trình cài đặt trước khi viết."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在写入前验证安装镜像。"
+          }
+        }
+      }
+    },
+    "helper.workflow.imagescan.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ueberpruefen des Installationsabbilds"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifying installer image"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificacion de la imagen del instalador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verification de l'image d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica dell'immagine del programma di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーライメージの検証"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weryfikowanie obrazu instalatora"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificacao da imagem do instalador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка образа установщика"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici görüntüsü doğrulanıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірка зображення інсталятора"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang xác minh hình ảnh trình cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在验证安装器镜像"
+          }
+        }
+      }
+    },
+    "helper.workflow.ppc_format.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anpassen des USB-Mediums fuer einen PowerPC-Installer."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adapting USB media for a PowerPC installer."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaptacion del medio USB para un instalador PowerPC."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaptation du support USB pour un installateur PowerPC."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adattamento del supporto USB per un programma di installazione PowerPC."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPCインストーラ向けにUSBメディアを調整しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostosowywanie nośnika USB dla instalatora PowerPC."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Adaptacao da midia USB para um instalador PowerPC."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка USB-носителя для установщика PowerPC."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB ortamını PowerPC yükleyicisi için uyarlama."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Адаптація носія USB для інсталятора PowerPC."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều chỉnh phương tiện USB cho trình cài đặt PowerPC."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在为 PowerPC 安装器调整 USB 介质。"
+          }
+        }
+      }
+    },
+    "helper.workflow.ppc_format.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten des USB-Mediums"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing USB media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion del medio USB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation du support USB"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione del supporto USB"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメディアの準備"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowywanie nośnika USB"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao da midia USB"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка USB-носителя"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB ortamının hazırlanması"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка USB-носія"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang chuẩn bị phương tiện USB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备 USB 介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.ppc_restore.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uebertragen des Systemabbilds auf ein PowerPC-kompatibles Medium."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferring the system image to PowerPC-compatible media."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferencia de la imagen del sistema a un medio compatible con PowerPC."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfert de l'image systeme vers un support compatible PowerPC."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trasferimento dell'immagine del sistema su un supporto compatibile con PowerPC."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPC対応メディアへシステムイメージを転送しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenoszenie obrazu systemu na nośnik zgodny z PowerPC."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferencia da imagem do sistema para uma midia compativel com PowerPC."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перенос образа системы на носитель, совместимый с PowerPC."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem görüntüsünü PowerPC uyumlu ortama aktarma."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перенесення образу системи на PowerPC-сумісний носій."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển hình ảnh hệ thống sang phương tiện tương thích với PowerPC."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在将系统镜像传输到与 PowerPC 兼容的介质。"
+          }
+        }
+      }
+    },
+    "helper.workflow.ppc_restore.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen des Installationsmediums"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating installation media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creacion del medio de instalacion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation du support d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione del supporto di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールメディアの作成"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tworzenie nośnika instalacyjnego"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criacao da midia de instalacao"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание установочного носителя"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurulum medyası oluşturma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення інсталяційного носія"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo phương tiện cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建安装介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.preformat.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurieren des USB-Mediums fuer die Erstellung des Installers."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuring USB media for installer creation."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuracion del medio USB para crear el instalador."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration du support USB pour la creation de l'installateur."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione del supporto USB per la creazione del programma di installazione."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラ作成のためにUSBメディアを構成しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfigurowanie nośnika USB do utworzenia instalatora."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuracao da midia USB para criar o instalador."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка USB-носителя для создания установщика."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici oluşturmak için USB ortamını yapılandırma."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування носія USB для створення інсталятора."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Định cấu hình phương tiện USB để tạo trình cài đặt."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在配置 USB 介质以创建安装器。"
+          }
+        }
+      }
+    },
+    "helper.workflow.preformat.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten des USB-Mediums"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing USB media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion del medio USB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation du support USB"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione del supporto USB"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメディアの準備"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowywanie nośnika USB"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao da midia USB"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка USB-носителя"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB ortamının hazırlanması"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка USB-носія"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang chuẩn bị phương tiện USB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备 USB 介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.prepare_source.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten der Quelldateien fuer einen sicheren Ablauf."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing source files for a safe workflow."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion de los archivos de origen para un proceso seguro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation des fichiers source pour un deroulement securise."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione dei file di origine per un flusso di lavoro sicuro."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安全に処理を進めるためソースファイルを準備しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowywanie plików źródłowych dla bezpiecznego przebiegu procesu."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao dos arquivos de origem para um fluxo seguro."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка исходных файлов для безопасного выполнения процесса."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güvenli bir iş akışı için kaynak dosyaları hazırlamak."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка вихідних файлів для безпечного робочого процесу."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuẩn bị các tập tin nguồn cho một quy trình làm việc an toàn."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备源文件，以确保流程安全进行。"
+          }
+        }
+      }
+    },
+    "helper.workflow.prepare_source.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereiten der Installationsdateien"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing installer files"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacion de los archivos del instalador"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation des fichiers d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione dei file di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラファイルの準備"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przygotowywanie plików instalatora"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparacao dos arquivos do instalador"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка файлов установщика"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurulum dosyalarının hazırlanması"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка файлів інсталятора"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang chuẩn bị file cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备安装器文件"
+          }
+        }
+      }
+    },
+    "helper.workflow.restore.status": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uebertragen des Systemabbilds auf das ausgewaehlte USB-Medium."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferring the system image to the selected USB media."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferencia de la imagen del sistema al medio USB seleccionado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfert de l'image systeme vers le support USB selectionne."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trasferimento dell'immagine del sistema sul supporto USB selezionato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したUSBメディアへシステムイメージを転送しています。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przenoszenie obrazu systemu na wybrany nośnik USB."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferencia da imagem do sistema para a midia USB selecionada."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перенос образа системы на выбранный USB-носитель."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem görüntüsünün seçilen USB ortamına aktarılması."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перенесення образу системи на вибраний носій USB."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Truyền hình ảnh hệ thống sang phương tiện USB đã chọn."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在将系统镜像传输到所选 USB 介质。"
+          }
+        }
+      }
+    },
+    "helper.workflow.restore.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erstellen des Installationsmediums"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating installation media"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creacion del medio de instalacion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation du support d'installation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione del supporto di installazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールメディアの作成"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tworzenie nośnika instalacyjnego"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criacao da midia de instalacao"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание установочного носителя"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kurulum medyası oluşturma"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення інсталяційного носія"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo phương tiện cài đặt"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建安装介质"
+          }
+        }
+      }
+    },
+    "Ignoruj": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignore"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorare"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無視"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Игнорировать"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Görmezden gelmek"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ігнорувати"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phớt lờ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "忽略"
+          }
+        }
+      }
+    },
+    "Informacje": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informationen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Information"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacion"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informations"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informazioni"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "情報"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacje"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacoes"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Информация"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilgi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інформація"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông tin"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信息"
+          }
+        }
+      }
+    },
+    "Instalator gotowy": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installationsprogramm ist bereit"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer is ready"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El instalador está listo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le programme d’installation est prêt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il programma di installazione è pronto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラの準備ができました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O instalador está pronto"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установщик готов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici hazır"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інсталятор готовий"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trình cài đặt đã sẵn sàng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安装器已就绪"
+          }
+        }
+      }
+    },
+    "Instrukcja bootowania z nośnika USB (GitHub)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anleitung zum Booten von USB (GitHub)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB boot instructions (GitHub)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrucciones para arrancar desde USB (GitHub)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instructions de démarrage depuis USB (GitHub)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Istruzioni di avvio da un'unità USB (GitHub)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB からの起動手順（GitHub）"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instruções para inicializar pelo USB (GitHub)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструкция по загрузке с USB (GitHub)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir USB sürücüsünden (GitHub) önyükleme talimatları"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інструкції із завантаження з USB-накопичувача (GitHub)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hướng dẫn khởi động từ ổ USB (GitHub)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "从 USB 启动说明（GitHub）"
+          }
+        }
+      }
+    },
+    "Italiano": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Italiano"
+          }
+        }
+      }
+    },
+    "Język": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprache"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Langue"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lingua"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idioma"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Язык"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Мова"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ngôn ngữ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言"
+          }
+        }
+      }
+    },
+    "Konfiguracja źródła i celu": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konfiguration von Quelle und Ziel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source and target configuration"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuracion de origen y destino"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration de la source et de la cible"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configurazione di origine e destinazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソースとターゲットの設定"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuracao de origem e destino"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройка источника и цели"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak ve hedef yapılandırması"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вихідна та цільова конфігурація"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cấu hình nguồn và đích"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "源与目标配置"
+          }
+        }
+      }
+    },
+    "Kontynuuj": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fortfahren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continua"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "続ける"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devam et"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продовжити"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
+          }
+        }
+      }
+    },
+    "Korzystasz z najnowszej dostępnej wersji aplikacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie verwenden die neueste verfügbare Version der Anwendung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You are using the latest available version of the application"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estás usando la última versión disponible de la aplicación"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous utilisez la dernière version disponible de l'application"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stai utilizzando l'ultima versione disponibile dell'applicazione"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新バージョンのアプリケーションを使用しています"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você está usando a versão mais recente disponível do aplicativo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вы используете последнюю доступную версию приложения"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamanın mevcut en son sürümünü kullanıyorsunuz"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ви використовуєте останню доступну версію програми"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bạn đang sử dụng phiên bản mới nhất hiện có của ứng dụng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "您正在使用该应用程序的最新可用版本"
+          }
+        }
+      }
+    },
+    "Lokalizacja aplikacji: /Applications (OK)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Standort: /Applications (OK)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App location: /Applications (OK)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicacion de la app: /Applications (OK)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement de l app : /Applications (OK)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posizione dell'applicazione: /Applicazioni (OK)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリの場所: /Applications (OK)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localizacao do app: /Applications (OK)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расположение приложения: /Applications (OK)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama konumu: /Uygulamalar (Tamam)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розташування програми: /Програми (OK)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí ứng dụng: /Ứng dụng (OK)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用位置：/Applications（正常）"
+          }
+        }
+      }
+    },
+    "Lokalizacja aplikacji: poza /Applications": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Standort: ausserhalb von /Applications"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App location: outside /Applications"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicacion de la app: fuera de /Applications"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement de l app : hors de /Applications"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luogo di applicazione: esterno/Applicazioni"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリの場所: /Applications の外"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Localizacao do app: fora de /Applications"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расположение приложения: вне /Applications"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama yeri: dışarıda /Uygulamalar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розташування заявки: зовні /Приложения"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí ứng dụng: bên ngoài /Ứng dụng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用位置：不在 /Applications 中"
+          }
+        }
+      }
+    },
+    "Lokalizacja aplikacji: środowisko Xcode (bypass DEBUG)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App-Speicherort: Xcode-Umgebung (DEBUG-Bypass)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App location: Xcode environment (DEBUG bypass)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicacion de la app: entorno Xcode (omision DEBUG)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement de l app : environnement Xcode (contournement DEBUG)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posizione dell'applicazione: ambiente Xcode (bypass DEBUG)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリの場所: Xcode 環境（DEBUG バイパス）"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokalizacja aplikacji: środowisko Xcode (bypass DEBUG)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local do app: ambiente do Xcode (bypass DEBUG)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Расположение приложения: среда Xcode (обход DEBUG)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulama konumu: Xcode ortamı (DEBUG bypass)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розташування програми: середовище Xcode (обхід DEBUG)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí ứng dụng: Môi trường Xcode (Bỏ qua DEBUG)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用位置：Xcode 环境（DEBUG 绕过）"
+          }
+        }
+      }
+    },
+    "Mac OS X Tiger 10.4 (Multi DVD)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Çoklu DVD)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (кілька DVD)"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Đa DVD)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger 10.4 (Multi DVD)"
+          }
+        }
+      }
+    },
+    "Mach service: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mach-Dienst: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mach service: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servicio Mach: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Service Mach : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Servizio macchina: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Machサービス: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usługa Mach: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Serviço Mach: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Служба Mach: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mach hizmeti: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сервіс Mach: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dịch vụ máy: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mach 服务：%@"
+          }
+        }
+      }
+    },
+    "macUSB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB"
+          }
+        }
+      }
+    },
+    "macUSB by Kruszoneq": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB di Kruszoneq"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kruszoneq tarafından macUSB"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB від Kruszoneq"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB của Kruszoneq"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB by Kruszoneq"
+          }
+        }
+      }
+    },
+    "macUSB wymaga zezwolenia na działanie w tle, aby umożliwić zarządzanie nośnikami. Przejdź do ustawień systemowych, aby nadać wymagane uprawnienia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB benotigt die Berechtigung zur Hintergrundaktivitat, um Datentrager verwalten zu konnen. Offne die Systemeinstellungen, um die erforderlichen Berechtigungen zu erteilen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB requires background activity permission to enable drive management. Go to System Settings to grant the required permissions"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB requiere permiso para ejecutarse en segundo plano para permitir la gestion de unidades. Ve a Ajustes del sistema para conceder los permisos necesarios"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB necessite l autorisation d activite en arriere-plan pour permettre la gestion des supports. Accedez aux reglages systeme pour accorder les autorisations requises"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB richiede l'autorizzazione per l'esecuzione in background per abilitare la gestione dei contenuti multimediali. Vai alle impostazioni di sistema per concedere le autorizzazioni richieste"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB でドライブ管理を有効にするには、バックグラウンド動作の許可が必要です。必要な権限を付与するため、システム設定に移動してください"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O macUSB requer permissao de atividade em segundo plano para permitir o gerenciamento de unidades. Va para os Ajustes do Sistema para conceder as permissoes necessarias"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB требуется разрешение на работу в фоне для управления носителями. Перейдите в системные настройки, чтобы выдать необходимые разрешения"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB, medya yönetimini etkinleştirmek için arka planda çalışma iznine ihtiyaç duyar. Gerekli izinleri vermek için sistem ayarlarına gidin"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB вимагає дозволу на роботу у фоновому режимі, щоб увімкнути керування медіафайлами. Перейдіть до налаштувань системи, щоб надати необхідні дозволи"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB yêu cầu quyền chạy ở chế độ nền để kích hoạt quản lý phương tiện. Đi tới cài đặt hệ thống để cấp các quyền cần thiết"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 需要后台运行权限才能进行磁盘管理。请前往系统设置授予所需权限"
+          }
+        }
+      }
+    },
+    "Napraw helpera": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper reparieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repair helper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparar helper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparer l outil auxiliaire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correggi l'aiutante"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーを修復"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparar helper"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановить helper"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıyı düzelt"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виправити помічника"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sửa chữa người trợ giúp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修复辅助工具"
+          }
+        }
+      }
+    },
+    "Naprawa helpera": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Reparatur"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparacion del helper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparation de l outil auxiliaire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riparazione dell'aiutante"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparo do helper"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановление helper"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı onarım"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підсобний ремонт"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trợ giúp sửa chữa"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复"
+          }
+        }
+      }
+    },
+    "Naprawa helpera zakończona": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Reparatur abgeschlossen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparacion del helper completada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparation de l outil auxiliaire terminee"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riparazione dell'assistente completata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復が完了しました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparo do helper concluido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановление helper завершено"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı onarım tamamlandı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ремонт помічника завершено"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trợ giúp sửa chữa đã hoàn thành"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复已完成"
+          }
+        }
+      }
+    },
+    "Naprawa helpera zakończona błędem": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Reparatur fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reparacion del helper fallo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echec de la reparation de l outil auxiliaire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La riparazione dell'helper è terminata con un errore"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復に失敗しました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha no reparo do helper"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка при восстановлении helper"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı onarım bir hatayla sona erdi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник ремонту завершився з помилкою"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sửa chữa trợ giúp đã kết thúc với một lỗi"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复失败"
+          }
+        }
+      }
+    },
+    "Naprawa helpera zakończona błędem.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Reparatur fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair failed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reparacion del helper fallo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echec de la reparation de l outil auxiliaire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La riparazione dell'helper è terminata con un errore."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復に失敗しました。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha no reparo do helper."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ошибка при восстановлении helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı onarım bir hatayla sona erdi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник ремонту завершився з помилкою."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sửa chữa trợ giúp đã kết thúc với một lỗi."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复失败。"
+          }
+        }
+      }
+    },
+    "Naprawa helpera zakończona pomyślnie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Reparatur erfolgreich abgeschlossen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair completed successfully."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reparacion del helper se completo correctamente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparation de l outil auxiliaire terminee avec succes."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riparazione dell'helper completata con successo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復が正常に完了しました。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O reparo do helper foi concluido com sucesso."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановление helper успешно завершено."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı onarım başarıyla tamamlandı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ремонт помічника успішно завершено."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sửa chữa trợ giúp đã hoàn tất thành công."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复已成功完成。"
+          }
+        }
+      }
+    },
+    "Narzędzia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Werkzeuge"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tools"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramientas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outils"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strumenti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ツール"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferramentas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Инструменты"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Araçlar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інструменти"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Công cụ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工具"
+          }
+        }
+      }
+    },
+    "Nie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nein"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NO"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "いいえ"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HAYIR"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НІ"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "KHÔNG"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "否"
+          }
+        }
+      }
+    },
+    "Nie rozpoznano instalatora": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer nicht erkannt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer not recognized"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalador no reconocido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installateur non reconnu"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installatore non riconosciuto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラが認識されませんでした"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalador não reconhecido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установщик не распознан"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici tanınmadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інсталятор не розпізнано"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trình cài đặt không được nhận dạng"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未识别安装程序"
+          }
+        }
+      }
+    },
+    "Nie teraz": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht jetzt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not now"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ahora no"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pas maintenant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non adesso"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今はしない"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agora não"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не сейчас"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şimdi değil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не зараз"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không phải bây giờ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂不"
+          }
+        }
+      }
+    },
+    "Nie udało się aktywować helpera.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktivierung des Helpers fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to activate helper."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo activar el helper."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d activer l outil auxiliaire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile attivare l'aiutante."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーの有効化に失敗しました。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nao foi possivel ativar o helper."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось активировать helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı etkinleştirilemedi."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося активувати помічника."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể kích hoạt trình trợ giúp."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法激活辅助工具。"
+          }
+        }
+      }
+    },
+    "Nie udało się automatycznie odświeżyć helpera. Otwórz Narzędzia → Napraw helpera i spróbuj ponownie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Helper konnte nicht automatisch aktualisiert werden. Oeffnen Sie Werkzeuge → Helper reparieren und versuchen Sie es erneut."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not automatically refresh the helper. Open Tools → Repair helper and try again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo actualizar automaticamente el helper. Abre Herramientas → Reparar helper e intentalo de nuevo."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d actualiser automatiquement le helper. Ouvrez Outils → Reparer le helper et reessayez."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile aggiornare automaticamente l'helper. Apri Strumenti → Aiuto riparazione e riprova."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper を自動的に更新できませんでした。ツール → helper を修復 を開いて、もう一度お試しください。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się automatycznie odświeżyć helpera. Otwórz Narzędzia → Napraw helpera i spróbuj ponownie."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nao foi possivel atualizar automaticamente o helper. Abra Ferramentas → Reparar helper e tente novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось автоматически обновить helper. Откройте Инструменты → Восстановить helper и попробуйте снова."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı otomatik olarak yenilenemedi. Araçlar → Onarım Yardımcısı'nı açın ve tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося автоматично оновити помічник. Відкрийте Tools → Repair Helper і повторіть спробу."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tự động làm mới trình trợ giúp. Mở Công cụ → Trình trợ giúp sửa chữa và thử lại."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法自动刷新 helper。请打开 工具 → 修复 helper 后重试。"
+          }
+        }
+      }
+    },
+    "Nie udało się usunąć plików tymczasowych: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temporäre Dateien konnten nicht gelöscht werden: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to delete temporary files: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error al eliminar archivos temporales: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de la suppression des fichiers temporaires : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile eliminare i file temporanei: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一時ファイルの削除に失敗しました: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao excluir arquivos temporários: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось удалить временные файлы: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geçici dosyalar silinemedi: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося видалити тимчасові файли: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không xóa được tệp tạm thời: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法删除临时文件：%@"
+          }
+        }
+      }
+    },
+    "Nie udało się utworzyć proxy XPC helpera.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC-Proxy des Helpers konnte nicht erstellt werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create helper XPC proxy."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo crear el proxy XPC del helper."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de créer le proxy XPC du helper."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile creare l'helper XPC proxy."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper の XPC プロキシを作成できませんでした。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się utworzyć proxy XPC helpera."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível criar o proxy XPC do helper."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось создать XPC-прокси helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proxy XPC yardımcısı oluşturulamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося створити помічник XPC проксі."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tạo được trình trợ giúp proxy XPC."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法创建 helper 的 XPC 代理。"
+          }
+        }
+      }
+    },
+    "Nie udało się uzyskać połączenia XPC z helperem.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die XPC-Verbindung zum Helper konnte nicht hergestellt werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to establish an XPC connection to the helper."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo establecer una conexión XPC con el helper."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d établir une connexion XPC avec l outil auxiliaire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile connettere XPC all'helper."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper への XPC 接続を確立できませんでした。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się uzyskać połączenia XPC z helperem."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível estabelecer conexão XPC com o helper."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось установить XPC-соединение с helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC yardımcıya bağlanamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося підключити XPC до помічника."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể kết nối XPC với người trợ giúp."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法与 helper 建立 XPC 连接。"
+          }
+        }
+      }
+    },
+    "Nie udało się zakodować żądania helpera: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Anfrage konnte nicht kodiert werden: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to encode helper request: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo codificar la solicitud del helper: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l encodage de la requête helper : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile codificare la richiesta di supporto: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper リクエストのエンコードに失敗しました: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się zakodować żądania helpera: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao codificar a solicitação do helper: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось закодировать запрос helper: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı isteği kodlanamadı: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося закодувати допоміжний запит: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể mã hóa yêu cầu trợ giúp: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法编码 helper 请求：%@"
+          }
+        }
+      }
+    },
+    "Nie udało się zapisać pliku z logami": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Protokolldatei konnte nicht gespeichert werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to save logs file"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo guardar el archivo de registros"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec de l'enregistrement du fichier de journaux"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile salvare il file di registro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ログファイルを保存できませんでした"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao salvar o arquivo de logs"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось сохранить файл журналов"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Günlük dosyası kaydedilemedi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося зберегти файл журналу"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không lưu được tệp nhật ký"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存日志文件"
+          }
+        }
+      }
+    },
+    "Nie udało się zarejestrować helpera": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper konnte nicht registriert werden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to register helper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo registrar el helper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d enregistrer l outil auxiliaire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile registrare l'aiutante"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーを登録できませんでした"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nao foi possivel registrar o helper"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось зарегистрировать helper"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı kaydedilemedi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося зареєструвати помічника"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể đăng ký người trợ giúp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法注册辅助工具"
+          }
+        }
+      }
+    },
+    "Nie udało się zdekodować wyniku helpera: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Ergebnis konnte nicht dekodiert werden: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to decode helper result: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo decodificar el resultado del helper: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du décodage du résultat helper : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile decodificare il risultato dell'helper: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper 結果のデコードに失敗しました: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się zdekodować wyniku helpera: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao decodificar o resultado do helper: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось декодировать результат helper: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı sonucun kodu çözülemedi: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося декодувати допоміжний результат: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không giải mã được kết quả của trình trợ giúp: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解码 helper 结果：%@"
+          }
+        }
+      }
+    },
+    "Nie udało się zdekodować zdarzenia helpera: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Ereignis konnte nicht dekodiert werden: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to decode helper event: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudo decodificar el evento del helper: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec du décodage de l événement helper : %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile decodificare l'evento helper: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper イベントのデコードに失敗しました: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie udało się zdekodować zdarzenia helpera: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha ao decodificar o evento do helper: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось декодировать событие helper: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı etkinliğin kodu çözülemedi: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося декодувати допоміжну подію: %@"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không giải mã được sự kiện trợ giúp: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法解码 helper 事件：%@"
+          }
+        }
+      }
+    },
+    "Nie wykryto nośnika USB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kein USB-Laufwerk erkannt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No USB drive detected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se detectó ninguna memoria USB"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucune clé USB détectée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna unità USB rilevata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメモリが検出されませんでした"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum pen drive detectado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-накопитель не обнаружен"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB sürücüsü algılanmadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-накопичувач не виявлено"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy ổ USB nào"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未检测到 U 盘"
+          }
+        }
+      }
+    },
+    "Nie zarejestrowany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht registriert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not registered"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No registrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non enregistre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non registrato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未登録"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nao registrado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не зарегистрирован"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıtlı değil"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не зареєстрований"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chưa đăng ký"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未注册"
+          }
+        }
+      }
+    },
+    "Nie znaleziono": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nicht gefunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not found"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No encontrado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Introuvable"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Non trovato"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "見つかりません"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nao encontrado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не найдено"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bulunamadı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не знайдено"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到"
+          }
+        }
+      }
+    },
+    "Nie znaleziono pliku InstallESD.dmg.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "InstallESD.dmg-Datei nicht gefunden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "InstallESD.dmg file not found."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivo InstallESD.dmg no encontrado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichier InstallESD.dmg introuvable."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File InstallESD.dmg non trovato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "InstallESD.dmgファイルが見つかりませんでした。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivo InstallESD.dmg não encontrado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл InstallESD.dmg не найден."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "InstallESD.dmg dosyası bulunamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл InstallESD.dmg не знайдено."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy tệp InstallESD.dmg."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到 InstallESD.dmg 文件。"
+          }
+        }
+      }
+    },
+    "Nie znaleziono źródłowego pliku obrazu.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quelldatei des Images wurde nicht gefunden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source image file not found."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se encontro el archivo de imagen de origen."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichier image source introuvable."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File immagine di origine non trovato."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソースイメージファイルが見つかりません。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivo de imagem de origem nao encontrado."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Исходный файл образа не найден."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaynak resim dosyası bulunamadı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вихідний файл зображення не знайдено."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không tìm thấy tập tin hình ảnh nguồn."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到源镜像文件。"
+          }
+        }
+      }
+    },
+    "Nieznany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconocido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inconnu"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sconosciuto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desconhecido"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестно"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bilinmiyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Невідомий"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không xác định"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
+          }
+        }
+      }
+    },
+    "Nieznany status helpera po rejestracji.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannter Helper-Status nach der Registrierung."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown helper status after registration."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado del helper desconocido despues del registro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut de l outil auxiliaire inconnu apres enregistrement."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato di helper sconosciuto dopo la registrazione."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "登録後のヘルパーステータスが不明です。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status do helper desconhecido apos o registro."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестный статус helper после регистрации."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kayıttan sonra bilinmeyen yardımcı durumu."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Невідомий статус помічника після реєстрації."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trạng thái trợ giúp không xác định sau khi đăng ký."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注册后辅助工具状态未知。"
+          }
+        }
+      }
+    },
+    "Nieznany status helpera.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unbekannter Helper-Status."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown helper status."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado del helper desconocido."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut de l outil auxiliaire inconnu."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato dell'aiutante sconosciuto."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーのステータスが不明です。"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status do helper desconhecido."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неизвестный статус helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı durumu bilinmiyor."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус помічника невідомий."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trạng thái của người trợ giúp không xác định."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具状态未知。"
+          }
+        }
+      }
+    },
+    "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das USB-Medium ist nicht bootfaehig, wenn der Vorgang vor Abschluss gestoppt wird. Das Geraet muss erneut vorbereitet werden."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The USB media will not be bootable if the process is stopped before completion. You will need to prepare the device again."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El medio USB no sera arrancable si el proceso se detiene antes de finalizar. Sera necesario preparar el dispositivo nuevamente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le support USB ne sera pas amorcable si le processus est arrete avant la fin. Il faudra preparer de nouveau l appareil."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'unità USB non sarà avviabile se il processo viene interrotto prima del completamento. Dovrai preparare nuovamente il tuo dispositivo."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了前に処理を停止すると、このUSBメディアは起動可能ではなくなります。デバイスを再度準備する必要があります。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A midia USB nao sera inicializavel se o processo for interrompido antes da conclusao. Sera necessario preparar o dispositivo novamente."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-носитель не будет загрузочным, если процесс остановить до завершения. Устройство потребуется подготовить заново."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem tamamlanmadan önce durdurulursa USB sürücüsü yeniden başlatılamaz. Cihazınızı tekrar hazırlamanız gerekecek."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-накопичувач не завантажуватиметься, якщо процес буде зупинено до його завершення. Вам потрібно буде знову підготувати пристрій."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ổ USB sẽ không thể khởi động được nếu quá trình này bị dừng trước khi hoàn tất. Bạn sẽ cần phải chuẩn bị lại thiết bị của mình."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果在完成前停止流程，USB 介质将无法启动。需要重新准备该设备。"
+          }
+        }
+      }
+    },
+    "Oczekiwanie na plik .dmg, .iso, .cdr lub .app...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warte auf .dmg, .iso, .cdr oder .app Datei..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for .dmg, .iso, .cdr, or .app file..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esperando archivo .dmg, .iso, .cdr o .app..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En attente d'un fichier .dmg, .iso, .cdr ou .app..."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In attesa di un file .dmg, .iso, .cdr o .app..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".dmg, .iso, .cdr または .app ファイルを待機中..."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aguardando arquivo .dmg, .iso, .cdr ou .app..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидание файла .dmg, .iso, .cdr или .app..."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir .dmg, .iso, .cdr veya .app dosyası bekleniyor..."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очікування файлу .dmg, .iso, .cdr або .app..."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang chờ tệp .dmg, .iso, .cdr hoặc .app..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待 .dmg, .iso, .cdr 或 .app 文件..."
+          }
+        }
+      }
+    },
+    "Odłączono nośnik USB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-Laufwerk getrennt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB drive disconnected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memoria USB desconectada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé USB déconnectée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unità USB disconnessa"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメモリが切断されました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pen drive desconectado"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-накопитель отключен"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB sürücüsünün bağlantısı kesildi"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-накопичувач від’єднано"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ổ USB bị ngắt kết nối"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U 盘已断开"
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aceptar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TAMAM"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "добре"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ĐƯỢC RỒI"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "确定"
+          }
+        }
+      }
+    },
+    "Opcje": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optionen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Options"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Options"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opzioni"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オプション"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opções"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опции"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçenekler"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Опції"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tùy chọn"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选项"
+          }
+        }
+      }
+    },
+    "Operacja nie powiodła się": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang fehlgeschlagen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation failed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La operacion fallo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echec de l operation"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'operazione è fallita"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作に失敗しました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A operacao falhou"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операция завершилась ошибкой"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem başarısız oldu"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операція не вдалася"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thao tác không thành công"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作失败"
+          }
+        }
+      }
+    },
+    "Operacja zakończona": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang abgeschlossen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation completed"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operacion completada"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation terminee"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operazione completata"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作が完了しました"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operacao concluida"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операция завершена"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem tamamlandı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Операція завершена"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thao tác đã hoàn tất"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作已完成"
+          }
         }
       }
     },
-    "helper.workflow.catalina_copy.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieren der Dateien auf das Installationsmedium"
+    "Ostrzeżenie o utracie danych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnung vor Datenverlust"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data loss warning"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertencia de perdida de datos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avertissement de perte de donnees"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copying files to installer media"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avviso di perdita di dati"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia de archivos al medio de instalacion"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "データ消失の警告"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copie des fichiers vers le support d'installation"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aviso de perda de dados"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストールメディアへのファイルコピー"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Предупреждение о потере данных"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiowanie plików na nośnik instalacyjny"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veri kaybı uyarısı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia de arquivos para a midia de instalacao"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попередження про втрату даних"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Копирование файлов на установочный носитель"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cảnh báo mất dữ liệu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将文件复制到安装介质"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "数据丢失警告"
           }
         }
       }
     },
-    "helper.workflow.catalina_xattr.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisieren der Dateiberechtigungen des Installers."
+    "Otwórz macUSB_temp": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB_temp oeffnen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open macUSB_temp"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir macUSB_temp"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir macUSB_temp"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri macUSB_temp"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizing installer file permissions."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB_temp を開く"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacion de los permisos de archivos del instalador."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz macUSB_temp"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisation des autorisations des fichiers de l'installateur."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir macUSB_temp"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラファイルの権限を最終調整しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть macUSB_temp"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizowanie uprawnień plików instalatora."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacUSB_temp'i açın"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacao das permissoes dos arquivos do instalador."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте macUSB_temp"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Финализация прав доступа к файлам установщика."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở macUSB_temp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在完成安装器文件权限设置。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 macUSB_temp"
           }
         }
       }
     },
-    "helper.workflow.catalina_xattr.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anwenden von Dateiberechtigungen fuer den Installer"
+    "Otwórz Narzędzie dyskowe": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Festplattendienstprogramm öffnen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Disk Utility"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Utilidad de Discos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Utilitaire de disque"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Applying installer file permissions"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Utilità Disco"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicacion de permisos de archivos del instalador"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスクユーティリティを開く"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application des autorisations des fichiers de l'installateur"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Utilitário de Disco"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラファイル権限の適用"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Дисковую утилиту"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nadawanie uprawnień plikom instalatora"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disk Yardımcı Programını Aç"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplicacao das permissoes de arquivos do instalador"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрийте Disk Utility"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Применение прав доступа к файлам установщика"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mở tiện ích đĩa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用安装器文件权限"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开磁盘工具"
           }
         }
       }
     },
-    "helper.workflow.cleanup_temp.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entfernen temporaerer Dateien, um Speicherplatz freizugeben."
+    "Pobierz": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Removing temporary files to free up space."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scaricamento"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminacion de archivos temporales para liberar espacio."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダウンロード"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suppression des fichiers temporaires pour liberer de l'espace."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baixar"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "空き容量を確保するため一時ファイルを削除しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузить"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuwanie tymczasowych plików w celu zwolnienia miejsca."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İndirmek"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remocao de arquivos temporarios para liberar espaco."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантажити"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удаление временных файлов для освобождения места."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tải xuống"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在删除临时文件以释放空间。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下载"
           }
         }
       }
     },
-    "helper.workflow.cleanup_temp.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufraeumen temporaerer Dateien"
+    "Podłącz nośnik USB i poczekaj na wykrycie...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen Sie das USB-Laufwerk an und warten Sie auf die Erkennung..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connect USB drive and wait for detection..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte la memoria USB y espere a que sea detectada..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connectez la clé USB et attendez la détection..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cleaning up temporary files"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collega l'unità USB e attendi che venga rilevata..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpieza de archivos temporales"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメモリを接続して検出を待機してください..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nettoyage des fichiers temporaires"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conecte o pen drive e aguarde a detecção..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時ファイルの整理"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подключите USB-накопитель и дождитесь обнаружения..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Porządkowanie plików tymczasowych"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB sürücüsünü bağlayın ve algılanmasını bekleyin..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limpeza de arquivos temporarios"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключіть USB-накопичувач і дочекайтеся його виявлення..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Очистка временных файлов"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối ổ USB và đợi cho đến khi nó được phát hiện..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在清理临时文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接 U 盘并等待检测..."
           }
         }
       }
     },
-    "helper.workflow.createinstallmedia.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopieren der Installationsdateien auf das ausgewaehlte USB-Medium."
+    "Połączenie z helperem zostało przerwane.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Verbindung zum Helper wurde unterbrochen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copying installer files to the selected USB media."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection with helper was interrupted."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copiado de los archivos del instalador al medio USB seleccionado."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La conexión con el helper se interrumpió."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copie des fichiers d'installation sur le support USB selectionne."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion avec le helper a été interrompue."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したUSBメディアへインストーラファイルをコピーしています。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connessione con l'aiutante è stata interrotta."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopiowanie plików instalatora na wybrany nośnik USB."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper との接続が中断されました。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copia dos arquivos do instalador para a midia USB selecionada."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączenie z helperem zostało przerwane."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Копирование файлов установщика на выбранный USB-носитель."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A conexão com o helper foi interrompida."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在将安装器文件复制到所选 USB 介质。"
-          }
-        }
-      }
-    },
-    "helper.workflow.createinstallmedia.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen des Installationsmediums"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соединение с helper было прервано."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating installation media"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıyla bağlantı kesildi."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creacion del medio de instalacion"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "З'єднання з помічником було перервано."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation du support d'installation"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối với người trợ giúp bị gián đoạn."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストールメディアの作成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 helper 的连接已中断。"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tworzenie nośnika instalacyjnego"
+        }
+      }
+    },
+    "Połączenie z helperem zostało unieważnione.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Verbindung zum Helper wurde ungültig."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criacao da midia de instalacao"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connection with helper was invalidated."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание установочного носителя"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La conexión con el helper fue invalidada."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在创建安装介质"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion avec le helper a été invalidée."
           }
-        }
-      }
-    },
-    "helper.workflow.finalize.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisieren des Vorgangs und Vorbereiten der Zusammenfassung."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connessione con l'aiutante è stata invalidata."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizing the operation and preparing a summary."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper との接続が無効化されました。"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacion de la operacion y preparacion del resumen."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączenie z helperem zostało unieważnione."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisation de l'operation et preparation du resume."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A conexão com o helper foi invalidada."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "処理を完了し、概要を準備しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Соединение с helper было аннулировано."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizowanie operacji i przygotowywanie podsumowania."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıyla bağlantı geçersiz kılındı."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacao da operacao e preparacao do resumo."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підключення до помічника було недійсним."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершение операции и подготовка итогов."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết nối với người trợ giúp đã bị vô hiệu."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在完成操作并准备摘要。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 helper 的连接已失效。"
           }
         }
       }
     },
-    "helper.workflow.finalize.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abschliessen des Vorgangs"
+    "Polski": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finishing the process"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacion del proceso"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalisation du processus"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "処理の完了"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakończenie procesu"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizacao do processo"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершение процесса"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在完成流程"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polski"
           }
         }
       }
     },
-    "helper.workflow.imagescan.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ueberpruefen des Installationsabbilds vor dem Schreiben."
+    "Pomiń analizowanie pliku": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateianalyse überspringen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skip file analysis"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Omitir análisis de archivo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ignorer l'analyse du fichier"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifying the installer image before writing."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salta l'analisi del file"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificacion de la imagen de instalacion antes de la grabacion."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル分析をスキップ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verification de l'image d'installation avant l'ecriture."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pular análise de arquivo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書き込み前にインストーライメージを検証しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустить анализ файла"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weryfikowanie obrazu instalacyjnego przed zapisem."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosya ayrıştırmayı atla"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificacao da imagem de instalacao antes da gravacao."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пропустити розбір файлів"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка установочного образа перед записью."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bỏ qua phân tích tập tin"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在写入前验证安装镜像。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "跳过文件分析"
           }
         }
       }
     },
-    "helper.workflow.imagescan.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ueberpruefen des Installationsabbilds"
+    "Pomyślnie wykryto system": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System erfolgreich erkannt"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System successfully detected"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema detectado con éxito"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Système détecté avec succès"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifying installer image"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema rilevato correttamente"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificacion de la imagen del instalador"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムが正常に検出されました"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verification de l'image d'installation"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema detectado com sucesso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーライメージの検証"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Система успешно обнаружена"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weryfikowanie obrazu instalatora"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem başarıyla algılandı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificacao da imagem do instalador"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Систему успішно виявлено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка образа установщика"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hệ thống được phát hiện thành công"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在验证安装器镜像"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统检测成功"
           }
         }
       }
     },
-    "helper.workflow.ppc_format.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anpassen des USB-Mediums fuer einen PowerPC-Installer."
+    "Português (BR)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adapting USB media for a PowerPC installer."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaptacion del medio USB para un instalador PowerPC."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaptation du support USB pour un installateur PowerPC."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PowerPCインストーラ向けにUSBメディアを調整しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dostosowywanie nośnika USB dla instalatora PowerPC."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adaptacao da midia USB para um instalador PowerPC."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройка USB-носителя для установщика PowerPC."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在为 PowerPC 安装器调整 USB 介质。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Português (BR)"
           }
         }
       }
     },
-    "helper.workflow.ppc_format.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten des USB-Mediums"
+    "Powiadomienia dla macUSB zostały zablokowane w ustawieniach systemowych. Aby otrzymywać informacje o zakończeniu procesów, należy zezwolić aplikacji na ich wyświetlanie w systemie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen für macUSB wurden in den Systemeinstellungen blockiert. Um Informationen über abgeschlossene Prozesse zu erhalten, musst du der App erlauben, Benachrichtigungen im System anzuzeigen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications for macUSB have been blocked in System Settings. To receive information about completed processes, you need to allow the app to display notifications in the system."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las notificaciones para macUSB se han bloqueado en los ajustes del sistema. Para recibir información sobre la finalización de los procesos, debes permitir que la app muestre notificaciones en el sistema."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les notifications pour macUSB ont été bloquées dans les réglages système. Pour recevoir des informations sur la fin des processus, vous devez autoriser l’application à afficher des notifications dans le système."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing USB media"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le notifiche per macUSB sono state bloccate nelle impostazioni di sistema. Per ricevere informazioni sul completamento dei processi, è necessario consentire all'applicazione di visualizzarli sul sistema."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion del medio USB"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB の通知はシステム設定でブロックされています。処理の完了情報を受け取るには、システムでこのアプリの通知表示を許可してください。"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation du support USB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As notificações do macUSB foram bloqueadas nas configurações do sistema. Para receber informações sobre a conclusão dos processos, você precisa permitir que o app exiba notificações no sistema."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメディアの準備"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомления для macUSB были заблокированы в системных настройках. Чтобы получать информацию о завершении процессов, необходимо разрешить приложению показывать уведомления в системе."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowywanie nośnika USB"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem ayarlarında macUSB bildirimleri engellendi. İşlemlerin tamamlandığına dair bilgi almak için uygulamanın bunları sistemde görüntülemesine izin vermelisiniz."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao da midia USB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сповіщення для macUSB заблоковано в налаштуваннях системи. Щоб отримати інформацію про завершення процесів, необхідно дозволити програмі відображати їх у системі."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка USB-носителя"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông báo cho macUSB đã bị chặn trong cài đặt hệ thống. Để nhận thông tin về việc hoàn thành các quy trình, bạn phải cho phép ứng dụng hiển thị chúng trên hệ thống."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备 USB 介质"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 的通知已在系统设置中被阻止。若要接收流程完成信息，需要在系统中允许该应用显示通知。"
           }
         }
       }
     },
-    "helper.workflow.ppc_restore.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uebertragen des Systemabbilds auf ein PowerPC-kompatibles Medium."
+    "Powiadomienia są wyłączone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen sind deaktiviert"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications are turned off"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las notificaciones están desactivadas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les notifications sont désactivées"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferring the system image to PowerPC-compatible media."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le notifiche sono disabilitate"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferencia de la imagen del sistema a un medio compatible con PowerPC."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知は無効です"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfert de l'image systeme vers un support compatible PowerPC."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As notificações estão desativadas"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PowerPC対応メディアへシステムイメージを転送しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомления отключены"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przenoszenie obrazu systemu na nośnik zgodny z PowerPC."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildirimler devre dışı bırakıldı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferencia da imagem do sistema para uma midia compativel com PowerPC."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сповіщення вимкнено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перенос образа системы на носитель, совместимый с PowerPC."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thông báo bị vô hiệu hóa"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在将系统镜像传输到与 PowerPC 兼容的介质。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知已关闭"
           }
         }
       }
     },
-    "helper.workflow.ppc_restore.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen des Installationsmediums"
+    "Powiadomienia włączone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen aktiviert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating installation media"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications enabled"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creacion del medio de instalacion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones activadas"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation du support d'installation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications activées"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストールメディアの作成"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifiche abilitate"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tworzenie nośnika instalacyjnego"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知オン"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criacao da midia de instalacao"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powiadomienia włączone"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание установочного носителя"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificações ativadas"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在创建安装介质"
-          }
-        }
-      }
-    },
-    "helper.workflow.preformat.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurieren des USB-Mediums fuer die Erstellung des Installers."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомления включены"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuring USB media for installer creation."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildirimler etkinleştirildi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuracion del medio USB para crear el instalador."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сповіщення ввімкнено"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration du support USB pour la creation de l'installateur."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật thông báo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラ作成のためにUSBメディアを構成しています。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知已开启"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurowanie nośnika USB do utworzenia instalatora."
+        }
+      }
+    },
+    "Powiadomienia wyłączone": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen deaktiviert"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuracao da midia USB para criar o instalador."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications disabled"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройка USB-носителя для создания установщика."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificaciones desactivadas"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在配置 USB 介质以创建安装器。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications désactivées"
           }
-        }
-      }
-    },
-    "helper.workflow.preformat.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten des USB-Mediums"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifiche disabilitate"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing USB media"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知オフ"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion del medio USB"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Powiadomienia wyłączone"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation du support USB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notificações desativadas"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメディアの準備"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уведомления отключены"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowywanie nośnika USB"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildirimler devre dışı bırakıldı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao da midia USB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сповіщення вимкнено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка USB-носителя"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã tắt thông báo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备 USB 介质"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知已关闭"
           }
         }
       }
     },
-    "helper.workflow.prepare_source.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten der Quelldateien fuer einen sicheren Ablauf."
+    "Pozwoli to na otrzymanie informacji o zakończeniu procesu przygotowania nośnika instalacyjnego.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "So erhältst du Informationen, wenn der Vorbereitungsprozess des Installationsmediums abgeschlossen ist."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will let you receive information when the installer media preparation process is finished."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esto te permitirá recibir información cuando finalice el proceso de preparación del medio de instalación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cela vous permettra de recevoir des informations à la fin du processus de préparation du support d’installation."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing source files for a safe workflow."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciò ti consentirà di ricevere informazioni sul completamento del processo di preparazione del supporto di installazione."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion de los archivos de origen para un proceso seguro."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これにより、インストールメディアの準備プロセス完了時に通知を受け取れます。"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation des fichiers source pour un deroulement securise."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Isso permitirá que você receba informações quando o processo de preparação da mídia de instalação for concluído."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安全に処理を進めるためソースファイルを準備しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Это позволит получать информацию о завершении процесса подготовки установочного носителя."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowywanie plików źródłowych dla bezpiecznego przebiegu procesu."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu, kurulum medyası hazırlama sürecinin tamamlandığına dair bilgi almanızı sağlayacaktır."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao dos arquivos de origem para um fluxo seguro."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Це дозволить вам отримати інформацію про завершення процесу підготовки інсталяційного носія."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка исходных файлов для безопасного выполнения процесса."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Điều này sẽ cho phép bạn nhận được thông tin về việc hoàn tất quá trình chuẩn bị phương tiện cài đặt."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备源文件，以确保流程安全进行。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这样可在安装介质准备过程完成后接收通知。"
           }
         }
       }
     },
-    "helper.workflow.prepare_source.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereiten der Installationsdateien"
+    "Proces przerwany": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang abgebrochen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Process interrupted"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceso interrumpido"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processus interrompu"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing installer files"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processo interrotto"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacion de los archivos del instalador"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスが中断されました"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation des fichiers d'installation"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processo interrompido"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラファイルの準備"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процесс прерван"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przygotowywanie plików instalatora"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Süreç kesintiye uğradı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparacao dos arquivos do instalador"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процес перервано"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка файлов установщика"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình bị gián đoạn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备安装器文件"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "进程已中断"
           }
         }
       }
     },
-    "helper.workflow.restore.status" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uebertragen des Systemabbilds auf das ausgewaehlte USB-Medium."
+    "Proces tworzenia instalatora na wybranym nośniku zakończył się niepowodzeniem.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Prozess zum Erstellen des Installationsprogramms auf dem ausgewählten Medium ist fehlgeschlagen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The installer creation process on the selected media has failed."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proceso de creación del instalador en el medio seleccionado ha fallado."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le processus de création de l’installateur sur le support sélectionné a échoué."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferring the system image to the selected USB media."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il processo di creazione del programma di installazione sul supporto selezionato non è riuscito."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferencia de la imagen del sistema al medio USB seleccionado."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したメディアでのインストーラ作成処理は失敗しました。"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfert de l'image systeme vers le support USB selectionne."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O processo de criação do instalador na mídia selecionada falhou."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したUSBメディアへシステムイメージを転送しています。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процесс создания установщика на выбранном носителе завершился неудачей."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przenoszenie obrazu systemu na wybrany nośnik USB."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen ortamda yükleyiciyi oluşturma işlemi başarısız oldu."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transferencia da imagem do sistema para a midia USB selecionada."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося створити інсталятор на вибраному носії."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перенос образа системы на выбранный USB-носитель."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình tạo trình cài đặt trên phương tiện đã chọn không thành công."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在将系统镜像传输到所选 USB 介质。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在所选介质上创建安装器的过程失败。"
           }
         }
       }
     },
-    "helper.workflow.restore.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erstellen des Installationsmediums"
+    "Proces zapisu na nośniku zakończył się pomyślnie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Schreibvorgang auf dem Medium wurde erfolgreich abgeschlossen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The write process on the media completed successfully."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proceso de escritura en el medio se completó correctamente."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le processus d’écriture sur le support s’est terminé avec succès."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating installation media"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il processo di scrittura sul supporto è stato completato con successo."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creacion del medio de instalacion"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メディアへの書き込み処理が正常に完了しました。"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation du support d'installation"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O processo de gravação na mídia foi concluído com sucesso."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストールメディアの作成"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процесс записи на носитель успешно завершён."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tworzenie nośnika instalacyjnego"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ortama yazma işlemi başarıyla tamamlandı."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criacao da midia de instalacao"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процес запису на носій успішно завершено."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание установочного носителя"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình ghi vào ổ đĩa đã hoàn tất thành công."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在创建安装介质"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "介质写入过程已成功完成。"
           }
         }
       }
     },
-    "Ignoruj" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorieren"
+    "Proszę czekać": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte warten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignore"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please wait"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor espere"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veuillez patienter"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無視"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "attendere prego"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorar"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お待ちください"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Игнорировать"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, aguarde"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "忽略"
-          }
-        }
-      }
-    },
-    "Informacje" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informationen"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожалуйста, подождите"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Information"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lütfen bekleyin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informacion"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Будь ласка, зачекайте"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informations"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vui lòng chờ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "情報"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请稍候"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informacje"
+        }
+      }
+    },
+    "Proszę czekać...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte warten..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informacoes"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please wait..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Информация"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor espere..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "信息"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Veuillez patienter..."
           }
-        }
-      }
-    },
-    "Instalator gotowy" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installationsprogramm ist bereit"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attendere prego..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer is ready"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お待ちください..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El instalador está listo"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Por favor, aguarde..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le programme d’installation est prêt"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пожалуйста, подождите..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラの準備ができました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lütfen bekleyin..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O instalador está pronto"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Будь ласка, зачекайте..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установщик готов"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vui lòng chờ..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "安装器已就绪"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请稍候..."
           }
         }
       }
     },
-    "Instrukcja bootowania z nośnika USB (GitHub)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anleitung zum Booten von USB (GitHub)"
+    "Przebieg procesu": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozessübersicht"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB boot instructions (GitHub)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Process overview"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instrucciones para arrancar desde USB (GitHub)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resumen del proceso"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instructions de démarrage depuis USB (GitHub)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aperçu du processus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB からの起動手順（GitHub）"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flusso del processo"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instruções para inicializar pelo USB (GitHub)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスの概要"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Инструкция по загрузке с USB (GitHub)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visão geral do processo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "从 USB 启动说明（GitHub）"
-          }
-        }
-      }
-    },
-    "Język" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sprache"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обзор процесса"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Süreç akışı"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потік процесу"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Langue"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luồng quy trình"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "言語"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "进程概览"
+          }
+        }
+      }
+    },
+    "Przebieg tworzenia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ablauf der Erstellung"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idioma"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation process"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Язык"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proceso de creación"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "语言"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processus de création"
           }
-        }
-      }
-    },
-    "Konfiguracja źródła i celu" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguration von Quelle und Ziel"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processo di creazione"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source and target configuration"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成プロセス"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuracion de origen y destino"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Processo de criação"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration de la source et de la cible"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процесс создания"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソースとターゲットの設定"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yaratılış süreci"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuracao de origem e destino"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процес створення"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройка источника и цели"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình tạo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "源与目标配置"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建过程"
           }
         }
       }
     },
-    "Kontynuuj" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fortfahren"
+    "Przejdź dalej": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weiter"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continue"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuer"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "続ける"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vai avanti"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次へ"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Continuar"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Продолжить"
           }
-        }
-      }
-    },
-    "Korzystasz z najnowszej dostępnej wersji aplikacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sie verwenden die neueste verfügbare Version der Anwendung"
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Devam et"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You are using the latest available version of the application"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Йди далі"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estás usando la última versión disponible de la aplicación"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếp tục"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vous utilisez la dernière version disponible de l'application"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续"
+          }
+        }
+      }
+    },
+    "Przejdź do podsumowania (Big Sur) (2s delay)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zur Zusammenfassung (Big Sur) wechseln (2s Verzoegerung)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最新バージョンのアプリケーションを使用しています"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to summary (Big Sur) (2s delay)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Você está usando a versão mais recente disponível do aplicativo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir al resumen (Big Sur) (retraso de 2 s)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Вы используете последнюю доступную версию приложения"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aller au resume (Big Sur) (delai 2 s)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您正在使用该应用程序的最新可用版本"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vai al riepilogo (Big Sur) (ritardo di 2 secondi)"
           }
-        }
-      }
-    },
-    "Lokalizacja aplikacji: /Applications (OK)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Standort: /Applications (OK)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サマリーへ移動（Big Sur）（2秒遅延）"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App location: /Applications (OK)"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przejdź do podsumowania (Big Sur) (2s delay)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicacion de la app: /Applications (OK)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir para o resumo (Big Sur) (atraso de 2 s)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement de l app : /Applications (OK)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейти к сводке (Big Sur) (задержка 2 с)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの場所: /Applications (OK)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özete git (Big Sur) (2s gecikme)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localizacao do app: /Applications (OK)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейти до підсумку (Big Sur) (затримка 2 с)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Расположение приложения: /Applications (OK)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển đến phần tóm tắt (Big Sur) (độ trễ 2 giây)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用位置：/Applications（正常）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往摘要（Big Sur）（延迟 2 秒）"
           }
         }
       }
     },
-    "Lokalizacja aplikacji: poza /Applications" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Standort: ausserhalb von /Applications"
+    "Przejdź do podsumowania (Tiger) (2s delay)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zur Zusammenfassung (Tiger) wechseln (2s Verzoegerung)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App location: outside /Applications"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to summary (Tiger) (2s delay)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicacion de la app: fuera de /Applications"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir al resumen (Tiger) (retraso de 2 s)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement de l app : hors de /Applications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aller au resume (Tiger) (delai 2 s)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの場所: /Applications の外"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vai al riepilogo (Tiger) (ritardo 2s)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Localizacao do app: fora de /Applications"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サマリーへ移動（Tiger）（2秒遅延）"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Расположение приложения: вне /Applications"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przejdź do podsumowania (Tiger) (2s delay)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用位置：不在 /Applications 中"
-          }
-        }
-      }
-    },
-    "Lokalizacja aplikacji: środowisko Xcode (bypass DEBUG)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App-Speicherort: Xcode-Umgebung (DEBUG-Bypass)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir para o resumo (Tiger) (atraso de 2 s)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "App location: Xcode environment (DEBUG bypass)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейти к сводке (Tiger) (задержка 2 с)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicacion de la app: entorno Xcode (omision DEBUG)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Özete git (Tiger) (2s gecikme)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement de l app : environnement Xcode (contournement DEBUG)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейти до підсумку (Тигр) (затримка 2 с)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリの場所: Xcode 環境（DEBUG バイパス）"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuyển đến phần tóm tắt (Tiger) (độ trễ 2 giây)"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lokalizacja aplikacji: środowisko Xcode (bypass DEBUG)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往摘要（Tiger）（延迟 2 秒）"
+          }
+        }
+      }
+    },
+    "Przejdź do ustawień systemowych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zu den Systemeinstellungen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local do app: ambiente do Xcode (bypass DEBUG)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Go to System Settings"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Расположение приложения: среда Xcode (обход DEBUG)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir a los ajustes del sistema"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "应用位置：Xcode 环境（DEBUG 绕过）"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aller aux réglages système"
           }
-        }
-      }
-    },
-    "Mac OS X Tiger 10.4 (Multi DVD)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vai alle impostazioni di sistema"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム設定を開く"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ir para Ajustes do Sistema"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейти в системные настройки"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem ayarlarına gidin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перейдіть до налаштувань системи"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đi tới cài đặt hệ thống"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger 10.4 (Multi DVD)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往系统设置"
           }
         }
       }
     },
-    "Mach service: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mach-Dienst: %@"
+    "Przekopiowane dane: %.1f GB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopierte Daten: %.1f GB"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mach service: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied data: %.1f GB"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Servicio Mach: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datos copiados: %.1f GB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Service Mach : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donnees copiees : %.1f GB"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Machサービス: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dati copiati: %.1f GB"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usługa Mach: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー済みデータ: %.1f GB"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Serviço Mach: %@"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przekopiowane dane: %.1f GB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Служба Mach: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dados copiados: %.1f GB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mach 服务：%@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопированные данные: %.1f GB"
           }
-        }
-      }
-    },
-    "macUSB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopyalanan veriler: %.1f GB"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопійовані дані: %.1f Гб"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dữ liệu đã sao chép: %.1f GB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已复制数据：%.1f GB"
+          }
+        }
+      }
+    },
+    "Przekroczono czas oczekiwania na odpowiedź helpera XPC.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitüberschreitung beim Warten auf die XPC-Antwort des Helpers."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timed out waiting for helper XPC response."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se superó el tiempo de espera de la respuesta XPC del helper."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Délai d attente dépassé pour la réponse XPC du helper."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'helper XPC è scaduto in attesa di una risposta."
           }
-        }
-      }
-    },
-    "macUSB by Kruszoneq" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper XPC 応答の待機がタイムアウトしました。"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przekroczono czas oczekiwania na odpowiedź helpera XPC."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tempo de espera pela resposta XPC do helper excedido."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Превышено время ожидания ответа XPC от helper."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC yardımcısı yanıt beklerken zaman aşımına uğradı."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник XPC вичерпав час очікування відповіді."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trình trợ giúp XPC đã hết thời gian chờ phản hồi."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB by Kruszoneq"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待 helper XPC 响应超时。"
           }
         }
       }
     },
-    "macUSB wymaga zezwolenia na działanie w tle, aby umożliwić zarządzanie nośnikami. Przejdź do ustawień systemowych, aby nadać wymagane uprawnienia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB benotigt die Berechtigung zur Hintergrundaktivitat, um Datentrager verwalten zu konnen. Offne die Systemeinstellungen, um die erforderlichen Berechtigungen zu erteilen"
+    "Przerwij": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abbrechen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB requires background activity permission to enable drive management. Go to System Settings to grant the required permissions"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB requiere permiso para ejecutarse en segundo plano para permitir la gestion de unidades. Ve a Ajustes del sistema para conceder los permisos necesarios"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrumpir"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB necessite l autorisation d activite en arriere-plan pour permettre la gestion des supports. Accedez aux reglages systeme pour accorder les autorisations requises"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompre"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB でドライブ管理を有効にするには、バックグラウンド動作の許可が必要です。必要な権限を付与するため、システム設定に移動してください"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompi"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O macUSB requer permissao de atividade em segundo plano para permitir o gerenciamento de unidades. Va para os Ajustes do Sistema para conceder as permissoes necessarias"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中断"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB требуется разрешение на работу в фоне для управления носителями. Перейдите в системные настройки, чтобы выдать необходимые разрешения"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przerwij"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB 需要后台运行权限才能进行磁盘管理。请前往系统设置授予所需权限"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interromper"
           }
-        }
-      }
-    },
-    "Napraw helpera" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper reparieren"
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прервать"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repair helper"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durdur"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparar helper"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перервати"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparer l outil auxiliaire"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dừng"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーを修復"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中断"
+          }
+        }
+      }
+    },
+    "Przerywanie działania": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang wird abgebrochen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparar helper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aborting operation"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановить helper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abortando operación"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "修复辅助工具"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interruption de l'opération"
           }
-        }
-      }
-    },
-    "Naprawa helpera" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Reparatur"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interruzione dell'operazione"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作を中止しています"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparacion del helper"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abortando operação"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparation de l outil auxiliaire"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прерывание операции"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyonun kesintiye uğraması"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparo do helper"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переривання роботи"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановление helper"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gián đoạn hoạt động"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在中止操作"
           }
         }
       }
     },
-    "Naprawa helpera zakończona" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Reparatur abgeschlossen"
+    "Przerywanie...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird abgebrochen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair completed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopping..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparacion del helper completada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrumpiendo..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparation de l outil auxiliaire terminee"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interruption..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復が完了しました"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interruzione..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparo do helper concluido"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中断中..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановление helper завершено"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przerywanie..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复已完成"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrompendo..."
           }
-        }
-      }
-    },
-    "Naprawa helpera zakończona błędem" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Reparatur fehlgeschlagen"
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прерывание..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair failed"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kesinti..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reparacion del helper fallo"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переривання..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echec de la reparation de l outil auxiliaire"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gián đoạn..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復に失敗しました"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在中断..."
+          }
+        }
+      }
+    },
+    "Przygotowanie...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorbereitung..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no reparo do helper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка при восстановлении helper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复失败"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation..."
           }
-        }
-      }
-    },
-    "Naprawa helpera zakończona błędem." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Reparatur fehlgeschlagen."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair failed."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "準備中..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reparacion del helper fallo."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echec de la reparation de l outil auxiliaire."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復に失敗しました。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hazırlık..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no reparo do helper."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ошибка при восстановлении helper."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sự chuẩn bị..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复失败。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "准备中..."
           }
         }
       }
     },
-    "Naprawa helpera zakończona pomyślnie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Reparatur erfolgreich abgeschlossen."
+    "Przygotowywanie operacji...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgang wird vorbereitet..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair completed successfully."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparing operation..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reparacion del helper se completo correctamente."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando la operacion..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparation de l outil auxiliaire terminee avec succes."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparation de l operation..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復が正常に完了しました。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparazione dell'operazione..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O reparo do helper foi concluido com sucesso."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作を準備中..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановление helper успешно завершено."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preparando a operacao..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复已成功完成。"
-          }
-        }
-      }
-    },
-    "Narzędzia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Werkzeuge"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подготовка операции..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tools"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyona hazırlanıyor..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herramientas"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підготовка до операції..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Outils"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chuẩn bị hoạt động..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ツール"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在准备操作..."
+          }
+        }
+      }
+    },
+    "Repozytorium macUSB na GitHub": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB-Repository auf GitHub"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ferramentas"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB GitHub Repository"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Инструменты"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositorio de macUSB en GitHub"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工具"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dépôt macUSB sur GitHub"
           }
-        }
-      }
-    },
-    "Nie" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nein"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "repository macUSB su GitHub"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSBのGitHubリポジトリ"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repositório do macUSB no GitHub"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Репозиторий macUSB на GitHub"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "いいえ"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub'daki macUSB deposu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "репозиторій macUSB на GitHub"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Нет"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "kho lưu trữ macUSB trên GitHub"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "否"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 的 GitHub 仓库"
           }
         }
       }
     },
-    "Nie rozpoznano instalatora" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer nicht erkannt"
+    "Rozpocznij": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starten"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installer not recognized"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalador no reconocido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installateur non reconnu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Démarrer"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インストーラが認識されませんでした"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizia"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalador não reconhecido"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Установщик не распознан"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciar"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未识别安装程序"
-          }
-        }
-      }
-    },
-    "Nie teraz" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht jetzt"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not now"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başlayın"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ahora no"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Почніть роботу"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pas maintenant"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "今はしない"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始"
+          }
+        }
+      }
+    },
+    "Rozpoczynanie...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird gestartet..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agora não"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Starting..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не сейчас"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciando..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "暂不"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Demarrage..."
           }
-        }
-      }
-    },
-    "Nie udało się aktywować helpera." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktivierung des Helpers fehlgeschlagen."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniziare..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to activate helper."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始中..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo activar el helper."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iniciando..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d activer l outil auxiliaire."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запуск..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーの有効化に失敗しました。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başlarken..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nao foi possivel ativar o helper."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Початок роботи..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось активировать helper."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法激活辅助工具。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在开始..."
           }
         }
       }
     },
-    "Nie udało się automatycznie odświeżyć helpera. Otwórz Narzędzia → Napraw helpera i spróbuj ponownie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Helper konnte nicht automatisch aktualisiert werden. Oeffnen Sie Werkzeuge → Helper reparieren und versuchen Sie es erneut."
+    "Ścieżka...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Path..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ruta..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chemin..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Could not automatically refresh the helper. Open Tools → Repair helper and try again."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sentiero..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo actualizar automaticamente el helper. Abre Herramientas → Reparar helper e intentalo de nuevo."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パス..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d actualiser automatiquement le helper. Ouvrez Outils → Reparer le helper et reessayez."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caminho..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper を自動的に更新できませんでした。ツール → helper を修復 を開いて、もう一度お試しください。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Путь..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się automatycznie odświeżyć helpera. Otwórz Narzędzia → Napraw helpera i spróbuj ponownie."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yol..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nao foi possivel atualizar automaticamente o helper. Abra Ferramentas → Reparar helper e tente novamente."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шлях..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось автоматически обновить helper. Откройте Инструменты → Восстановить helper и попробуйте снова."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Con đường..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法自动刷新 helper。请打开 工具 → 修复 helper 后重试。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路径..."
           }
         }
       }
     },
-    "Nie udało się usunąć plików tymczasowych: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temporäre Dateien konnten nicht gelöscht werden: %@"
+    "Sprawdź dostępność aktualizacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nach Updates suchen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for updates"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buscar actualizaciones"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rechercher des mises à jour"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Controlla gli aggiornamenti"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to delete temporary files: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデートを確認"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error al eliminar archivos temporales: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificar atualizações"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la suppression des fichiers temporaires : %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверить наличие обновлений"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時ファイルの削除に失敗しました: %@"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncellemeleri kontrol edin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao excluir arquivos temporários: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірте наявність оновлень"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось удалить временные файлы: %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiểm tra các bản cập nhật"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法删除临时文件：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检查更新"
           }
         }
       }
     },
-    "Nie udało się utworzyć proxy XPC helpera." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC-Proxy des Helpers konnte nicht erstellt werden."
+    "Sprawdzanie statusu...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status wird gepruft..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Checking status..."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Comprobando el estado..."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verification du statut..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to create helper XPC proxy."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verifica dello stato..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo crear el proxy XPC del helper."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ステータスを確認中..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de créer le proxy XPC du helper."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verificando o status..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper の XPC プロキシを作成できませんでした。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Проверка статуса..."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się utworzyć proxy XPC helpera."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Durum kontrol ediliyor..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível criar o proxy XPC do helper."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перевірка статусу..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось создать XPC-прокси helper."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang kiểm tra trạng thái..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法创建 helper 的 XPC 代理。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查状态..."
           }
         }
       }
     },
-    "Nie udało się uzyskać połączenia XPC z helperem." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die XPC-Verbindung zum Helper konnte nicht hergestellt werden."
+    "Start": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accueil"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to establish an XPC connection to the helper."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inizio"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo establecer una conexión XPC con el helper."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d établir une connexion XPC avec l outil auxiliaire."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Início"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper への XPC 接続を確立できませんでした。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Старт"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się uzyskać połączenia XPC z helperem."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başlangıç"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível estabelecer conexão XPC com o helper."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "старт"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось установить XPC-соединение с helper."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法与 helper 建立 XPC 连接。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始"
           }
         }
       }
     },
-    "Nie udało się zakodować żądania helpera: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Anfrage konnte nicht kodiert werden: %@"
+    "Status helpera": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper-Status"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper status"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado del helper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut de l outil auxiliaire"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to encode helper request: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato di aiutante"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo codificar la solicitud del helper: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーのステータス"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de l encodage de la requête helper : %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status do helper"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper リクエストのエンコードに失敗しました: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус helper"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się zakodować żądania helpera: %@"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı durumu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao codificar a solicitação do helper: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус помічника"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось закодировать запрос helper: %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trạng thái người trợ giúp"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法编码 helper 请求：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具状态"
           }
         }
       }
     },
-    "Nie udało się zapisać pliku z logami" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Protokolldatei konnte nicht gespeichert werden"
+    "Status usługi: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dienststatus: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to save logs file"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Service status: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo guardar el archivo de registros"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado del servicio: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de l'enregistrement du fichier de journaux"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Statut du service : %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ログファイルを保存できませんでした"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato del servizio: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao salvar o arquivo de logs"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サービス状態: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось сохранить файл журналов"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status usługi: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法保存日志文件"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status do serviço: %@"
           }
-        }
-      }
-    },
-    "Nie udało się zarejestrować helpera" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper konnte nicht registriert werden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to register helper"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo registrar el helper"
-          }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d enregistrer l outil auxiliaire"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус службы: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーを登録できませんでした"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hizmet durumu: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nao foi possivel registrar o helper"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статус служби: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось зарегистрировать helper"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trạng thái dịch vụ: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法注册辅助工具"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "服务状态：%@"
           }
         }
       }
     },
-    "Nie udało się zdekodować wyniku helpera: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Ergebnis konnte nicht dekodiert werden: %@"
+    "Strona internetowa macUSB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB-Website"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to decode helper result: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB Website"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo decodificar el resultado del helper: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sitio web de macUSB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec du décodage du résultat helper : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site web de macUSB"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper 結果のデコードに失敗しました: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sito web macUSB"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się zdekodować wyniku helpera: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSBウェブサイト"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao decodificar o resultado do helper: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Site do macUSB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось декодировать результат helper: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Веб-сайт macUSB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法解码 helper 结果：%@"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB web sitesi"
           }
-        }
-      }
-    },
-    "Nie udało się zdekodować zdarzenia helpera: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Ereignis konnte nicht dekodiert werden: %@"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Failed to decode helper event: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "веб-сайт macUSB"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo decodificar el evento del helper: %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "trang web macUSB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec du décodage de l événement helper : %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 网站"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper イベントのデコードに失敗しました: %@"
+        }
+      }
+    },
+    "System zablokował rejestrację helpera z uruchomienia Xcode. Uruchom raz aplikację z katalogu Applications, zatwierdź działanie helpera w tle, a następnie wróć do testów w Xcode. Szczegóły XPC: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das System hat die Helper-Registrierung bei einem Start aus Xcode blockiert. Starte die App einmal aus dem Ordner Applications, genehmige die Hintergrundaktivitat des Helpers und kehre dann zu Tests in Xcode zuruck. XPC-Details: %@"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się zdekodować zdarzenia helpera: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The system blocked helper registration from an Xcode launch. Run the app once from the Applications folder, approve helper background activity, then return to testing in Xcode. XPC details: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao decodificar o evento do helper: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El sistema bloqueo el registro del helper al iniciarse desde Xcode. Ejecuta la app una vez desde la carpeta Aplicaciones, autoriza la actividad en segundo plano del helper y luego vuelve a las pruebas en Xcode. Detalles de XPC: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось декодировать событие helper: %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le systeme a bloque l enregistrement de l outil auxiliaire lors d un lancement depuis Xcode. Lancez l application une fois depuis le dossier Applications, autorisez l activite en arriere-plan de l outil auxiliaire, puis revenez aux tests dans Xcode. Details XPC : %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法解码 helper 事件：%@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il sistema ha bloccato la registrazione dell'assistente per l'esecuzione di Xcode. Esegui l'applicazione dalla directory Applicazioni una volta, consenti l'esecuzione dell'helper in background, quindi torna al test in Xcode. Dettagli XPC: %@"
           }
-        }
-      }
-    },
-    "Nie wykryto nośnika USB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kein USB-Laufwerk erkannt"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No USB drive detected"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xcode から起動したため、システムがヘルパー登録をブロックしました。まず Applications フォルダからアプリを一度起動し、ヘルパーのバックグラウンド動作を許可してから、Xcode でのテストに戻ってください。XPC 詳細: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se detectó ninguna memoria USB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O sistema bloqueou o registro do helper ao iniciar pelo Xcode. Execute o app uma vez na pasta Aplicativos, autorize a atividade em segundo plano do helper e depois volte aos testes no Xcode. Detalhes do XPC: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune clé USB détectée"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Система заблокировала регистрацию helper при запуске из Xcode. Один раз запустите приложение из папки Applications, разрешите фоновую работу helper, затем вернитесь к тестированию в Xcode. Подробности XPC: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメモリが検出されませんでした"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem, yardımcı kaydının Xcode çalıştırmasını engelledi. Uygulamayı Uygulamalar dizininden bir kez çalıştırın, yardımcının arka planda çalışmasına izin verin ve ardından Xcode'da test etmeye geri dönün. XPC Ayrıntıları: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhum pen drive detectado"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Система заблокувала реєстрацію помічника для запуску Xcode. Запустіть програму з каталогу Applications один раз, дозвольте помічнику працювати у фоновому режимі, а потім поверніться до тестування в Xcode. Деталі XPC: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-накопитель не обнаружен"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hệ thống đã chặn đăng ký trợ giúp chạy Xcode. Chạy ứng dụng từ thư mục Ứng dụng một lần, cho phép trình trợ giúp chạy ở chế độ nền và sau đó quay lại thử nghiệm trong Xcode. Chi tiết XPC: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未检测到 U 盘"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统阻止了从 Xcode 启动时的辅助工具注册。请先从Applications文件夹运行一次应用，批准辅助工具后台运行，然后再回到 Xcode 测试。XPC 详情：%@"
           }
         }
       }
     },
-    "Nie zarejestrowany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht registriert"
+    "Szczegóły operacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorgangsdetails"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not registered"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No registrado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles de la operacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non enregistre"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details de l operation"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未登録"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettagli dell'operazione"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nao registrado"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作の詳細"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не зарегистрирован"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes da operacao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未注册"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подробности операции"
           }
-        }
-      }
-    },
-    "Nie znaleziono" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nicht gefunden"
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyon ayrıntıları"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Not found"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Деталі операції"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No encontrado"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chi tiết hoạt động"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introuvable"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作详情"
           }
+        }
+      }
+    },
+    "Szczegóły: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details: %@"
+          }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "見つかりません"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nao encontrado"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalles: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не найдено"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Détails : %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dettagli: %@"
           }
-        }
-      }
-    },
-    "Nie znaleziono pliku InstallESD.dmg." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "InstallESD.dmg-Datei nicht gefunden."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "InstallESD.dmg file not found."
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szczegóły: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Archivo InstallESD.dmg no encontrado."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detalhes: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fichier InstallESD.dmg introuvable."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подробности: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "InstallESD.dmgファイルが見つかりませんでした。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayrıntılar: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arquivo InstallESD.dmg não encontrado."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подробиці: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Файл InstallESD.dmg не найден."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chi tiết: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到 InstallESD.dmg 文件。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "详情：%@"
           }
         }
       }
     },
-    "Nie znaleziono źródłowego pliku obrazu." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quelldatei des Images wurde nicht gefunden."
+    "Szybkość zapisu: - MB/s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schreibgeschwindigkeit: - MB/s"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Source image file not found."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write speed: - MB/s"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se encontro el archivo de imagen de origen."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidad de escritura: - MB/s"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fichier image source introuvable."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitesse d'ecriture : - MB/s"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ソースイメージファイルが見つかりません。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocità di scrittura: - MB/s"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arquivo de imagem de origem nao encontrado."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書き込み速度: - MB/s"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Исходный файл образа не найден."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidade de gravacao: - MB/s"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未找到源镜像文件。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость записи: - MB/s"
           }
-        }
-      }
-    },
-    "Nieznany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannt"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yazma hızı: - MB/sn"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconocido"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Швидкість запису: - МБ/с"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inconnu"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tốc độ ghi: - MB/s"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "写入速度：- MB/s"
+          }
+        }
+      }
+    },
+    "Szybkość zapisu: %d MB/s": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schreibgeschwindigkeit: %d MB/s"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconhecido"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write speed: %d MB/s"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Неизвестно"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidad de escritura: %d MB/s"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "未知"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vitesse d'ecriture : %d MB/s"
           }
-        }
-      }
-    },
-    "Nieznany status helpera po rejestracji." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannter Helper-Status nach der Registrierung."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocità di scrittura: %d MB/s"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown helper status after registration."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "書き込み速度: %d MB/s"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado del helper desconocido despues del registro."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Velocidade de gravacao: %d MB/s"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statut de l outil auxiliaire inconnu apres enregistrement."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скорость записи: %d MB/s"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登録後のヘルパーステータスが不明です。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yazma hızı: %d MB/sn"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status do helper desconhecido apos o registro."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Швидкість запису: %d МБ/с"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Неизвестный статус helper после регистрации."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tốc độ ghi: %d MB/s"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注册后辅助工具状态未知。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "写入速度：%d MB/s"
           }
         }
       }
     },
-    "Nieznany status helpera." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unbekannter Helper-Status."
+    "Ta funkcja umożliwia tworzenie instalatora na zewnętrznych dyskach twardych i SSD. Zachowaj szczególną ostrożność przy wyborze dysku docelowego z listy, aby uniknąć przypadkowej utraty danych!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Funktion ermöglicht das Erstellen des Installers auf externen Festplatten und SSDs. Seien Sie bei der Auswahl des Ziellaufwerks besonders vorsichtig, um Datenverlust zu vermeiden!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown helper status."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This feature allows creating the installer on external hard drives and SSDs. Please verify the selected target drive carefully to avoid accidental data loss!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado del helper desconocido."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta función permite crear el instalador en discos duros externos y SSD. ¡Tenga mucho cuidado al seleccionar el disco de destino para evitar la pérdida accidental de datos!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statut de l outil auxiliaire inconnu."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette fonctionnalité permet de créer l'installateur sur des disques durs externes et SSD. Soyez particulièrement prudent lors du choix du disque cible pour éviter toute perte de données accidentelle !"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーのステータスが不明です。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa funzionalità consente di creare un programma di installazione su dischi rigidi e SSD esterni. Prestare particolare attenzione quando si seleziona l'unità di destinazione dall'elenco per evitare perdite accidentali di dati!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status do helper desconhecido."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この機能を使用すると、外付けハードドライブやSSDにインストーラを作成できます。データの誤消去を防ぐため、ターゲットドライブを選択する際は十分注意してください！"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Неизвестный статус helper."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Este recurso permite criar o instalador em discos rígidos externos e SSDs. Tenha muito cuidado ao selecionar o disco de destino para evitar a perda acidental de dados!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具状态未知。"
-          }
-        }
-      }
-    },
-    "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das USB-Medium ist nicht bootfaehig, wenn der Vorgang vor Abschluss gestoppt wird. Das Geraet muss erneut vorbereitet werden."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта функция позволяет создавать установщик на внешних жестких дисках и SSD. Будьте особенно осторожны при выборе целевого диска, чтобы избежать случайной потери данных!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The USB media will not be bootable if the process is stopped before completion. You will need to prepare the device again."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bu özellik, harici sabit sürücülerde ve SSD'lerde bir yükleyici oluşturmanıza olanak tanır. Kazara veri kaybını önlemek için listeden hedef sürücüyü seçerken özellikle dikkatli olun!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El medio USB no sera arrancable si el proceso se detiene antes de finalizar. Sera necesario preparar el dispositivo nuevamente."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ця функція дозволяє створювати інсталятор на зовнішніх жорстких дисках і SSD. Будьте особливо уважні при виборі цільового диска зі списку, щоб уникнути випадкової втрати даних!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le support USB ne sera pas amorcable si le processus est arrete avant la fin. Il faudra preparer de nouveau l appareil."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tính năng này cho phép bạn tạo trình cài đặt trên ổ cứng ngoài và SSD. Hãy đặc biệt cẩn thận khi chọn ổ đĩa đích từ danh sách để tránh tình cờ mất dữ liệu!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完了前に処理を停止すると、このUSBメディアは起動可能ではなくなります。デバイスを再度準備する必要があります。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此功能允许在外部硬盘和 SSD 上创建安装程序。选择目标驱动器时请格外小心，以避免意外丢失数据！"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia."
+        }
+      }
+    },
+    "Ta wersja systemu macOS Sierra nie jest wspierana przez aplikację. Potrzebna jest nowsza wersja instalatora.": {
+      "comment": "Unsupported Sierra (not 12.6.06) message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Diese Version von macOS Sierra wird von der Anwendung nicht unterstützt. Eine neuere Installer-Version ist erforderlich."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A midia USB nao sera inicializavel se o processo for interrompido antes da conclusao. Sera necessario preparar o dispositivo novamente."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This version of macOS Sierra is not supported by the application. A newer installer version is required."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-носитель не будет загрузочным, если процесс остановить до завершения. Устройство потребуется подготовить заново."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta versión de macOS Sierra no es compatible con la aplicación. Se requiere una versión más reciente del instalador."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "如果在完成前停止流程，USB 介质将无法启动。需要重新准备该设备。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cette version de macOS Sierra n’est pas prise en charge par l’application. Une version plus récente de l’installateur est requise."
           }
-        }
-      }
-    },
-    "Oczekiwanie na plik .dmg, .iso, .cdr lub .app..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warte auf .dmg, .iso, .cdr oder .app Datei..."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Questa versione di macOS Sierra non è supportata dall'app. È necessaria una versione più recente del programma di installazione."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Waiting for .dmg, .iso, .cdr, or .app file..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このバージョンの macOS Sierra はこのアプリケーションではサポートされていません。より新しいインストーラが必要です。"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esperando archivo .dmg, .iso, .cdr o .app..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Esta versão do macOS Sierra não é compatível com o aplicativo. É necessária uma versão mais recente do instalador."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En attente d'un fichier .dmg, .iso, .cdr ou .app..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Эта версия macOS Sierra не поддерживается приложением. Требуется более новая версия установщика."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ".dmg, .iso, .cdr または .app ファイルを待機中..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacOS Sierra'nın bu sürümü uygulama tarafından desteklenmiyor. Yükleyicinin daha yeni bir sürümü gerekiyor."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aguardando arquivo .dmg, .iso, .cdr ou .app..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ця версія macOS Sierra не підтримується програмою. Потрібна новіша версія інсталятора."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ожидание файла .dmg, .iso, .cdr или .app..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản macOS Sierra này không được ứng dụng hỗ trợ. Cần có phiên bản mới hơn của trình cài đặt."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "等待 .dmg, .iso, .cdr 或 .app 文件..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此版本的 macOS Sierra 不受该应用程序支持，需要更新版本的安装器。"
           }
         }
       }
     },
-    "Odłączono nośnik USB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-Laufwerk getrennt"
+    "Tak": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ja"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB drive disconnected"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memoria USB desconectada"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sí"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clé USB déconnectée"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oui"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメモリが切断されました"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SÌ"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pen drive desconectado"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "はい"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-накопитель отключен"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sim"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U 盘已断开"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Да"
           }
-        }
-      }
-    },
-    "OK" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Evet"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aceptar"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "так"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đúng"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "是"
+          }
+        }
+      }
+    },
+    "Tiếng Việt": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "确定"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
-        }
-      }
-    },
-    "Opcje" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Optionen"
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Options"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opciones"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Options"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オプション"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opções"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Опции"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选项"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiếng Việt"
           }
         }
       }
     },
-    "Operacja nie powiodła się" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang fehlgeschlagen"
+    "Timeout połączenia XPC z helperem": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC-Verbindung zum Helper abgelaufen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation failed"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC connection timeout with helper"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La operacion fallo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tiempo de espera agotado para la conexión XPC con el helper"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echec de l operation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Délai de connexion XPC au helper dépassé"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作に失敗しました"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout della connessione XPC con l'helper"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A operacao falhou"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "helper への XPC 接続がタイムアウトしました"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Операция завершилась ошибкой"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout połączenia XPC z helperem"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作失败"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tempo limite da conexão XPC com o helper"
           }
-        }
-      }
-    },
-    "Operacja zakończona" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang abgeschlossen"
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Таймаут XPC-соединения с helper"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation completed"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcıyla XPC bağlantısı zaman aşımı"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operacion completada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Час очікування підключення XPC із помічником"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation terminee"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hết thời gian kết nối XPC với trình trợ giúp"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作が完了しました"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 helper 的 XPC 连接超时"
           }
+        }
+      }
+    },
+    "Trwa analizowanie pliku, proszę czekać": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei wird analysiert, bitte warten"
+          }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operacao concluida"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyzing file, please wait"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Операция завершена"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analizando archivo, por favor espere"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作已完成"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analyse du fichier en cours, veuillez patienter"
           }
-        }
-      }
-    },
-    "Ostrzeżenie o utracie danych" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warnung vor Datenverlust"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il file è in fase di analisi, attendi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Data loss warning"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを分析中、お待ちください"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Advertencia de perdida de datos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Analisando arquivo, aguarde"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avertissement de perte de donnees"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Анализ файла, пожалуйста, подождите"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "データ消失の警告"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosya analiz ediliyor, lütfen bekleyin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aviso de perda de dados"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файл аналізується, зачекайте"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Предупреждение о потере данных"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File đang được phân tích, vui lòng đợi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "数据丢失警告"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在分析文件，请稍候"
           }
         }
       }
     },
-    "Otwórz macUSB_temp" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB_temp oeffnen"
+    "Trwa inna operacja helpera. Poczekaj chwilę i spróbuj ponownie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine andere Helper-Operation wird gerade ausgefuhrt. Bitte warte kurz und versuche es erneut."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open macUSB_temp"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Another helper operation is in progress. Please wait and try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir macUSB_temp"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ya hay otra operacion del helper en curso. Espera un momento y vuelve a intentarlo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir macUSB_temp"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une autre operation de l outil auxiliaire est en cours. Veuillez patienter puis reessayer."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB_temp を開く"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È in corso un'altra operazione di supporto. Attendi qualche istante e riprova."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz macUSB_temp"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "別のヘルパー操作を実行中です。しばらく待ってから再試行してください。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir macUSB_temp"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outra operacao do helper ja esta em andamento. Aguarde um momento e tente novamente."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть macUSB_temp"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется другая операция helper. Подождите немного и попробуйте снова."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 macUSB_temp"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir yardımcı operasyon daha sürüyor. Lütfen bir süre bekleyip tekrar deneyin."
           }
-        }
-      }
-    },
-    "Otwórz Narzędzie dyskowe" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Festplattendienstprogramm öffnen"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open Disk Utility"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ще одна допоміжна операція триває. Зачекайте деякий час і спробуйте ще раз."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Utilidad de Discos"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Một hoạt động trợ giúp khác đang được tiến hành. Vui lòng chờ một lát và thử lại."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir Utilitaire de disque"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另一项辅助工具操作正在进行中。请稍候再试。"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ディスクユーティリティを開く"
+        }
+      }
+    },
+    "Trwa już naprawa helpera. Poczekaj na jej zakończenie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Helper-Reparatur lauft bereits. Bitte warte, bis sie abgeschlossen ist."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Utilitário de Disco"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper repair is already in progress. Please wait for it to finish."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть Дисковую утилиту"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reparacion del helper ya esta en curso. Espera a que termine."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开磁盘工具"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La reparation de l outil auxiliaire est deja en cours. Veuillez attendre la fin."
           }
-        }
-      }
-    },
-    "Pobierz" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herunterladen"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante è attualmente in riparazione. Aspetta che finisca."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Download"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパー修復はすでに進行中です。完了までお待ちください。"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Descargar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O reparo do helper ja esta em andamento. Aguarde a conclusao."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Télécharger"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановление helper уже выполняется. Дождитесь завершения."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダウンロード"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı şu anda onarılıyor. Bitmesini bekleyin."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baixar"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник зараз на ремонті. Зачекайте, поки він закінчиться."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Загрузить"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Người trợ giúp hiện đang được sửa chữa. Đợi nó kết thúc."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下载"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具修复已在进行中。请等待其完成。"
           }
         }
       }
     },
-    "Podłącz nośnik USB i poczekaj na wykrycie..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen Sie das USB-Laufwerk an und warten Sie auf die Erkennung..."
+    "Trwa naprawa helpera...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Helper wird repariert..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connect USB drive and wait for detection..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repairing helper..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conecte la memoria USB y espere a que sea detectada..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparando helper..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connectez la clé USB et attendez la détection..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparation de l outil auxiliaire..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメモリを接続して検出を待機してください..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L'aiutante è in riparazione..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conecte o pen drive e aguarde a detecção..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーを修復中..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подключите USB-накопитель и дождитесь обнаружения..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reparando helper..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "连接 U 盘并等待检测..."
-          }
-        }
-      }
-    },
-    "Połączenie z helperem zostało przerwane." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Verbindung zum Helper wurde unterbrochen."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется восстановление helper..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection with helper was interrupted."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı tamir ediliyor..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La conexión con el helper se interrumpió."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Помічник в ремонті..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La connexion avec le helper a été interrompue."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trợ lý đang được sửa chữa..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper との接続が中断されました。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在修复辅助工具..."
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Połączenie z helperem zostało przerwane."
+        }
+      }
+    },
+    "Türkçe": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A conexão com o helper foi interrompida."
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Соединение с helper было прервано."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 helper 的连接已中断。"
-          }
-        }
-      }
-    },
-    "Połączenie z helperem zostało unieważnione." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Verbindung zum Helper wurde ungültig."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connection with helper was invalidated."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La conexión con el helper fue invalidada."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La connexion avec le helper a été invalidée."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper との接続が無効化されました。"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Połączenie z helperem zostało unieważnione."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A conexão com o helper foi invalidada."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Соединение с helper было аннулировано."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 helper 的连接已失效。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Türkçe"
           }
         }
       }
     },
-    "Polski" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+    "Tworzenie bootowalnych dysków USB z systemem macOS oraz OS X nigdy nie było takie proste!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Erstellen von bootfähigen macOS- und OS X-USB-Laufwerken war noch nie so einfach!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating bootable macOS and OS X USB drives has never been easier!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Crear memorias USB de arranque con macOS y OS X nunca fue tan fácil!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Créer des clés USB amorçables macOS et OS X n'a jamais été aussi simple !"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creare unità USB avviabili con macOS e OS X non è mai stato così facile!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOSおよびOS Xの起動可能なUSBメモリの作成がかつてないほど簡単になりました！"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criar pen drives inicializáveis do macOS e OS X nunca foi tão fácil!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Polski"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание загрузочных USB-дисков macOS и OS X еще никогда не было таким простым!"
           }
-        }
-      }
-    },
-    "Pomiń analizowanie pliku" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateianalyse überspringen"
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacOS ve OS X ile önyüklenebilir USB sürücüler oluşturmak hiç bu kadar kolay olmamıştı!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skip file analysis"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення завантажувальних USB-накопичувачів з macOS і OS X ще ніколи не було таким простим!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Omitir análisis de archivo"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo ổ USB có khả năng khởi động với macOS và OS X chưa bao giờ dễ dàng đến thế!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer l'analyse du fichier"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建可引导的 macOS 和 OS X U 盘从未如此简单！"
+          }
+        }
+      }
+    },
+    "Tworzenie nośnika": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-Medium wird erstellt"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイル分析をスキップ"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating USB media"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pular análise de arquivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creando medio USB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пропустить анализ файла"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creation du support USB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳过文件分析"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione di media"
           }
-        }
-      }
-    },
-    "Pomyślnie wykryto system" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System erfolgreich erkannt"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメディアを作成中"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System successfully detected"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tworzenie nośnika"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema detectado con éxito"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criando midia USB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Système détecté avec succès"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание USB-носителя"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システムが正常に検出されました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medya oluşturma"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema detectado com sucesso"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення медіа"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Система успешно обнаружена"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo phương tiện"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统检测成功"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建 USB 介质"
           }
         }
       }
     },
-    "Português (BR)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+    "Tworzenie USB z Mac OS X Tiger (Multi DVD)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger (Multi DVD) USB erstellen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creating Mac OS X Tiger (Multi DVD) USB"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creando USB de Mac OS X Tiger (Multi DVD)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Création de la clé USB Mac OS X Tiger (Multi DVD)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Creazione di USB da Mac OS X Tiger (Multi DVD)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger (Multi DVD) USBを作成中"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Criando USB do Mac OS X Tiger (Multi DVD)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Português (BR)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание USB с Mac OS X Tiger (Multi DVD)"
           }
-        }
-      }
-    },
-    "Powiadomienia dla macUSB zostały zablokowane w ustawieniach systemowych. Aby otrzymywać informacje o zakończeniu procesów, należy zezwolić aplikacji na ich wyświetlanie w systemie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen für macUSB wurden in den Systemeinstellungen blockiert. Um Informationen über abgeschlossene Prozesse zu erhalten, musst du der App erlauben, Benachrichtigungen im System anzuzeigen."
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac OS X Tiger'dan (Multi DVD) USB oluşturma"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications for macUSB have been blocked in System Settings. To receive information about completed processes, you need to allow the app to display notifications in the system."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення USB з Mac OS X Tiger (Multi DVD)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las notificaciones para macUSB se han bloqueado en los ajustes del sistema. Para recibir información sobre la finalización de los procesos, debes permitir que la app muestre notificaciones en el sistema."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tạo USB từ Mac OS X Tiger (Multi DVD)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les notifications pour macUSB ont été bloquées dans les réglages système. Pour recevoir des informations sur la fin des processus, vous devez autoriser l’application à afficher des notifications dans le système."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在创建 Mac OS X Tiger (Multi DVD) USB"
           }
+        }
+      }
+    },
+    "Ukończono w %02dm %02ds": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgeschlossen in %1$02dm %2$02ds"
+          }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB の通知はシステム設定でブロックされています。処理の完了情報を受け取るには、システムでこのアプリの通知表示を許可してください。"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completed in %1$02dm %2$02ds"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As notificações do macUSB foram bloqueadas nas configurações do sistema. Para receber informações sobre a conclusão dos processos, você precisa permitir que o app exiba notificações no sistema."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completado en %1$02dm %2$02ds"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уведомления для macUSB были заблокированы в системных настройках. Чтобы получать информацию о завершении процессов, необходимо разрешить приложению показывать уведомления в системе."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Termine en %1$02dm %2$02ds"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB 的通知已在系统设置中被阻止。若要接收流程完成信息，需要在系统中允许该应用显示通知。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Completato in %02dm %02ds"
           }
-        }
-      }
-    },
-    "Powiadomienia są wyłączone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen sind deaktiviert"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$02d分 %2$02d秒で完了"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications are turned off"
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Ukończono w %1$02dm %2$02ds"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las notificaciones están desactivadas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concluido em %1$02dm %2$02ds"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les notifications sont désactivées"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполнено за %1$02dм %2$02dс"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知は無効です"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02ddk %02ds içinde tamamlandı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As notificações estão desativadas"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершено за %02dхв %02dс"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уведомления отключены"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoàn thành sau %02dphút %02d giây"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知已关闭"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已在 %1$02d分 %2$02d秒 内完成"
           }
         }
       }
     },
-    "Powiadomienia włączone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen aktiviert"
+    "Upewnij się, że wybrany obraz systemu pochodzi ze strony Mavericks Forever. Inne wersje mogą powodować błędy w trakcie tworzenia instalatora na nośniku USB.": {
+      "comment": "Mavericks detected alert description",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stellen Sie sicher, dass das ausgewählte Systemabbild von der Mavericks Forever-Website stammt. Andere Versionen können Fehler beim Erstellen des USB-Installers verursachen."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications enabled"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ensure that the selected system image comes from the Mavericks Forever website. Other versions may cause errors during the USB installer creation."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaciones activadas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Asegúrese de que la imagen del sistema seleccionada provenga del sitio web de Mavericks Forever. Otras versiones pueden causar errores durante la creación del instalador USB."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications activées"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assurez-vous que l'image système sélectionnée provient du site Web Mavericks Forever. D'autres versions peuvent provoquer des erreurs lors de la création du programme d'installation USB."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知オン"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assicurati che l'immagine del sistema selezionata provenga da Mavericks Forever. Altre versioni potrebbero causare errori durante la creazione del programma di installazione sull'unità USB."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Powiadomienia włączone"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したシステムイメージがMavericks ForeverのWebサイトからのものであることを確認してください。他のバージョンでは、USBインストーラの作成中にエラーが発生する可能性があります。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificações ativadas"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Certifique-se de que a imagem do sistema selecionada venha do site Mavericks Forever. Outras versões podem causar erros durante a criação do instalador USB."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уведомления включены"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Убедитесь, что выбранный образ системы загружен с сайта Mavericks Forever. Другие версии могут вызвать ошибки при создании установочного USB-накопителя."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知已开启"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen sistem görüntüsünün Mavericks Forever'dan olduğundan emin olun. Diğer sürümler, USB sürücüsünde yükleyiciyi oluştururken hatalara neden olabilir."
           }
-        }
-      }
-    },
-    "Powiadomienia wyłączone" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen deaktiviert"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications disabled"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переконайтеся, що вибраний образ системи належить Mavericks Forever. Інші версії можуть викликати помилки під час створення інсталятора на USB-накопичувачі."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificaciones desactivadas"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đảm bảo hình ảnh hệ thống đã chọn là từ Mavericks Forever. Các phiên bản khác có thể gây ra lỗi khi tạo trình cài đặt trên ổ USB."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications désactivées"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请确保所选系统镜像来自 Mavericks Forever 网站。其他版本可能会在创建 USB 安装程序时导致错误。"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知オフ"
+        }
+      }
+    },
+    "Uruchom aplikację ponownie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anwendung neu starten"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Powiadomienia wyłączone"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart application"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notificações desativadas"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar aplicación"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Уведомления отключены"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrer l'application"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知已关闭"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riavviare l'applicazione"
           }
-        }
-      }
-    },
-    "Pozwoli to na otrzymanie informacji o zakończeniu procesu przygotowania nośnika instalacyjnego." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "So erhältst du Informationen, wenn der Vorbereitungsprozess des Installationsmediums abgeschlossen ist."
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This will let you receive information when the installer media preparation process is finished."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションを再起動"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esto te permitirá recibir información cuando finalice el proceso de preparación del medio de instalación."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reiniciar aplicativo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cela vous permettra de recevoir des informations à la fin du processus de préparation du support d’installation."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустить приложение"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "これにより、インストールメディアの準備プロセス完了時に通知を受け取れます。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamayı yeniden başlatın"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Isso permitirá que você receba informações quando o processo de preparação da mídia de instalação for concluído."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Перезапустіть програму"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Это позволит получать информацию о завершении процесса подготовки установочного носителя."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Khởi động lại ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这样可在安装介质准备过程完成后接收通知。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重启应用程序"
           }
         }
       }
     },
-    "Proces przerwany" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang abgebrochen"
+    "Ustawienia działania w tle…": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Einstellungen fur Hintergrundaktivitat…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Process interrupted"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Background activity settings…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceso interrumpido"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de actividad en segundo plano…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processus interrompu"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reglages activite en arriere-plan…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセスが中断されました"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impostazioni dello sfondo…"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processo interrompido"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バックグラウンド動作の設定…"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Процесс прерван"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ajustes de atividade em segundo plano…"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "进程已中断"
-          }
-        }
-      }
-    },
-    "Proces tworzenia instalatora na wybranym nośniku zakończył się niepowodzeniem." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Prozess zum Erstellen des Installationsprogramms auf dem ausgewählten Medium ist fehlgeschlagen."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Настройки работы в фоне…"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The installer creation process on the selected media has failed."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arka Plan Ayarları…"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El proceso de creación del instalador en el medio seleccionado ha fallado."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Налаштування фону…"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le processus de création de l’installateur sur le support sélectionné a échoué."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cài đặt nền…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したメディアでのインストーラ作成処理は失敗しました。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "后台运行设置…"
           }
+        }
+      }
+    },
+    "UWAGA!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ACHTUNG!"
+          }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O processo de criação do instalador na mídia selecionada falhou."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WARNING!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Процесс создания установщика на выбранном носителе завершился неудачей."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡ADVERTENCIA!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在所选介质上创建安装器的过程失败。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ATTENTION !"
           }
-        }
-      }
-    },
-    "Proces zapisu na nośniku zakończył się pomyślnie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Schreibvorgang auf dem Medium wurde erfolgreich abgeschlossen."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ATTENZIONE!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The write process on the media completed successfully."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告！"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El proceso de escritura en el medio se completó correctamente."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ATENÇÃO!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le processus d’écriture sur le support s’est terminé avec succès."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ВНИМАНИЕ!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メディアへの書き込み処理が正常に完了しました。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DİKKAT!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O processo de gravação na mídia foi concluído com sucesso."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "УВАГА!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Процесс записи на носитель успешно завершён."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CHÚ Ý!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "介质写入过程已成功完成。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告！"
           }
         }
       }
     },
-    "Proszę czekać" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte warten"
+    "W przypadku Maca z PowerPC": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für PowerPC-Macs"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please wait"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For PowerPC Macs"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor espere"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para Macs PowerPC"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez patienter"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pour les Mac PowerPC"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お待ちください"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Per Mac con PowerPC"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, aguarde"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPC Mac の場合"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пожалуйста, подождите"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para Macs PowerPC"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请稍候"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для Mac с PowerPC"
           }
-        }
-      }
-    },
-    "Proszę czekać..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bitte warten..."
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Please wait..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PowerPC'li Mac için"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor espere..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для Mac з PowerPC"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Veuillez patienter..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dành cho máy Mac có PowerPC"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "お待ちください..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对于 PowerPC Mac"
+          }
+        }
+      }
+    },
+    "Wesprzyj projekt macUSB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstütze das macUSB‑Projekt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Por favor, aguarde..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Support the macUSB project"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пожалуйста, подождите..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoya el proyecto macUSB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请稍候..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Soutenir le projet macUSB"
           }
-        }
-      }
-    },
-    "Przebieg procesu" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prozessübersicht"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supporta il progetto macUSB"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Process overview"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB プロジェクトを支援"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resumen del proceso"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apoie o projeto macUSB"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aperçu du processus"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поддержать проект macUSB"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "プロセスの概要"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "MacUSB projesini destekleyin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visão geral do processo"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Підтримайте проект macUSB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обзор процесса"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hỗ trợ dự án macUSB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "进程概览"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "支持 macUSB 项目"
           }
         }
       }
     },
-    "Przebieg tworzenia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ablauf der Erstellung"
+    "Włącz obsługę zewnętrznych dysków twardych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unterstützung für externe Festplatten aktivieren"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation process"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable external hard drive support"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proceso de creación"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar soporte para discos duros externos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processus de création"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer la prise en charge des disques durs externes"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成プロセス"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abilita il supporto per i dischi rigidi esterni"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Processo de criação"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外付けハードドライブのサポートを有効にする"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Процесс создания"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar suporte a discos rígidos externos"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建过程"
-          }
-        }
-      }
-    },
-    "Przejdź dalej" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weiter"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить поддержку внешних жестких дисков"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continue"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici sabit sürücüler için desteği etkinleştirin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкніть підтримку зовнішніх жорстких дисків"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuer"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kích hoạt hỗ trợ cho ổ cứng ngoài"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次へ"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用外部硬盘支持"
           }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuar"
+        }
+      }
+    },
+    "Włącz powiadomienia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benachrichtigungen aktivieren"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Продолжить"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable notifications"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "继续"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activar notificaciones"
           }
-        }
-      }
-    },
-    "Przejdź do podsumowania (Big Sur) (2s delay)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zur Zusammenfassung (Big Sur) wechseln (2s Verzoegerung)"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activer les notifications"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to summary (Big Sur) (2s delay)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attiva le notifiche"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir al resumen (Big Sur) (retraso de 2 s)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知を有効にする"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aller au resume (Big Sur) (delai 2 s)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativar notificações"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サマリーへ移動（Big Sur）（2秒遅延）"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включить уведомления"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przejdź do podsumowania (Big Sur) (2s delay)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bildirimleri aç"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir para o resumo (Big Sur) (atraso de 2 s)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкніть сповіщення"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейти к сводке (Big Sur) (задержка 2 с)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bật thông báo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "前往摘要（Big Sur）（延迟 2 秒）"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用通知"
           }
         }
       }
     },
-    "Przejdź do podsumowania (Tiger) (2s delay)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zur Zusammenfassung (Tiger) wechseln (2s Verzoegerung)"
+    "Włączony": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktiviert"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to summary (Tiger) (2s delay)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir al resumen (Tiger) (retraso de 2 s)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aller au resume (Tiger) (delai 2 s)"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Active"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サマリーへ移動（Tiger）（2秒遅延）"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abilitato"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przejdź do podsumowania (Tiger) (2s delay)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir para o resumo (Tiger) (atraso de 2 s)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ativado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейти к сводке (Tiger) (задержка 2 с)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Включен"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "前往摘要（Tiger）（延迟 2 秒）"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Etkinleştirilmiş"
           }
-        }
-      }
-    },
-    "Przejdź do ustawień systemowych" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zu den Systemeinstellungen"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Go to System Settings"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увімкнено"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir a los ajustes del sistema"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã bật"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aller aux réglages système"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "システム設定を開く"
+        }
+      }
+    },
+    "Wróć": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurueck"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ir para Ajustes do Sistema"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перейти в системные настройки"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Volver"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "前往系统设置"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retour"
           }
-        }
-      }
-    },
-    "Przekopiowane dane: %.1f GB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kopierte Daten: %.1f GB"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indietro"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Copied data: %.1f GB"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "戻る"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datos copiados: %.1f GB"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wróć"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donnees copiees : %.1f GB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voltar"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コピー済みデータ: %.1f GB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przekopiowane dane: %.1f GB"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geri"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dados copiados: %.1f GB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Назад"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скопированные данные: %.1f GB"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quay lại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已复制数据：%.1f GB"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "返回"
           }
         }
       }
     },
-    "Przekroczono czas oczekiwania na odpowiedź helpera XPC." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zeitüberschreitung beim Warten auf die XPC-Antwort des Helpers."
+    "Wszystkie dane na wybranym nośniku zostaną usunięte. Czy na pewno chcesz rozpocząć proces?": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Daten auf dem ausgewahlten Laufwerk werden geloscht. Mochtest du den Vorgang wirklich starten?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timed out waiting for helper XPC response."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All data on the selected drive will be erased. Are you sure you want to start?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se superó el tiempo de espera de la respuesta XPC del helper."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos los datos de la unidad seleccionada se eliminaran. Seguro que quieres iniciar el proceso?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Délai d attente dépassé pour la réponse XPC du helper."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les donnees du support selectionne seront supprimees. Voulez-vous vraiment demarrer le processus ?"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper XPC 応答の待機がタイムアウトしました。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutti i dati sul supporto selezionato verranno eliminati. Sei sicuro di voler avviare il processo?"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przekroczono czas oczekiwania na odpowiedź helpera XPC."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したドライブ上のすべてのデータが削除されます。処理を開始してもよろしいですか？"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempo de espera pela resposta XPC do helper excedido."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os dados da unidade selecionada serao apagados. Tem certeza de que deseja iniciar o processo?"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Превышено время ожидания ответа XPC от helper."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все данные на выбранном носителе будут удалены. Вы уверены, что хотите начать процесс?"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "等待 helper XPC 响应超时。"
-          }
-        }
-      }
-    },
-    "Przerwij" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen ortamdaki tüm veriler silinecektir. İşlemi başlatmak istediğinizden emin misiniz?"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Усі дані на вибраному носії будуть видалені. Ви впевнені, що хочете почати процес?"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrumpir"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tất cả dữ liệu trên phương tiện đã chọn sẽ bị xóa. Bạn có chắc chắn muốn bắt đầu quá trình này không?"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrompre"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选磁盘上的所有数据都将被删除。确定要开始此过程吗？"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中断"
+        }
+      }
+    },
+    "Wszystkie pliki na wybranym nośniku USB zostaną bezpowrotnie usunięte!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Dateien auf dem ausgewählten USB-Laufwerk werden unwiderruflich gelöscht!"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przerwij"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All files on the selected USB drive will be permanently erased!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interromper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Todos los archivos en la memoria USB seleccionada se borrarán permanentemente!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Прервать"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tous les fichiers sur la clé USB sélectionnée seront définitivement effacés !"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中断"
-          }
-        }
-      }
-    },
-    "Przerywanie działania" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang wird abgebrochen"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutti i file sull'unità USB selezionata verranno eliminati definitivamente!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aborting operation"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したUSBメモリ上のすべてのファイルは完全に消去されます！"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abortando operación"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todos os arquivos no pen drive selecionado serão apagados permanentemente!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interruption de l'opération"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все файлы на выбранном USB-накопителе будут безвозвратно удалены!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作を中止しています"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen USB sürücüsündeki tüm dosyalar kalıcı olarak silinecek!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abortando operação"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Усі файли на вибраному USB-накопичувачі буде остаточно видалено!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Прерывание операции"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tất cả các tập tin trên ổ USB đã chọn sẽ bị xóa vĩnh viễn!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在中止操作"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选 U 盘上的所有文件将被永久清除！"
           }
         }
       }
     },
-    "Przerywanie..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird abgebrochen..."
+    "Wybierz": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stopping..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrumpiendo..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interruption..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "中断中..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegliere"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przerywanie..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Interrompendo..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Прерывание..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在中断..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçmek"
           }
-        }
-      }
-    },
-    "Przygotowanie..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorbereitung..."
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "準備中..."
+        }
+      }
+    },
+    "Wybierz docelowy nośnik USB:": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-Ziellaufwerk auswählen:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select target USB drive:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccione la memoria USB de destino:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "准备中..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez la clé USB cible :"
           }
-        }
-      }
-    },
-    "Przygotowywanie operacji..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgang wird vorbereitet..."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleziona l'unità USB di destinazione:"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparing operation..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対象のUSBメモリを選択:"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando la operacion..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione o pen drive de destino:"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparation de l operation..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите целевой USB-накопитель:"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作を準備中..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hedef USB sürücüsünü seçin:"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preparando a operacao..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть цільовий USB-накопичувач:"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подготовка операции..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn ổ USB mục tiêu:"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在准备操作..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择目标 U 盘："
           }
         }
       }
     },
-    "Repozytorium macUSB na GitHub" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB-Repository auf GitHub"
+    "Wybierz go ręcznie lub przeciągnij powyżej": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie es manuell aus oder ziehen Sie es nach oben"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB GitHub Repository"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select it manually or drag it above"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repositorio de macUSB en GitHub"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecciónelo manualmente o arrástrelo arriba"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dépôt macUSB sur GitHub"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionnez-le manuellement ou glissez-le ci-dessus"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSBのGitHubリポジトリ"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selezionalo manualmente o trascinalo sopra"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repositório do macUSB no GitHub"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手動で選択するか、上にドラッグしてください"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Репозиторий macUSB на GitHub"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecione manualmente ou arraste acima"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB 的 GitHub 仓库"
-          }
-        }
-      }
-    },
-    "Rozpocznij" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starten"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите его вручную или перетащите выше"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manuel olarak seçin veya yukarıya sürükleyin"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть його вручну або перетягніть вище"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Démarrer"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn thủ công hoặc kéo nó lên trên"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "手动选择或将其拖到上方"
           }
+        }
+      }
+    },
+    "Wybierz miejsce zapisu pliku z logami diagnostycznymi": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speicherort für Diagnoseprotokolldatei auswählen"
+          }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select location to save diagnostic logs file"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Начать"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleccionar ubicación para guardar el archivo de registros de diagnóstico"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélectionner l'emplacement pour enregistrer le fichier de journaux de diagnostic"
           }
-        }
-      }
-    },
-    "Rozpoczynanie..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wird gestartet..."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selezionare una posizione in cui salvare il file di registro diagnostico"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Starting..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "診断ログファイルの保存先を選択"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciando..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selecionar local para salvar o arquivo de logs de diagnóstico"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Demarrage..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выберите место для сохранения файла журналов диагностики"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始中..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tanılama günlük dosyasının kaydedileceği konumu seçin"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Iniciando..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть місце для збереження файлу журналу діагностики"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Запуск..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn vị trí để lưu tệp nhật ký chẩn đoán"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在开始..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择保存诊断日志文件的位置"
           }
         }
       }
     },
-    "Ścieżka..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pfad..."
+    "Wybierz...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auswählen..."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Path..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruta..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Elegir..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chemin..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choisir..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パス..."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scegliere..."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Caminho..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択..."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Путь..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escolher..."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "路径..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать..."
           }
-        }
-      }
-    },
-    "Sprawdź dostępność aktualizacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nach Updates suchen"
-          }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check for updates"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçmek..."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buscar actualizaciones"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виберіть..."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rechercher des mises à jour"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn..."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アップデートを確認"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择..."
+          }
+        }
+      }
+    },
+    "Wybór nośnika USB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-Laufwerksauswahl"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar atualizações"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB Drive Selection"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверить наличие обновлений"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección de memoria USB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检查更新"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélection de la clé USB"
           }
-        }
-      }
-    },
-    "Sprawdzanie statusu..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status wird gepruft..."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selezione di un'unità USB"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checking status..."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメモリの選択"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprobando el estado..."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleção de pen drive"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verification du statut..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбор USB-накопителя"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ステータスを確認中..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir USB sürücüsü seçme"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificando o status..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибір USB-накопичувача"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка статуса..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chọn ổ USB"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在检查状态..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "U 盘选择"
           }
         }
       }
     },
-    "Start" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+    "Wybór pliku": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateiauswahl"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File selection"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inicio"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selección de archivo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accueil"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sélection du fichier"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開始"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selezione del file"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Início"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルの選択"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Старт"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seleção de arquivo"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开始"
-          }
-        }
-      }
-    },
-    "Status helpera" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper-Status"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбор файла"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper status"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosya seçimi"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado del helper"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибір файлу"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statut de l outil auxiliaire"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lựa chọn tập tin"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーのステータス"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件选择"
           }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status do helper"
+        }
+      }
+    },
+    "Wybrana wersja systemu": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewählte Systemversion"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Статус helper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected system version"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具状态"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versión del sistema seleccionada"
           }
-        }
-      }
-    },
-    "Status usługi: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dienststatus: %@"
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version du système sélectionnée"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Service status: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versione del sistema selezionata"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado del servicio: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたシステムバージョン"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Statut du service : %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versão do sistema selecionada"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サービス状態: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранная версия системы"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status usługi: %@"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen sistem sürümü"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Status do serviço: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибрана версія системи"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Статус службы: %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phiên bản hệ thống được chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "服务状态：%@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择系统版本"
           }
         }
       }
     },
-    "Strona internetowa macUSB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB-Website"
+    "Wybrano nośnik USB 2.0": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB 2.0-Laufwerk ausgewählt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB Website"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB 2.0 drive selected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sitio web de macUSB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidad USB 2.0 seleccionada"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site web de macUSB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lecteur USB 2.0 sélectionné"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSBウェブサイト"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supporto USB 2.0 selezionato"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Site do macUSB"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB 2.0ドライブが選択されました"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Веб-сайт macUSB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unidade USB 2.0 selecionada"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB 网站"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбран накопитель USB 2.0"
           }
-        }
-      }
-    },
-    "System zablokował rejestrację helpera z uruchomienia Xcode. Uruchom raz aplikację z katalogu Applications, zatwierdź działanie helpera w tle, a następnie wróć do testów w Xcode. Szczegóły XPC: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das System hat die Helper-Registrierung bei einem Start aus Xcode blockiert. Starte die App einmal aus dem Ordner Applications, genehmige die Hintergrundaktivitat des Helpers und kehre dann zu Tests in Xcode zuruck. XPC-Details: %@"
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB 2.0 ortamı seçildi"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The system blocked helper registration from an Xcode launch. Run the app once from the Applications folder, approve helper background activity, then return to testing in Xcode. XPC details: %@"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибрано носій USB 2.0"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El sistema bloqueo el registro del helper al iniciarse desde Xcode. Ejecuta la app una vez desde la carpeta Aplicaciones, autoriza la actividad en segundo plano del helper y luego vuelve a las pruebas en Xcode. Detalles de XPC: %@"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã chọn phương tiện USB 2.0"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择 USB 2.0 驱动器"
+          }
+        }
+      }
+    },
+    "Wybrany folder nie istnieje": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der ausgewaehlte Ordner existiert nicht"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le systeme a bloque l enregistrement de l outil auxiliaire lors d un lancement depuis Xcode. Lancez l application une fois depuis le dossier Applications, autorisez l activite en arriere-plan de l outil auxiliaire, puis revenez aux tests dans Xcode. Details XPC : %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected folder does not exist"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xcode から起動したため、システムがヘルパー登録をブロックしました。まず Applications フォルダからアプリを一度起動し、ヘルパーのバックグラウンド動作を許可してから、Xcode でのテストに戻ってください。XPC 詳細: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La carpeta seleccionada no existe"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O sistema bloqueou o registro do helper ao iniciar pelo Xcode. Execute o app uma vez na pasta Aplicativos, autorize a atividade em segundo plano do helper e depois volte aos testes no Xcode. Detalhes do XPC: %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le dossier selectionne n existe pas"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Система заблокировала регистрацию helper при запуске из Xcode. Один раз запустите приложение из папки Applications, разрешите фоновую работу helper, затем вернитесь к тестированию в Xcode. Подробности XPC: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La cartella selezionata non esiste"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "系统阻止了从 Xcode 启动时的辅助工具注册。请先从Applications文件夹运行一次应用，批准辅助工具后台运行，然后再回到 Xcode 测试。XPC 详情：%@"
-          }
-        }
-      }
-    },
-    "Szczegóły operacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vorgangsdetails"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したフォルダは存在しません"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation details"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybrany folder nie istnieje"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles de la operacion"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A pasta selecionada nao existe"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details de l operation"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранная папка не существует"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作の詳細"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen klasör mevcut değil"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalhes da operacao"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибрана папка не існує"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подробности операции"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thư mục đã chọn không tồn tại"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作详情"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选文件夹不存在"
           }
         }
       }
     },
-    "Szczegóły: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details: %@"
+    "Wybrany nośnik pracuje w starszym standardzie przesyłu danych. Proces tworzenia instalatora może potrwać kilkanaście minut": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das ausgewählte Laufwerk verwendet einen älteren Datenübertragungsstandard. Die Erstellung des Installers kann einige Minuten dauern."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected drive operates on an older data transfer standard. The installer creation process may take several minutes."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalles: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La unidad seleccionada utiliza un estándar de transferencia de datos más antiguo. El proceso de creación del instalador puede tardar varios minutos."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Détails : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le lecteur sélectionné utilise une norme de transfert de données plus ancienne. La création de l'installateur peut prendre plusieurs minutes."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詳細: %@"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il mezzo selezionato funziona con uno standard di trasferimento dati precedente. Il processo di creazione del programma di installazione potrebbe richiedere diversi minuti"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szczegóły: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたドライブは古いデータ転送規格を使用しています。インストーラの作成には十数分かかる場合があります。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Detalhes: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A unidade selecionada usa um padrão de transferência de dados mais antigo. O processo de criação do instalador pode levar vários minutos."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Подробности: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранный накопитель использует устаревший стандарт передачи данных. Процесс создания установщика может занять несколько минут."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "详情：%@"
-          }
-        }
-      }
-    },
-    "Szybkość zapisu: - MB/s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schreibgeschwindigkeit: - MB/s"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen ortam daha eski bir veri aktarım standardında çalışır. Yükleyiciyi oluşturma işlemi birkaç dakika sürebilir"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write speed: - MB/s"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибраний носій працює в старішому стандарті передачі даних. Процес створення інсталятора може зайняти кілька хвилин"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velocidad de escritura: - MB/s"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phương tiện đã chọn hoạt động theo tiêu chuẩn truyền dữ liệu cũ hơn. Quá trình tạo trình cài đặt có thể mất vài phút"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vitesse d'ecriture : - MB/s"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选驱动器使用的是较旧的数据传输标准。安装程序创建过程可能需要几分钟。"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書き込み速度: - MB/s"
+        }
+      }
+    },
+    "Wybrany nośnik USB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewähltes USB-Laufwerk"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velocidade de gravacao: - MB/s"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected USB drive"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скорость записи: - MB/s"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Memoria USB seleccionada"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "写入速度：- MB/s"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clé USB sélectionnée"
           }
-        }
-      }
-    },
-    "Szybkość zapisu: %d MB/s" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schreibgeschwindigkeit: %d MB/s"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispositivo di archiviazione USB selezionato"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Write speed: %d MB/s"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたUSBメモリ"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velocidad de escritura: %d MB/s"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pen drive selecionado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vitesse d'ecriture : %d MB/s"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранный USB-накопитель"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "書き込み速度: %d MB/s"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen USB depolama aygıtı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velocidade de gravacao: %d MB/s"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибраний накопичувач USB"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скорость записи: %d MB/s"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết bị lưu trữ USB đã chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "写入速度：%d MB/s"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选择 U 盘"
           }
         }
       }
     },
-    "Ta funkcja umożliwia tworzenie instalatora na zewnętrznych dyskach twardych i SSD. Zachowaj szczególną ostrożność przy wyborze dysku docelowego z listy, aby uniknąć przypadkowej utraty danych!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Funktion ermöglicht das Erstellen des Installers auf externen Festplatten und SSDs. Seien Sie bei der Auswahl des Ziellaufwerks besonders vorsichtig, um Datenverlust zu vermeiden!"
+    "Wybrany nośnik USB ma za małą pojemność": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Kapazität des ausgewählten USB-Laufwerks ist zu gering"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This feature allows creating the installer on external hard drives and SSDs. Please verify the selected target drive carefully to avoid accidental data loss!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected USB drive capacity is too small"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta función permite crear el instalador en discos duros externos y SSD. ¡Tenga mucho cuidado al seleccionar el disco de destino para evitar la pérdida accidental de datos!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capacidad de la memoria USB seleccionada es demasiado pequeña"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette fonctionnalité permet de créer l'installateur sur des disques durs externes et SSD. Soyez particulièrement prudent lors du choix du disque cible pour éviter toute perte de données accidentelle !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La capacité de la clé USB sélectionnée est trop faible"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この機能を使用すると、外付けハードドライブやSSDにインストーラを作成できます。データの誤消去を防ぐため、ターゲットドライブを選択する際は十分注意してください！"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il dispositivo di archiviazione USB selezionato ha una capacità troppo piccola"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este recurso permite criar o instalador em discos rígidos externos e SSDs. Tenha muito cuidado ao selecionar o disco de destino para evitar a perda acidental de dados!"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたUSBメモリの容量が小さすぎます"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эта функция позволяет создавать установщик на внешних жестких дисках и SSD. Будьте особенно осторожны при выборе целевого диска, чтобы избежать случайной потери данных!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A capacidade do pen drive selecionado é muito pequena"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此功能允许在外部硬盘和 SSD 上创建安装程序。选择目标驱动器时请格外小心，以避免意外丢失数据！"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Емкость выбранного USB-накопителя слишком мала"
           }
-        }
-      }
-    },
-    "Ta wersja systemu macOS Sierra nie jest wspierana przez aplikację. Potrzebna jest nowsza wersja instalatora." : {
-      "comment" : "Unsupported Sierra (not 12.6.06) message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Diese Version von macOS Sierra wird von der Anwendung nicht unterstützt. Eine neuere Installer-Version ist erforderlich."
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen USB depolama cihazının kapasitesi çok küçük"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This version of macOS Sierra is not supported by the application. A newer installer version is required."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибраний USB-накопичувач має замалу ємність"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta versión de macOS Sierra no es compatible con la aplicación. Se requiere una versión más reciente del instalador."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết bị lưu trữ USB được chọn có dung lượng quá nhỏ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cette version de macOS Sierra n’est pas prise en charge par l’application. Une version plus récente de l’installateur est requise."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选 U 盘容量太小"
+          }
+        }
+      }
+    },
+    "Wybrany system": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewaehltes System"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このバージョンの macOS Sierra はこのアプリケーションではサポートされていません。より新しいインストーラが必要です。"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected system"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esta versão do macOS Sierra não é compatível com o aplicativo. É necessária uma versão mais recente do instalador."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema seleccionado"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эта версия macOS Sierra не поддерживается приложением. Требуется более новая версия установщика."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Systeme selectionne"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此版本的 macOS Sierra 不受该应用程序支持，需要更新版本的安装器。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema selezionato"
           }
-        }
-      }
-    },
-    "Tak" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したシステム"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yes"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybrany system"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sí"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistema selecionado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oui"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранная система"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen sistem"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обрана система"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Да"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hệ thống đã chọn"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已选系统"
           }
         }
       }
     },
-    "Timeout połączenia XPC z helperem" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC-Verbindung zum Helper abgelaufen"
+    "Wybrany system nie jest wspierany przez aplikację": {
+      "comment": "Generic unsupported system message",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das ausgewählte System wird von der Anwendung nicht unterstützt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC connection timeout with helper"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Selected system is not supported by the application"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tiempo de espera agotado para la conexión XPC con el helper"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El sistema seleccionado no es compatible con la aplicación"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Délai de connexion XPC au helper dépassé"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le système sélectionné n'est pas pris en charge par l'application"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "helper への XPC 接続がタイムアウトしました"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il sistema selezionato non è supportato dall'applicazione"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timeout połączenia XPC z helperem"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択されたシステムはアプリケーションでサポートされていません"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempo limite da conexão XPC com o helper"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O sistema selecionado não é compatível com o aplicativo"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Таймаут XPC-соединения с helper"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбранная система не поддерживается приложением"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 helper 的 XPC 连接超时"
-          }
-        }
-      }
-    },
-    "Trwa analizowanie pliku, proszę czekać" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Datei wird analysiert, bitte warten"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen sistem uygulama tarafından desteklenmiyor"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyzing file, please wait"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибрана система не підтримується програмою"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analizando archivo, por favor espere"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hệ thống đã chọn không được ứng dụng hỗ trợ"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analyse du fichier en cours, veuillez patienter"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所选系统不受此应用支持"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイルを分析中、お待ちください"
+        }
+      }
+    },
+    "Wykryto kompatybilny instalator": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kompatibler Installer erkannt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Analisando arquivo, aguarde"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compatible installer detected"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Анализ файла, пожалуйста, подождите"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se detectó un instalador compatible"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在分析文件，请稍候"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installateur compatible détecté"
           }
-        }
-      }
-    },
-    "Trwa inna operacja helpera. Poczekaj chwilę i spróbuj ponownie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eine andere Helper-Operation wird gerade ausgefuhrt. Bitte warte kurz und versuche es erneut."
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rilevato programma di installazione compatibile"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Another helper operation is in progress. Please wait and try again."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "互換性のあるインストーラが検出されました"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ya hay otra operacion del helper en curso. Espera un momento y vuelve a intentarlo."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instalador compatível detectado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une autre operation de l outil auxiliaire est en cours. Veuillez patienter puis reessayer."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обнаружен совместимый установщик"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "別のヘルパー操作を実行中です。しばらく待ってから再試行してください。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uyumlu yükleyici algılandı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Outra operacao do helper ja esta em andamento. Aguarde um momento e tente novamente."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виявлено сумісний інсталятор"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выполняется другая операция helper. Подождите немного и попробуйте снова."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã phát hiện trình cài đặt tương thích"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "另一项辅助工具操作正在进行中。请稍候再试。"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到兼容的安装器"
           }
         }
       }
     },
-    "Trwa już naprawa helpera. Poczekaj na jej zakończenie." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Helper-Reparatur lauft bereits. Bitte warte, bis sie abgeschlossen ist."
+    "Wykryto system OS X Mavericks": {
+      "comment": "Mavericks detected alert title",
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks erkannt"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper repair is already in progress. Please wait for it to finish."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks detected"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reparacion del helper ya esta en curso. Espera a que termine."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks detectado"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La reparation de l outil auxiliaire est deja en cours. Veuillez attendre la fin."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks détecté"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパー修復はすでに進行中です。完了までお待ちください。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rilevati OS X Mavericks"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O reparo do helper ja esta em andamento. Aguarde a conclusao."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericksが検出されました"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстановление helper уже выполняется. Дождитесь завершения."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks detectado"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "辅助工具修复已在进行中。请等待其完成。"
-          }
-        }
-      }
-    },
-    "Trwa naprawa helpera..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper wird repariert..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обнаружена система OS X Mavericks"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Repairing helper..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OS X Mavericks algılandı"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparando helper..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Виявлено OS X Mavericks"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparation de l outil auxiliaire..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã phát hiện thấy OS X Mavericks"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ヘルパーを修復中..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "检测到 OS X Mavericks"
+          }
+        }
+      }
+    },
+    "Wymaga zatwierdzenia": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Genehmigung erforderlich"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reparando helper..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requires approval"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выполняется восстановление helper..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requiere aprobacion"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在修复辅助工具..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Necessite une approbation"
           }
-        }
-      }
-    },
-    "Tworzenie bootowalnych dysków USB z systemem macOS oraz OS X nigdy nie było takie proste!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Erstellen von bootfähigen macOS- und OS X-USB-Laufwerken war noch nie so einfach!"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Richiede l'approvazione"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating bootable macOS and OS X USB drives has never been easier!"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "承認が必要"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Crear memorias USB de arranque con macOS y OS X nunca fue tan fácil!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requer aprovacao"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Créer des clés USB amorçables macOS et OS X n'a jamais été aussi simple !"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется подтверждение"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macOSおよびOS Xの起動可能なUSBメモリの作成がかつてないほど簡単になりました！"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Onay gerektirir"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criar pen drives inicializáveis do macOS e OS X nunca foi tão fácil!"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потребує погодження"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание загрузочных USB-дисков macOS и OS X еще никогда не было таким простым!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yêu cầu phê duyệt"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建可引导的 macOS 和 OS X U 盘从未如此简单！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要批准"
           }
         }
       }
     },
-    "Tworzenie nośnika" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-Medium wird erstellt"
+    "Wymagana lokalizacja /Applications": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderlicher Speicherort /Applications"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating USB media"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required location /Applications"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creando medio USB"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ubicacion requerida /Applications"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creation du support USB"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emplacement requis /Applications"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメディアを作成中"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Posizione/Applicazioni richieste"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tworzenie nośnika"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必須の場所 /Applications"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criando midia USB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Local obrigatorio /Applications"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание USB-носителя"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуемое расположение /Applications"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在创建 USB 介质"
-          }
-        }
-      }
-    },
-    "Tworzenie USB z Mac OS X Tiger (Multi DVD)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger (Multi DVD) USB erstellen"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gerekli konum /Uygulamalar"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creating Mac OS X Tiger (Multi DVD) USB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обов’язкове місце розташування/Додатки"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Creando USB de Mac OS X Tiger (Multi DVD)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vị trí bắt buộc/Ứng dụng"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Création de la clé USB Mac OS X Tiger (Multi DVD)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必须位置 /Applications"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mac OS X Tiger (Multi DVD) USBを作成中"
+        }
+      }
+    },
+    "Wymagane jest minimum 16 GB.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mindestens 16 GB erforderlich."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Criando USB do Mac OS X Tiger (Multi DVD)"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Min 16GB required."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Создание USB с Mac OS X Tiger (Multi DVD)"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo 16 GB requeridos."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在创建 Mac OS X Tiger (Multi DVD) USB"
-          }
-        }
-      }
-    },
-    "Ukończono w %02dm %02ds" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abgeschlossen in %1$02dm %2$02ds"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimum 16 Go requis."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completed in %1$02dm %2$02ds"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È richiesto un minimo di 16 GB."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Completado en %1$02dm %2$02ds"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最低16GBが必要です。"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Termine en %1$02dm %2$02ds"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mínimo 16 GB necessários."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$02d分 %2$02d秒で完了"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется минимум 16 ГБ."
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Ukończono w %1$02dm %2$02ds"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimum 16 GB gereklidir."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concluido em %1$02dm %2$02ds"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необхідно мінімум 16 ГБ."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выполнено за %1$02dм %2$02dс"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yêu cầu tối thiểu 16 GB."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已在 %1$02d分 %2$02d秒 内完成"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "至少需要 16 GB。"
           }
         }
       }
     },
-    "Upewnij się, że wybrany obraz systemu pochodzi ze strony Mavericks Forever. Inne wersje mogą powodować błędy w trakcie tworzenia instalatora na nośniku USB." : {
-      "comment" : "Mavericks detected alert description",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stellen Sie sicher, dass das ausgewählte Systemabbild von der Mavericks Forever-Website stammt. Andere Versionen können Fehler beim Erstellen des USB-Installers verursachen."
+    "Wymagane narzędzie pomocnicze": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erforderliches Hilfswerkzeug"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ensure that the selected system image comes from the Mavericks Forever website. Other versions may cause errors during the USB installer creation."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Required helper tool"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asegúrese de que la imagen del sistema seleccionada provenga del sitio web de Mavericks Forever. Otras versiones pueden causar errores durante la creación del instalador USB."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herramienta auxiliar requerida"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Assurez-vous que l'image système sélectionnée provient du site Web Mavericks Forever. D'autres versions peuvent provoquer des erreurs lors de la création du programme d'installation USB."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Outil auxiliaire requis"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したシステムイメージがMavericks ForeverのWebサイトからのものであることを確認してください。他のバージョンでは、USBインストーラの作成中にエラーが発生する可能性があります。"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Strumento di supporto richiesto"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Certifique-se de que a imagem do sistema selecionada venha do site Mavericks Forever. Outras versões podem causar erros durante a criação do instalador USB."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "必要な補助ツール"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Убедитесь, что выбранный образ системы загружен с сайта Mavericks Forever. Другие версии могут вызвать ошибки при создании установочного USB-накопителя."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ferramenta auxiliar necessaria"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "请确保所选系统镜像来自 Mavericks Forever 网站。其他版本可能会在创建 USB 安装程序时导致错误。"
-          }
-        }
-      }
-    },
-    "Uruchom aplikację ponownie" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anwendung neu starten"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется вспомогательный инструмент"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restart application"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destek aracı gerekli"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar aplicación"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потрібен інструмент підтримки"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redémarrer l'application"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cần có công cụ hỗ trợ"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションを再起動"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要辅助工具"
+          }
+        }
+      }
+    },
+    "Wymagania": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anforderungen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reiniciar aplicativo"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requirements"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перезапустить приложение"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisitos"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重启应用程序"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exigences"
           }
-        }
-      }
-    },
-    "Ustawienia działania w tle…" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen fur Hintergrundaktivitat…"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisiti"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Background activity settings…"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要件"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes de actividad en segundo plano…"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisitos"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reglages activite en arriere-plan…"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требования"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バックグラウンド動作の設定…"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gereksinimler"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes de atividade em segundo plano…"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимоги"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Настройки работы в фоне…"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yêu cầu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "后台运行设置…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要求"
           }
         }
       }
     },
-    "UWAGA!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ACHTUNG!"
+    "Wymagania sprzętowe": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hardwareanforderungen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "WARNING!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hardware Requirements"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡ADVERTENCIA!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisitos de hardware"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ATTENTION !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration matérielle requise"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "警告！"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisiti hardware"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ATENÇÃO!"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハードウェア要件"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ВНИМАНИЕ!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Requisitos de hardware"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "警告！"
-          }
-        }
-      }
-    },
-    "W przypadku Maca z PowerPC" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Für PowerPC-Macs"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требования к оборудованию"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For PowerPC Macs"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donanım gereksinimleri"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para Macs PowerPC"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вимоги до обладнання"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pour les Mac PowerPC"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yêu cầu phần cứng"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PowerPC Mac の場合"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "硬件要求"
+          }
+        }
+      }
+    },
+    "Wymagany restart aplikacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Neustart der Anwendung erforderlich"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Para Macs PowerPC"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Application restart required"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для Mac с PowerPC"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se requiere reiniciar la aplicación"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "对于 PowerPC Mac"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redémarrage de l'application requis"
           }
-        }
-      }
-    },
-    "Wesprzyj projekt macUSB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstütze das macUSB‑Projekt"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "È necessario il riavvio dell'applicazione"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Support the macUSB project"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリケーションの再起動が必要です"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoya el proyecto macUSB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reinicialização do aplicativo necessária"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Soutenir le projet macUSB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требуется перезапуск приложения"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "macUSB プロジェクトを支援"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uygulamanın yeniden başlatılması gerekiyor"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apoie o projeto macUSB"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потрібен перезапуск програми"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поддержать проект macUSB"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yêu cầu khởi động lại ứng dụng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持 macUSB 项目"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要重启应用程序"
           }
         }
       }
     },
-    "Włącz obsługę zewnętrznych dysków twardych" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstützung für externe Festplatten aktivieren"
+    "Wynik operacji": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ergebnis des Vorgangs"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable external hard drive support"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operation result"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar soporte para discos duros externos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultado de la operacion"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer la prise en charge des disques durs externes"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultat de l operation"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "外付けハードドライブのサポートを有効にする"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il risultato dell'operazione"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ativar suporte a discos rígidos externos"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "処理結果"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включить поддержку внешних жестких дисков"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resultado da operacao"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用外部硬盘支持"
-          }
-        }
-      }
-    },
-    "Włącz powiadomienia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Benachrichtigungen aktivieren"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Результат операции"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enable notifications"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operasyonun sonucu"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activar notificaciones"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Результат операції"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activer les notifications"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết quả của hoạt động"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "通知を有効にする"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作结果"
+          }
+        }
+      }
+    },
+    "Wystąpił błąd": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein Fehler ist aufgetreten"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ativar notificações"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "An error occurred"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включить уведомления"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocurrió un error"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "启用通知"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Une erreur est survenue"
           }
-        }
-      }
-    },
-    "Włączony" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktiviert"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Si è verificato un errore"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Enabled"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラーが発生しました"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Activado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocorreu um erro"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Active"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Произошла ошибка"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "有効"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bir hata oluştu"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ativado"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сталася помилка"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Включен"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã xảy ra lỗi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已启用"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "发生错误"
           }
         }
       }
     },
-    "Wróć" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zurueck"
+    "Wyświetl szczegóły": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Details anzeigen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Back"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show details"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Volver"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar detalles"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Retour"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les details"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "戻る"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizza i dettagli"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wróć"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細を表示"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voltar"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar detalhes"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Назад"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать подробности"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "返回"
-          }
-        }
-      }
-    },
-    "Wszystkie dane na wybranym nośniku zostaną usunięte. Czy na pewno chcesz rozpocząć proces?" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Daten auf dem ausgewahlten Laufwerk werden geloscht. Mochtest du den Vorgang wirklich starten?"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayrıntıları görüntüle"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All data on the selected drive will be erased. Are you sure you want to start?"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переглянути деталі"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos los datos de la unidad seleccionada se eliminaran. Seguro que quieres iniciar el proceso?"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Xem chi tiết"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toutes les donnees du support selectionne seront supprimees. Voulez-vous vraiment demarrer le processus ?"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示详细信息"
+          }
+        }
+      }
+    },
+    "XPC health: %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC-Status: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したドライブ上のすべてのデータが削除されます。処理を開始してもよろしいですか？"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC health: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos os dados da unidade selecionada serao apagados. Tem certeza de que deseja iniciar o processo?"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado de XPC: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Все данные на выбранном носителе будут удалены. Вы уверены, что хотите начать процесс?"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "État XPC : %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选磁盘上的所有数据都将被删除。确定要开始此过程吗？"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stato dell'XPC: %@"
           }
-        }
-      }
-    },
-    "Wszystkie pliki na wybranym nośniku USB zostaną bezpowrotnie usunięte!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle Dateien auf dem ausgewählten USB-Laufwerk werden unwiderruflich gelöscht!"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC状態: %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All files on the selected USB drive will be permanently erased!"
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stan XPC: %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Todos los archivos en la memoria USB seleccionada se borrarán permanentemente!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estado do XPC: %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tous les fichiers sur la clé USB sélectionnée seront définitivement effacés !"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Состояние XPC: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したUSBメモリ上のすべてのファイルは完全に消去されます！"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC sağlığı: %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos os arquivos no pen drive selecionado serão apagados permanentemente!"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Здоров'я XPC: %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Все файлы на выбранном USB-накопителе будут безвозвратно удалены!"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tình trạng XPC: %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选 U 盘上的所有文件将被永久清除！"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "XPC 状态：%@"
           }
         }
       }
     },
-    "Wybierz" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen"
+    "Zacznij od początku": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Von vorne beginnen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start over"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empezar de nuevo"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recommencer"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ricominciare"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最初からやり直す"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recomeçar"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择"
-          }
-        }
-      }
-    },
-    "Wybierz docelowy nośnik USB:" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-Ziellaufwerk auswählen:"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Начать сначала"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select target USB drive:"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeniden başla"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccione la memoria USB de destino:"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Почніть спочатку"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez la clé USB cible :"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bắt đầu lại"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "対象のUSBメモリを選択:"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新开始"
+          }
+        }
+      }
+    },
+    "Zakończ i wyjdź": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beenden und schließen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione o pen drive de destino:"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finish and Exit"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите целевой USB-накопитель:"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminar y salir"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择目标 U 盘："
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminer et Quitter"
           }
-        }
-      }
-    },
-    "Wybierz go ręcznie lub przeciągnij powyżej" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wählen Sie es manuell aus oder ziehen Sie es nach oben"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finisci e parti"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select it manually or drag it above"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了して終了"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecciónelo manualmente o arrástrelo arriba"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finalizar e Sair"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionnez-le manuellement ou glissez-le ci-dessus"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершить и выйти"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手動で選択するか、上にドラッグしてください"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitir ve ayrıl"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione manualmente ou arraste acima"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закінчити і піти"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите его вручную или перетащите выше"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kết thúc và rời đi"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手动选择或将其拖到上方"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成并退出"
           }
         }
       }
     },
-    "Wybierz miejsce zapisu pliku z logami diagnostycznymi" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Speicherort für Diagnoseprotokolldatei auswählen"
+    "Zakończono pracę!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeit abgeschlossen!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Select location to save diagnostic logs file"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Work complete!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar ubicación para guardar el archivo de registros de diagnóstico"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Trabajo completado!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner l'emplacement pour enregistrer le fichier de journaux de diagnostic"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Travail terminé !"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "診断ログファイルの保存先を選択"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lavoro completato!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar local para salvar o arquivo de logs de diagnóstico"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作業完了！"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выберите место для сохранения файла журналов диагностики"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trabalho concluído!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择保存诊断日志文件的位置"
-          }
-        }
-      }
-    },
-    "Wybierz..." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Auswählen..."
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Работа завершена!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choose..."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma tamamlandı!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elegir..."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Робота завершена!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Choisir..."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Công việc đã hoàn thành!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作完成！"
+          }
+        }
+      }
+    },
+    "Zamknij": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schließen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Escolher..."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбрать..."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cerrar"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择..."
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fermer"
           }
-        }
-      }
-    },
-    "Wybór nośnika USB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB-Laufwerksauswahl"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vicino"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB Drive Selection"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selección de memoria USB"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fechar"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélection de la clé USB"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрыть"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメモリの選択"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapalı"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleção de pen drive"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрити"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбор USB-накопителя"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đóng"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U 盘选择"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
           }
         }
       }
     },
-    "Wybór pliku" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dateiauswahl"
+    "Zgłoś błąd (GitHub)": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehler melden (GitHub)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "File selection"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Report a bug (GitHub)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selección de archivo"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reportar un error (GitHub)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélection du fichier"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Signaler un bug (GitHub)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファイルの選択"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Segnala un bug (GitHub)"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleção de arquivo"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バグを報告 (GitHub)"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбор файла"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relatar um erro (GitHub)"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "文件选择"
-          }
-        }
-      }
-    },
-    "Wybrana wersja systemu" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewählte Systemversion"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сообщить об ошибке (GitHub)"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected system version"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hata bildirme (GitHub)"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versión del sistema seleccionada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Повідомити про помилку (GitHub)"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version du système sélectionnée"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Báo cáo lỗi (GitHub)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたシステムバージョン"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "报告错误 (GitHub)"
+          }
+        }
+      }
+    },
+    "Русский": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do sistema selecionada"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранная версия системы"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选择系统版本"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
-        }
-      }
-    },
-    "Wybrano nośnik USB 2.0" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB 2.0-Laufwerk ausgewählt"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB 2.0 drive selected"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unidad USB 2.0 seleccionada"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lecteur USB 2.0 sélectionné"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB 2.0ドライブが選択されました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unidade USB 2.0 selecionada"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбран накопитель USB 2.0"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选择 USB 2.0 驱动器"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Русский"
           }
         }
       }
     },
-    "Wybrany folder nie istnieje" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der ausgewaehlte Ordner existiert nicht"
+    "Українська": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The selected folder does not exist"
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La carpeta seleccionada no existe"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le dossier selectionne n existe pas"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したフォルダは存在しません"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybrany folder nie istnieje"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A pasta selecionada nao existe"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранная папка не существует"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选文件夹不存在"
-          }
-        }
-      }
-    },
-    "Wybrany nośnik pracuje w starszym standardzie przesyłu danych. Proces tworzenia instalatora może potrwać kilkanaście minut" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das ausgewählte Laufwerk verwendet einen älteren Datenübertragungsstandard. Die Erstellung des Installers kann einige Minuten dauern."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The selected drive operates on an older data transfer standard. The installer creation process may take several minutes."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La unidad seleccionada utiliza un estándar de transferencia de datos más antiguo. El proceso de creación del instalador puede tardar varios minutos."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le lecteur sélectionné utilise une norme de transfert de données plus ancienne. La création de l'installateur peut prendre plusieurs minutes."
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Українська"
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたドライブは古いデータ転送規格を使用しています。インストーラの作成には十数分かかる場合があります。"
+        }
+      }
+    },
+    "日本語": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A unidade selecionada usa um padrão de transferência de dados mais antigo. O processo de criação do instalador pode levar vários minutos."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранный накопитель использует устаревший стандарт передачи данных. Процесс создания установщика может занять несколько минут."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选驱动器使用的是较旧的数据传输标准。安装程序创建过程可能需要几分钟。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
-        }
-      }
-    },
-    "Wybrany nośnik USB" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewähltes USB-Laufwerk"
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected USB drive"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memoria USB seleccionada"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Clé USB sélectionnée"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたUSBメモリ"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pen drive selecionado"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранный USB-накопитель"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选择 U 盘"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         }
       }
     },
-    "Wybrany nośnik USB ma za małą pojemność" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Kapazität des ausgewählten USB-Laufwerks ist zu gering"
+    "简体中文": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected USB drive capacity is too small"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La capacidad de la memoria USB seleccionada es demasiado pequeña"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La capacité de la clé USB sélectionnée est trop faible"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたUSBメモリの容量が小さすぎます"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A capacidade do pen drive selecionado é muito pequena"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Емкость выбранного USB-накопителя слишком мала"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选 U 盘容量太小"
-          }
-        }
-      }
-    },
-    "Wybrany system" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ausgewaehltes System"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected system"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema seleccionado"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Systeme selectionne"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択したシステム"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "简体中文"
           }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wybrany system"
+        }
+      }
+    },
+    "Przerwano": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abgebrochen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sistema selecionado"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelled"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранная система"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelado"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已选系统"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annulé"
           }
-        }
-      }
-    },
-    "Wybrany system nie jest wspierany przez aplikację" : {
-      "comment" : "Generic unsupported system message",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das ausgewählte System wird von der Anwendung nicht unterstützt"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中止しました"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selected system is not supported by the application"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancelado"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El sistema seleccionado no es compatible con la aplicación"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прервано"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le système sélectionné n'est pas pris en charge par l'application"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已中止"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選択されたシステムはアプリケーションでサポートされていません"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Interrotto"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O sistema selecionado não é compatível com o aplicativo"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасовано"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Выбранная система не поддерживается приложением"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã hủy"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所选系统不受此应用支持"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İptal edildi"
           }
         }
       }
     },
-    "Wykryto kompatybilny instalator" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kompatibler Installer erkannt"
+    "Niepowodzenie!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fehlgeschlagen!"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compatible installer detected"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failure!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se detectó un instalador compatible"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Error!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Installateur compatible détecté"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Échec !"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "互換性のあるインストーラが検出されました"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗！"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Instalador compatível detectado"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Falha!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обнаружен совместимый установщик"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Неудача!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检测到兼容的安装器"
-          }
-        }
-      }
-    },
-    "Wykryto system OS X Mavericks" : {
-      "comment" : "Mavericks detected alert title",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericks erkannt"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失败！"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericks detected"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Errore!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericks detectado"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Невдача!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericks détecté"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thất bại!"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericksが検出されました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başarısız!"
+          }
+        }
+      }
+    },
+    "Sukces!": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfolg!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OS X Mavericks detectado"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Success!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Обнаружена система OS X Mavericks"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "¡Éxito!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "检测到 OS X Mavericks"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Succès !"
           }
-        }
-      }
-    },
-    "Wymaga zatwierdzenia" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Genehmigung erforderlich"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成功！"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requires approval"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sucesso!"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requiere aprobacion"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успех!"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necessite une approbation"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成功！"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "承認が必要"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Successo!"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requer aprovacao"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успіх!"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуется подтверждение"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thành công!"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要批准"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başarılı!"
           }
         }
       }
     },
-    "Wymagana lokalizacja /Applications" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderlicher Speicherort /Applications"
+    "Proces został zatrzymany przez użytkownika": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Der Vorgang wurde vom Benutzer abgebrochen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Required location /Applications"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The process was stopped by the user"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ubicacion requerida /Applications"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El proceso fue interrumpido por el usuario"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Emplacement requis /Applications"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le processus a été interrompu par l’utilisateur"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "必須の場所 /Applications"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスはユーザーによって停止されました"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Local obrigatorio /Applications"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O processo foi interrompido pelo usuário"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуемое расположение /Applications"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процесс был остановлен пользователем"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "必须位置 /Applications"
-          }
-        }
-      }
-    },
-    "Wymagane jest minimum 16 GB." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mindestens 16 GB erforderlich."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该过程已被用户停止"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Min 16GB required."
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il processo è stato interrotto dall’utente"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mínimo 16 GB requeridos."
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Процес зупинено користувачем"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minimum 16 Go requis."
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình đã được người dùng dừng lại"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最低16GBが必要です。"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "İşlem kullanıcı tarafından durduruldu"
+          }
+        }
+      }
+    },
+    "Spróbuj ponownie od początku": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bitte versuchen Sie es von Anfang an erneut"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mínimo 16 GB necessários."
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Try again from the beginning"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуется минимум 16 ГБ."
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inténtalo de nuevo desde el principio"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "至少需要 16 GB。"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réessayez depuis le début"
           }
-        }
-      }
-    },
-    "Wymagane narzędzie pomocnicze" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erforderliches Hilfswerkzeug"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最初からもう一度お試しください"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Required helper tool"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tente novamente desde o início"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herramienta auxiliar requerida"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Попробуйте снова с самого начала"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Outil auxiliaire requis"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请从头再试一次"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "必要な補助ツール"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Riprova dall’inizio"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ferramenta auxiliar necessaria"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Спробуйте ще раз із самого початку"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуется вспомогательный инструмент"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hãy thử lại từ đầu"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要辅助工具"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Baştan tekrar deneyin"
           }
         }
       }
     },
-    "Wymagania" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anforderungen"
+    "Nośnik został przygotowany poprawnie": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das USB-Medium wurde korrekt vorbereitet"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requirements"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The USB media was prepared correctly"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requisitos"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El medio USB se preparó correctamente"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exigences"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le support USB a été préparé correctement"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要件"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USBメディアは正常に準備されました"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requisitos"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A mídia USB foi preparada corretamente"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требования"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-носитель был успешно подготовлен"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "要求"
-          }
-        }
-      }
-    },
-    "Wymagania sprzętowe" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardwareanforderungen"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB 介质已正确准备"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardware Requirements"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il supporto è stato preparato correttamente"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requisitos de hardware"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB-носій підготовлено успішно"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration matérielle requise"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thiết bị USB đã được chuẩn bị thành công"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ハードウェア要件"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "USB ortamı başarıyla hazırlandı"
+          }
+        }
+      }
+    },
+    "Tworzenie nośnika zostało przerwane": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Erstellung des Mediums wurde abgebrochen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Requisitos de hardware"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Media creation was cancelled"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требования к оборудованию"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se canceló la creación del medio"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "硬件要求"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La création du support a été interrompue"
           }
-        }
-      }
-    },
-    "Wymagany restart aplikacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neustart der Anwendung erforderlich"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メディアの作成は中止されました"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Application restart required"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A criação da mídia foi cancelada"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requiere reiniciar la aplicación"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создание носителя было прервано"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redémarrage de l'application requis"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "介质创建已中止"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アプリケーションの再起動が必要です"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La creazione del supporto è stata interrotta"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reinicialização do aplicativo necessária"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створення носія було перервано"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Требуется перезапуск приложения"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quá trình tạo thiết bị đã bị hủy"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要重启应用程序"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ortam oluşturma işlemi iptal edildi"
           }
         }
       }
     },
-    "Wynik operacji" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ergebnis des Vorgangs"
+    "Tworzenie instalatora nie powiodło się": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Erstellung des Installationsprogramms ist fehlgeschlagen"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operation result"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer creation failed"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resultado de la operacion"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La creación del instalador falló"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resultat de l operation"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La création de l’installateur a échoué"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "処理結果"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストーラの作成に失敗しました"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resultado da operacao"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A criação do instalador falhou"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Результат операции"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось создать установщик"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作结果"
-          }
-        }
-      }
-    },
-    "Wystąpił błąd" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ein Fehler ist aufgetreten"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建安装器失败"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An error occurred"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La creazione dell’installer non è riuscita"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocurrió un error"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося створити інсталятор"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Une erreur est survenue"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể tạo bộ cài đặt"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "エラーが発生しました"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yükleyici oluşturulamadı"
+          }
+        }
+      }
+    },
+    "Utworzono instalator systemu": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System-Installationsprogramm erstellt"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocorreu um erro"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System installer created"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Произошла ошибка"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se creó el instalador del sistema"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "发生错误"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’installateur du système a été créé"
           }
-        }
-      }
-    },
-    "Wyświetl szczegóły" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Details anzeigen"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムインストーラが作成されました"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show details"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O instalador do sistema foi criado"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar detalles"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Установщик системы создан"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les details"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统安装器已创建"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "詳細を表示"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Installer di sistema creato"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar detalhes"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Інсталятор системи створено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показать подробности"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã tạo bộ cài đặt hệ thống"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示详细信息"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sistem yükleyicisi oluşturuldu"
           }
         }
       }
     },
-    "XPC health: %@" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC-Status: %@"
+    "Brak uprawnień do zapisu na wybranym nośniku USB. Zresetuj uprawnienia aplikacji w menu Opcje → Resetuj uprawnienia dostępu do dysków zewnętrznych, a następnie spróbuj ponownie.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sie haben keine Berechtigung zum Schreiben auf das ausgewählte USB-Medium. Setzen Sie die App-Berechtigungen über Optionen → „Zugriffsberechtigungen für externe Laufwerke zurücksetzen“ zurück und versuchen Sie es erneut."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC health: %@"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No permission to write to the selected USB media. Reset app permissions in Options → Reset external-drive access permissions, then try again."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de XPC: %@"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No tiene permiso para escribir en el dispositivo USB seleccionado. Restablece los permisos de la app en Opciones → Restablecer permisos de acceso a unidades externas y vuelve a intentarlo."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "État XPC : %@"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vous n’avez pas l’autorisation d’écrire sur le support USB sélectionné. Réinitialisez les autorisations de l’app dans Options → Réinitialiser les autorisations d’accès aux disques externes, puis réessayez."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC状態: %@"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した USB メディアに書き込む権限がありません。オプション → 「外付けドライブのアクセス権をリセット」でアプリの権限をリセットしてから、もう一度お試しください。"
           }
         },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stan XPC: %@"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Você não tem permissão para gravar no dispositivo USB selecionado. Redefina as permissões do app em Opções → Redefinir permissões de acesso a unidades externas e tente novamente."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado do XPC: %@"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет разрешения на запись на выбранный USB-носитель. Сбросьте разрешения приложения через «Опции» → «Сбросить разрешения доступа к внешним дискам», затем попробуйте снова."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Состояние XPC: %@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有权限写入所选 USB 介质。请在“选项”→“重置外部驱动器访问权限”中重置应用权限，然后重试。"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "XPC 状态：%@"
-          }
-        }
-      }
-    },
-    "Zacznij od początku" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Von vorne beginnen"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessuna autorizzazione di scrittura sul supporto USB selezionato. Reimposta i permessi dell’app in Opzioni → Reimposta i permessi di accesso ai dischi esterni, quindi riprova."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Start over"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає дозволу на запис на вибраний USB-носій. Скиньте дозволи програми в меню «Опції» → «Скинути дозволи доступу до зовнішніх дисків», а потім спробуйте ще раз."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empezar de nuevo"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không có quyền ghi vào thiết bị USB đã chọn. Hãy đặt lại quyền của ứng dụng trong Tùy chọn → Đặt lại quyền truy cập ổ đĩa ngoài, rồi thử lại."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recommencer"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seçilen USB ortamına yazma izni yok. Uygulama izinlerini Seçenekler → Harici disk erişim izinlerini sıfırla menüsünden sıfırlayın ve tekrar deneyin."
           }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最初からやり直す"
+        }
+      }
+    },
+    "Nie udało się wyczyścić uprawnień dostępu do dysków zewnętrznych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriffsberechtigungen für externe Laufwerke konnten nicht gelöscht werden"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recomeçar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not clear external-drive access permissions"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Начать сначала"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron borrar los permisos de acceso a unidades externas"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重新开始"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible d’effacer les autorisations d’accès aux disques externes"
           }
-        }
-      }
-    },
-    "Zakończ i wyjdź" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beenden und schließen"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外付けドライブのアクセス権を消去できませんでした"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finish and Exit"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível limpar as permissões de acesso a unidades externas"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminar y salir"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось очистить разрешения доступа к внешним дискам"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminer et Quitter"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法清除外部驱动器访问权限"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完了して終了"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile cancellare i permessi di accesso ai dischi esterni"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Finalizar e Sair"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося очистити дозволи доступу до зовнішніх дисків"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Завершить и выйти"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể xóa quyền truy cập ổ đĩa ngoài"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "完成并退出"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici disk erişim izinleri temizlenemedi"
           }
         }
       }
     },
-    "Zakończono pracę!" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arbeit abgeschlossen!"
+    "Nie udało się zresetować uprawnień dostępu do nośników zewnętrznych. Spróbuj ponownie lub uruchom ręcznie w Terminalu: tccutil reset SystemPolicyRemovableVolumes %@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zugriffsberechtigungen für externe Datenträger konnten nicht zurückgesetzt werden. Versuchen Sie es erneut oder führen Sie diesen Befehl manuell im Terminal aus: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Work complete!"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not reset external-media access permissions. Try again, or run this command manually in Terminal: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¡Trabajo completado!"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No se pudieron restablecer los permisos de acceso a medios externos. Inténtalo de nuevo o ejecuta manualmente este comando en Terminal: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Travail terminé !"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossible de réinitialiser les autorisations d’accès aux supports externes. Réessayez ou exécutez manuellement cette commande dans le Terminal : tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作業完了！"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外部メディアへのアクセス権をリセットできませんでした。再試行するか、次のコマンドをターミナルで手動実行してください: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trabalho concluído!"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Não foi possível redefinir as permissões de acesso a mídias externas. Tente novamente ou execute este comando manualmente no Terminal: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Работа завершена!"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не удалось сбросить разрешения доступа к внешним носителям. Попробуйте снова или выполните эту команду вручную в Терминале: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "工作完成！"
-          }
-        }
-      }
-    },
-    "Zamknij" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schließen"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法重置外部介质访问权限。请重试，或在“终端”中手动运行以下命令：tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Impossibile reimpostare i permessi di accesso ai supporti esterni. Riprova oppure esegui manualmente questo comando in Terminale: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cerrar"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося скинути дозволи доступу до зовнішніх носіїв. Спробуйте ще раз або виконайте цю команду вручну в Терміналі: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fermer"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Không thể đặt lại quyền truy cập thiết bị lưu trữ ngoài. Hãy thử lại hoặc chạy thủ công lệnh sau trong Terminal: tccutil reset SystemPolicyRemovableVolumes %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "閉じる"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici ortam erişim izinleri sıfırlanamadı. Yeniden deneyin veya şu komutu Terminal'de manuel olarak çalıştırın: tccutil reset SystemPolicyRemovableVolumes %@"
+          }
+        }
+      }
+    },
+    "Resetuj uprawnienia dostępu do dysków zewnętrznych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriffsberechtigungen für externe Laufwerke zurücksetzen"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fechar"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset external-drive access permissions"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Закрыть"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer permisos de acceso a unidades externas"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser les autorisations d’accès aux disques externes"
           }
-        }
-      }
-    },
-    "Zgłoś błąd (GitHub)" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler melden (GitHub)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外付けドライブのアクセス権をリセット"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Report a bug (GitHub)"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir permissões de acesso a unidades externas"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reportar un error (GitHub)"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить разрешения доступа к внешним дискам"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaler un bug (GitHub)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置外部驱动器访问权限"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "バグを報告 (GitHub)"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reimposta i permessi di accesso ai dischi esterni"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Relatar um erro (GitHub)"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути дозволи доступу до зовнішніх дисків"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщить об ошибке (GitHub)"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đặt lại quyền truy cập ổ đĩa ngoài"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "报告错误 (GitHub)"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici disk erişim izinlerini sıfırla"
           }
         }
       }
     },
-    "Русский" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+    "Uprawnienia aplikacji macUSB do nośników zewnętrznych zostały zresetowane. Przy kolejnej próbie tworzenia nośnika system poprosi ponownie o zgodę.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die macUSB-Berechtigungen für externe Datenträger wurden zurückgesetzt. Beim nächsten Versuch, einen USB-Installer zu erstellen, fragt das System erneut nach der Erlaubnis."
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB permissions for external media have been reset. The system will ask for permission again the next time you try to create a USB installer."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se restablecieron los permisos de macUSB para medios externos. La próxima vez que intentes crear un instalador USB, el sistema volverá a pedir permiso."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les autorisations de macUSB pour les supports externes ont été réinitialisées. Lors de la prochaine tentative de création d’un installateur USB, le système demandera de nouveau l’autorisation."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB の外部メディアに対する権限をリセットしました。次回 USB インストーラを作成するときに、システムが再度許可を求めます。"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As permissões do macUSB para mídias externas foram redefinidas. Na próxima tentativa de criar um instalador USB, o sistema solicitará a permissão novamente."
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения macUSB для внешних носителей были сброшены. При следующей попытке создать USB-установщик система снова запросит доступ."
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Русский"
-          }
-        }
-      }
-    },
-    "日本語" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 对外部介质的权限已重置。下次尝试创建 USB 安装器时，系统会再次请求授权。"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I permessi di macUSB per i supporti esterni sono stati reimpostati. Al prossimo tentativo di creare un installer USB, il sistema richiederà nuovamente il consenso."
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволи macUSB для зовнішніх носіїв було скинуто. Під час наступної спроби створити USB-інсталятор система знову попросить дозвіл."
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Quyền của macUSB đối với thiết bị lưu trữ ngoài đã được đặt lại. Ở lần tiếp theo khi bạn tạo bộ cài USB, hệ thống sẽ yêu cầu cấp quyền lại."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB’nin harici ortamlar için izinleri sıfırlandı. Bir sonraki USB yükleyici oluşturma denemesinde sistem izni yeniden isteyecek."
+          }
+        }
+      }
+    },
+    "Wyczyszczono uprawnienia dostępu do dysków zewnętrznych": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugriffsberechtigungen für externe Laufwerke wurden gelöscht"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "External-drive access permissions cleared"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Se borraron los permisos de acceso a unidades externas"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "日本語"
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les autorisations d’accès aux disques externes ont été effacées"
           }
-        }
-      }
-    },
-    "简体中文" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "外付けドライブのアクセス権を消去しました"
           }
         },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As permissões de acesso a unidades externas foram limpas"
           }
         },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения доступа к внешним дискам очищены"
           }
         },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已清除外部驱动器访问权限"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I permessi di accesso ai dischi esterni sono stati cancellati"
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволи доступу до зовнішніх дисків очищено"
           }
         },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đã xóa quyền truy cập ổ đĩa ngoài"
           }
         },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "简体中文"
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Harici disk erişim izinleri temizlendi"
           }
         }
       }
     }
   },
-  "version" : "1.1"
+  "version": "1.1"
 }

--- a/macUSB/Shared/Services/LanguageManager.swift
+++ b/macUSB/Shared/Services/LanguageManager.swift
@@ -13,7 +13,11 @@ class LanguageManager: ObservableObject {
         "es",       // Hiszpański
         "pt-BR",    // Portugalski (Brazylia)
         "zh-Hans",  // Chiński Uproszczony
-        "ru"        // Rosyjski
+        "ru",       // Rosyjski
+        "it",       // Włoski
+        "uk",       // Ukraiński
+        "vi",       // Wietnamski
+        "tr"        // Turecki
     ]
 
     // Sprawdza, czy dany identyfikator jest wspierany (dokładnie lub po prefiksie języka)


### PR DESCRIPTION
Add full IT/UK/VI/TR language support across app configuration and language menu.

Complete and correct string catalog translations, including finish-screen and permission-error texts.

Replace external-settings menu link with an Options action that runs tccutil reset and shows localized success/failure alerts.

Update DEVELOPMENT.md to reflect localization rules and current menu behavior.