### PR TITLE
Isolate debug helper identity from release runtime

### DIFF
--- a/docs/reference/features/helper/HELPER.md
+++ b/docs/reference/features/helper/HELPER.md
@@ -253,6 +253,7 @@ Diagnostics should allow answering:
 - DEBUG-only helper/debug UI must not leak into Release.
 - Runtime helper invariants are identical across build configurations.
 - Any debug convenience path must not alter production helper semantics.
+- DEBUG and Release must use isolated helper identity tuples (`bundle id`, daemon plist name, daemon label, mach service) to avoid BTM/TCC cross-environment collisions.
 
 ---
 

--- a/docs/reference/platform/DEBUG_CONTRACT.md
+++ b/docs/reference/platform/DEBUG_CONTRACT.md
@@ -8,6 +8,7 @@ Release must not expose DEBUG controls.
 ## Runtime Safety
 
 Debug routing and helper/debug convenience actions must remain deterministic and must not change production semantics.
+Debug helper identity must stay isolated from Release (`bundle id`, daemon plist name, daemon label, mach service).
 
 ## Current Examples
 

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -9,9 +9,10 @@
 /* Begin PBXBuildFile section */
 		0F0460D42EF45FFC00C6F937 /* version.json in Resources */ = {isa = PBXBuildFile; fileRef = 0F1D673B2EEF235A00EC9CA8 /* version.json */; };
 		0FB1C3B02EEC7E6700A86E0F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0FB1C3AF2EEC7E5F00A86E0F /* README.md */; };
-		A10000012F00000100000001 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000006 /* main.swift */; };
-		A10000012F00000100000002 /* macUSBHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000005 /* macUSBHelper */; };
-		A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */; };
+			A10000012F00000100000001 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000006 /* main.swift */; };
+			A10000012F00000100000002 /* macUSBHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000005 /* macUSBHelper */; };
+			A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */; };
+			A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */; };
 		A10000012F00000100000031 /* IPC/HelperIPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000021 /* IPC/HelperIPC.swift */; };
 		A10000012F00000100000032 /* Service/PrivilegedHelperService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000022 /* Service/PrivilegedHelperService.swift */; };
 		A10000012F00000100000033 /* Service/HelperListenerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000023 /* Service/HelperListenerDelegate.swift */; };
@@ -65,16 +66,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A10000012F00000100000009 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = Contents/Library/LaunchDaemons;
-			dstSubfolderSpec = 1;
-			files = (
-				A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+			A10000012F00000100000009 /* CopyFiles */ = {
+				isa = PBXCopyFilesBuildPhase;
+				buildActionMask = 2147483647;
+				dstPath = Contents/Library/LaunchDaemons;
+				dstSubfolderSpec = 1;
+				files = (
+					A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */,
+					A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */,
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+			};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -85,10 +87,11 @@
 		0FB1C3772EEC7B5A00A86E0F /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		0FB1C3AC2EEC7C8D00A86E0F /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		0FB1C3AF2EEC7E5F00A86E0F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		A10000012F00000100000005 /* macUSBHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macUSBHelper; sourceTree = BUILT_PRODUCTS_DIR; };
-		A10000012F00000100000006 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist; sourceTree = "<group>"; };
-		A10000012F00000100000013 /* macUSBHelper.debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.debug.entitlements; sourceTree = "<group>"; };
+			A10000012F00000100000005 /* macUSBHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macUSBHelper; sourceTree = BUILT_PRODUCTS_DIR; };
+			A10000012F00000100000006 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+			A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist; sourceTree = "<group>"; };
+			A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist; sourceTree = "<group>"; };
+			A10000012F00000100000013 /* macUSBHelper.debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.debug.entitlements; sourceTree = "<group>"; };
 		A10000012F00000100000014 /* macUSBHelper.release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.release.entitlements; sourceTree = "<group>"; };
 		A10000012F00000100000021 /* IPC/HelperIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPC/HelperIPC.swift; sourceTree = "<group>"; };
 		A10000012F00000100000022 /* Service/PrivilegedHelperService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service/PrivilegedHelperService.swift; sourceTree = "<group>"; };
@@ -376,13 +379,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0FC49EED2F3E823C00F847B1 /* Recovered References */ = {
-			isa = PBXGroup;
-			children = (
-				A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */,
-				B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */,
-				D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */,
-			);
+			0FC49EED2F3E823C00F847B1 /* Recovered References */ = {
+				isa = PBXGroup;
+				children = (
+					A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */,
+					A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */,
+					B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */,
+					D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */,
+				);
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
@@ -827,7 +831,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 2.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macUSB;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macUSB.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
@@ -998,7 +1002,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macusb.helper;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macusb.helper.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist
+++ b/macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AssociatedBundleIdentifiers</key>
+	<array>
+		<string>com.kruszoneq.macUSB.debug</string>
+	</array>
+	<key>Label</key>
+	<string>com.kruszoneq.macusb.helper.debug</string>
+	<key>BundleProgram</key>
+	<string>Contents/Library/Helpers/macUSBHelper</string>
+	<key>MachServices</key>
+	<dict>
+		<key>com.kruszoneq.macusb.helper.debug</key>
+		<true/>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+</dict>
+</plist>

--- a/macUSB/Shared/Services/Helper/HelperServiceManager.swift
+++ b/macUSB/Shared/Services/Helper/HelperServiceManager.swift
@@ -6,8 +6,13 @@ import Darwin
 final class HelperServiceManager: NSObject {
     static let shared = HelperServiceManager()
 
+    #if DEBUG
+    static let daemonPlistName = "com.kruszoneq.macusb.helper.debug.plist"
+    static let machServiceName = "com.kruszoneq.macusb.helper.debug"
+    #else
     static let daemonPlistName = "com.kruszoneq.macusb.helper.plist"
     static let machServiceName = "com.kruszoneq.macusb.helper"
+    #endif
     static let helperRepairFingerprintDefaultsKey = "macUSB.Helper.LastSuccessfulAutoRepairFingerprint"
 
     typealias EnsureCompletion = (Bool, String?) -> Void

--- a/macUSBHelper/main.swift
+++ b/macUSBHelper/main.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 private let delegate = HelperListenerDelegate()
-private let listener = NSXPCListener(machServiceName: "com.kruszoneq.macusb.helper")
+#if DEBUG
+private let machServiceName = "com.kruszoneq.macusb.helper.debug"
+#else
+private let machServiceName = "com.kruszoneq.macusb.helper"
+#endif
+private let listener = NSXPCListener(machServiceName: machServiceName)
 listener.delegate = delegate
 listener.resume()
 dispatchMain()


### PR DESCRIPTION
This PR separates helper identity between Debug and Release builds to prevent Background Task Management (BTM) and TCC collisions when switching between Xcode (DerivedData) runs and the app installed in /Applications. It introduces Debug-specific app/helper bundle identifiers, a dedicated debug LaunchDaemon plist, and build-configuration-based wiring for helper daemon plist and mach service selection, while keeping Release helper identity and runtime paths unchanged.