### PR TITLE
Stabilize Linux USB unmount flow and APFS readability detection

### DIFF
--- a/docs/reference/features/helper/HELPER.md
+++ b/docs/reference/features/helper/HELPER.md
@@ -106,6 +106,7 @@ Serialization:
 Contract invariants:
 - Stage keys and status keys are treated as stable technical identifiers.
 - App-side localization rendering must stay compatible with helper payload content.
+- Helper workflow `stageTitleKey` and `statusKey` values must be localization catalog keys only (no user-facing literal strings in payload fields).
 - IPC shape changes are major helper changes and require explicit confirmation before implementation.
 
 ---

--- a/docs/reference/platform/LOCALIZATION_CONTRACT.md
+++ b/docs/reference/platform/LOCALIZATION_CONTRACT.md
@@ -10,6 +10,7 @@
 - Static UI text should map cleanly through localization catalog.
 - Runtime non-`Text` user-facing strings should use `String(localized:)`.
 - Helper localization keys and app-side rendering keys must stay synchronized.
+- In helper workflow transport/rendering, `titleKey` and `statusKey` fields must always carry localization catalog keys, never prelocalized literal text.
 
 ## Language Set Consistency
 

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -9,10 +9,9 @@
 /* Begin PBXBuildFile section */
 		0F0460D42EF45FFC00C6F937 /* version.json in Resources */ = {isa = PBXBuildFile; fileRef = 0F1D673B2EEF235A00EC9CA8 /* version.json */; };
 		0FB1C3B02EEC7E6700A86E0F /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 0FB1C3AF2EEC7E5F00A86E0F /* README.md */; };
-			A10000012F00000100000001 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000006 /* main.swift */; };
-			A10000012F00000100000002 /* macUSBHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000005 /* macUSBHelper */; };
-			A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */; };
-			A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */; };
+		A10000012F00000100000001 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000006 /* main.swift */; };
+		A10000012F00000100000002 /* macUSBHelper in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000005 /* macUSBHelper */; };
+		A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */; };
 		A10000012F00000100000031 /* IPC/HelperIPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000021 /* IPC/HelperIPC.swift */; };
 		A10000012F00000100000032 /* Service/PrivilegedHelperService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000022 /* Service/PrivilegedHelperService.swift */; };
 		A10000012F00000100000033 /* Service/HelperListenerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000023 /* Service/HelperListenerDelegate.swift */; };
@@ -26,6 +25,8 @@
 		A10000012F0000010000003E /* Workflow/Linux/HelperWorkflowLinuxStages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003B /* Workflow/Linux/HelperWorkflowLinuxStages.swift */; };
 		A10000012F0000010000003F /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003C /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift */; };
 		A10000012F00000100000040 /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003D /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift */; };
+		A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */; };
+		A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */; };
 		B10000012F00000100000001 /* macUSB/Resources/Sounds/burn_complete.aif in Resources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */; };
 		C10000012F00000100000001 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */; };
 		D10000012F00000100000001 /* macUSB/Resources/Icons/Linux/Distros in Resources */ = {isa = PBXBuildFile; fileRef = D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */; };
@@ -66,17 +67,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-			A10000012F00000100000009 /* CopyFiles */ = {
-				isa = PBXCopyFilesBuildPhase;
-				buildActionMask = 2147483647;
-				dstPath = Contents/Library/LaunchDaemons;
-				dstSubfolderSpec = 1;
-				files = (
-					A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */,
-					A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */,
-				);
-				runOnlyForDeploymentPostprocessing = 0;
-			};
+		A10000012F00000100000009 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = Contents/Library/LaunchDaemons;
+			dstSubfolderSpec = 1;
+			files = (
+				A10000012F00000100000003 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist in CopyFiles */,
+				A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -87,11 +88,10 @@
 		0FB1C3772EEC7B5A00A86E0F /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		0FB1C3AC2EEC7C8D00A86E0F /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		0FB1C3AF2EEC7E5F00A86E0F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-			A10000012F00000100000005 /* macUSBHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macUSBHelper; sourceTree = BUILT_PRODUCTS_DIR; };
-			A10000012F00000100000006 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-			A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist; sourceTree = "<group>"; };
-			A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist; sourceTree = "<group>"; };
-			A10000012F00000100000013 /* macUSBHelper.debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.debug.entitlements; sourceTree = "<group>"; };
+		A10000012F00000100000005 /* macUSBHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = macUSBHelper; sourceTree = BUILT_PRODUCTS_DIR; };
+		A10000012F00000100000006 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist; sourceTree = "<group>"; };
+		A10000012F00000100000013 /* macUSBHelper.debug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.debug.entitlements; sourceTree = "<group>"; };
 		A10000012F00000100000014 /* macUSBHelper.release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macUSBHelper.release.entitlements; sourceTree = "<group>"; };
 		A10000012F00000100000021 /* IPC/HelperIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPC/HelperIPC.swift; sourceTree = "<group>"; };
 		A10000012F00000100000022 /* Service/PrivilegedHelperService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Service/PrivilegedHelperService.swift; sourceTree = "<group>"; };
@@ -106,6 +106,8 @@
 		A10000012F0000010000003B /* Workflow/Linux/HelperWorkflowLinuxStages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxStages.swift; sourceTree = "<group>"; };
 		A10000012F0000010000003C /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift; sourceTree = "<group>"; };
 		A10000012F0000010000003D /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxDiskOps.swift; sourceTree = "<group>"; };
+		A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift; sourceTree = "<group>"; };
+		A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist; sourceTree = "<group>"; };
 		B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = macUSB/Resources/Sounds/burn_complete.aif; sourceTree = "<group>"; };
 		C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift; sourceTree = "<group>"; };
 		D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */ = {isa = PBXFileReference; lastKnownFileType = folder; path = macUSB/Resources/Icons/Linux/Distros; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 				Features/Installation/Linux/CreationProgressLinuxMapping.swift,
 				Features/Installation/Linux/CreatorLinuxHelperLogic.swift,
 				Features/Installation/Linux/CreatorLinuxLogic.swift,
+				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/UniversalInstallationView.swift,
 				Features/Welcome/WelcomeView.swift,
@@ -265,6 +268,7 @@
 				Features/Installation/Linux/CreationProgressLinuxMapping.swift,
 				Features/Installation/Linux/CreatorLinuxHelperLogic.swift,
 				Features/Installation/Linux/CreatorLinuxLogic.swift,
+				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/UniversalInstallationView.swift,
 				Features/Welcome/WelcomeView.swift,
@@ -379,14 +383,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-			0FC49EED2F3E823C00F847B1 /* Recovered References */ = {
-				isa = PBXGroup;
-				children = (
-					A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */,
-					A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */,
-					B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */,
-					D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */,
-				);
+		0FC49EED2F3E823C00F847B1 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				A10000012F00000100000007 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.plist */,
+				A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */,
+				B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */,
+				D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */,
+			);
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
@@ -405,6 +409,7 @@
 				A10000012F0000010000003B /* Workflow/Linux/HelperWorkflowLinuxStages.swift */,
 				A10000012F0000010000003C /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift */,
 				A10000012F0000010000003D /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift */,
+				A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */,
 				A10000012F00000100000029 /* DownloaderAssembly/DownloaderAssemblyExecutor.swift */,
 				A10000012F0000010000002A /* DownloaderAssembly/DownloaderAssemblyProcess.swift */,
 				C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */,
@@ -636,6 +641,7 @@
 				A10000012F0000010000003E /* Workflow/Linux/HelperWorkflowLinuxStages.swift in Sources */,
 				A10000012F0000010000003F /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift in Sources */,
 				A10000012F00000100000040 /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift in Sources */,
+				A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */,
 				A10000012F00000100000039 /* DownloaderAssembly/DownloaderAssemblyExecutor.swift in Sources */,
 				A10000012F0000010000003A /* DownloaderAssembly/DownloaderAssemblyProcess.swift in Sources */,
 			);

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
@@ -113,7 +113,8 @@ extension AnalysisLogic {
                                             defer { self.isAnalyzing = false }
 
                                             if let linuxResult {
-                                                self.applyLinuxDetectionResult(linuxResult, sourceURL: url, mountedImagePath: nil)
+                                                let mountPathForFallback = self.mountedDMGPath
+                                                self.applyLinuxDetectionResult(linuxResult, sourceURL: url, mountedImagePath: mountPathForFallback)
                                                 return
                                             }
 

--- a/macUSB/Features/Analysis/Logic/Linux/AnalysisLogicLinuxLifecycle.swift
+++ b/macUSB/Features/Analysis/Logic/Linux/AnalysisLogicLinuxLifecycle.swift
@@ -96,6 +96,20 @@ extension AnalysisLogic {
         return 8
     }
 
+    private func resolveLinuxSourceFileSizeBytes(for sourceURL: URL) -> (bytes: Int64, source: String)? {
+        if let values = try? sourceURL.resourceValues(forKeys: [.fileSizeKey]),
+           let fileSize = values.fileSize {
+            return (Int64(fileSize), "fileSizeKey")
+        }
+
+        if let attributes = try? FileManager.default.attributesOfItem(atPath: sourceURL.path),
+           let size = attributes[.size] as? NSNumber {
+            return (size.int64Value, "attributesOfItem")
+        }
+
+        return nil
+    }
+
     private func loadLinuxDetectedSystemIcon(for distro: String?) -> NSImage? {
         if let distro, let distroIcon = loadLinuxDistroIcon(for: distro) {
             self.log("Załadowano ikonę Linux distro: \(distro)")
@@ -237,12 +251,10 @@ extension AnalysisLogic {
         self.isPPC = false
         self.legacyArchInfo = nil
         self.userSkippedAnalysis = false
-        if let values = try? sourceURL.resourceValues(forKeys: [.fileSizeKey]),
-           let fileSize = values.fileSize {
-            let fileSizeBytes = Int64(fileSize)
-            let requiredGB = linuxRequiredUSBCapacityGB(fromFileSizeBytes: fileSizeBytes)
+        if let fileSizeResolution = resolveLinuxSourceFileSizeBytes(for: sourceURL) {
+            let requiredGB = linuxRequiredUSBCapacityGB(fromFileSizeBytes: fileSizeResolution.bytes)
             self.requiredUSBCapacityGB = requiredGB
-            self.log("Linux source size: \(fileSizeBytes) bytes")
+            self.log("Linux source size: \(fileSizeResolution.bytes) bytes (source=\(fileSizeResolution.source))")
             self.log("Linux required USB threshold: \(requiredGB) GB")
         } else {
             self.requiredUSBCapacityGB = nil

--- a/macUSB/Features/Finish/FinishUSBView.swift
+++ b/macUSB/Features/Finish/FinishUSBView.swift
@@ -17,6 +17,7 @@ struct FinishUSBView: View {
     let cleanupTempWorkURL: URL?
     let shouldDetachMountPoint: Bool
     let detectedSystemIcon: NSImage?
+    let resultDetailMessage: String?
     
     @State private var isCleaning: Bool = true
     @State private var cleanupSuccess: Bool = false
@@ -36,7 +37,8 @@ struct FinishUSBView: View {
         creationStartedAt: Date? = nil,
         cleanupTempWorkURL: URL? = nil,
         shouldDetachMountPoint: Bool = true,
-        detectedSystemIcon: NSImage? = nil
+        detectedSystemIcon: NSImage? = nil,
+        resultDetailMessage: String? = nil
     ) {
         self.systemName = systemName
         self.mountPoint = mountPoint
@@ -49,6 +51,7 @@ struct FinishUSBView: View {
         self.cleanupTempWorkURL = cleanupTempWorkURL
         self.shouldDetachMountPoint = shouldDetachMountPoint
         self.detectedSystemIcon = detectedSystemIcon
+        self.resultDetailMessage = resultDetailMessage
     }
     
     private var isSnowLeopard: Bool {
@@ -134,6 +137,26 @@ struct FinishUSBView: View {
                                     Text(verbatim: systemName)
                                         .font(.headline)
                                         .foregroundColor(.primary)
+                                }
+                                Spacer()
+                            }
+                        }
+                    }
+
+                    if let resultDetailMessage, !resultDetailMessage.isEmpty {
+                        StatusCard(tone: isCancelledResult ? .warning : .error, density: .compact) {
+                            HStack(alignment: .top) {
+                                Image(systemName: "info.circle.fill")
+                                    .font(sectionIconFont)
+                                    .foregroundColor(isCancelledResult ? .orange : .red)
+                                    .frame(width: MacUSBDesignTokens.iconColumnWidth)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(isCancelledResult ? String(localized: "Szczegóły przerwania") : String(localized: "Szczegóły błędu"))
+                                        .font(.headline)
+                                        .foregroundColor(isCancelledResult ? .orange : .red)
+                                    Text(resultDetailMessage)
+                                        .font(.subheadline)
+                                        .foregroundColor(isCancelledResult ? .orange.opacity(0.9) : .red.opacity(0.85))
                                 }
                                 Spacer()
                             }

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -41,6 +41,7 @@ struct CreationProgressView: View {
     @Binding var isCancelling: Bool
     @Binding var navigateToFinish: Bool
     @Binding var helperOperationFailed: Bool
+    @Binding var workflowResultDetailMessage: String?
     @Binding var didCancelCreation: Bool
     @Binding var creationStartedAt: Date?
     private var sectionIconFont: Font { .title3 }
@@ -171,7 +172,8 @@ struct CreationProgressView: View {
                     didCancel: didCancelCreation,
                     creationStartedAt: creationStartedAt,
                     shouldDetachMountPoint: shouldDetachMountPoint,
-                    detectedSystemIcon: detectedSystemIcon
+                    detectedSystemIcon: detectedSystemIcon,
+                    resultDetailMessage: workflowResultDetailMessage
                 ),
                 isActive: $navigateToFinish
             ) { EmptyView() }

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -221,7 +221,7 @@ struct CreationProgressView: View {
                                 .foregroundColor(.accentColor)
                         }
                     }
-                    Text(LocalizedStringKey(helperStatusKey.isEmpty ? "Rozpoczynanie..." : helperStatusKey))
+                    Text(LocalizedStringKey(helperStatusKey.isEmpty ? HelperWorkflowLocalizationKeys.initializingStatus : helperStatusKey))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     if shouldShowCopyProgress(for: stage.key) {

--- a/macUSB/Features/Installation/CreatorHelperLogic.swift
+++ b/macUSB/Features/Installation/CreatorHelperLogic.swift
@@ -40,6 +40,7 @@ extension UniversalInstallationView {
         processingSubtitle = String(localized: "Przygotowywanie operacji...")
         isHelperWorking = false
         errorMessage = ""
+        workflowResultDetailMessage = nil
         navigateToFinish = false
         didCancelCreation = false
         cancellationRequestedBeforeWorkflowStart = false
@@ -112,13 +113,13 @@ extension UniversalInstallationView {
 
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    let request = try prepareHelperWorkflowRequest(for: drive)
-                    let transferTotals = calculateTransferStageTotals(for: request)
+                    var workflowRequest = try prepareHelperWorkflowRequest(for: drive)
+                    let transferTotals = calculateTransferStageTotals(for: workflowRequest)
                     DispatchQueue.main.async {
-                        helperTransferMonitoringRequestedBSDName = request.targetBSDName
-                        helperTransferMonitoringWholeDiskBSDName = extractWholeDiskName(from: request.targetBSDName)
-                        helperTransferMonitoringTargetVolumePath = request.targetVolumePath
-                        helperTransferMonitoringLastKnownPath = request.targetVolumePath
+                        helperTransferMonitoringRequestedBSDName = workflowRequest.targetBSDName
+                        helperTransferMonitoringWholeDiskBSDName = extractWholeDiskName(from: workflowRequest.targetBSDName)
+                        helperTransferMonitoringTargetVolumePath = workflowRequest.targetVolumePath
+                        helperTransferMonitoringLastKnownPath = workflowRequest.targetVolumePath
 
                         withAnimation {
                             isProcessing = false
@@ -152,7 +153,7 @@ extension UniversalInstallationView {
                         var startHelperWorkflow: ((Bool) -> Void)!
                         startHelperWorkflow = { allowCompatibilityRecovery in
                             PrivilegedOperationClient.shared.startWorkflow(
-                                request: request,
+                                request: workflowRequest,
                                 onEvent: { event in
                                     guard event.workflowID == activeHelperWorkflowID else { return }
                                     let normalizedStageKey = canonicalStageKeyForPresentation(event.stageKey)
@@ -197,7 +198,35 @@ extension UniversalInstallationView {
                                         return
                                     }
 
+                                    if shouldPromptLinuxForceUnmountAlert(for: result) {
+                                        showLinuxForceUnmountAlert(
+                                            onForce: {
+                                                workflowResultDetailMessage = nil
+                                                let forcedRequest = makeLinuxForceUnmountRequest(from: workflowRequest)
+                                                workflowRequest = forcedRequest
+                                                helperStageTitleKey = String(localized: "Uruchamianie procesu")
+                                                helperStatusKey = String(localized: "Rozpoczynanie...")
+                                                helperCurrentStageKey = ""
+                                                helperProgressPercent = 0
+                                                helperCopyProgressPercent = 0
+                                                helperWriteSpeedText = "- MB/s"
+                                                withAnimation {
+                                                    isHelperWorking = true
+                                                }
+                                                log("LinuxInstallFlow: użytkownik wyraził zgodę na wymuszenie odmontowania nośnika.", category: "LinuxInstallFlow")
+                                                startHelperWorkflow(true)
+                                            },
+                                            onCancel: {
+                                                workflowResultDetailMessage = String(localized: "Nośnik USB był używany przez inną aplikację. Nie wyrażono zgody na wymuszenie odmontowania, dlatego proces został przerwany. Zamknij aplikacje korzystające z nośnika i spróbuj ponownie.")
+                                                log("LinuxInstallFlow: użytkownik odmówił wymuszonego odmontowania nośnika.", category: "LinuxInstallFlow")
+                                                performLinuxUnmountDeclinedCleanupAndCancel()
+                                            }
+                                        )
+                                        return
+                                    }
+
                                     helperOperationFailed = !result.success
+                                    workflowResultDetailMessage = result.success ? nil : result.errorMessage
 
                                     if !result.success, let errorMessageText = result.errorMessage {
                                         logError("Helper zakończył się błędem: \(errorMessageText)", category: "Installation")
@@ -255,10 +284,10 @@ extension UniversalInstallationView {
                                     helperTransferFallbackBytes = 0
                                     helperTransferFallbackStageKey = ""
                                     helperTransferFallbackLastSampleAt = nil
-                                    helperTransferMonitoringRequestedBSDName = request.targetBSDName
-                                    helperTransferMonitoringWholeDiskBSDName = extractWholeDiskName(from: request.targetBSDName)
-                                    helperTransferMonitoringTargetVolumePath = request.targetVolumePath
-                                    helperTransferMonitoringLastKnownPath = request.targetVolumePath
+                                    helperTransferMonitoringRequestedBSDName = workflowRequest.targetBSDName
+                                    helperTransferMonitoringWholeDiskBSDName = extractWholeDiskName(from: workflowRequest.targetBSDName)
+                                    helperTransferMonitoringTargetVolumePath = workflowRequest.targetVolumePath
+                                    helperTransferMonitoringLastKnownPath = workflowRequest.targetVolumePath
                                     MenuState.shared.updateDebugCopiedData(bytes: 0)
                                     startHelperWriteSpeedMonitoring(for: drive)
                                     log("Uruchomiono helper workflow: \(workflowID)")
@@ -326,7 +355,8 @@ extension UniversalInstallationView {
                 isSierra: false,
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
-                requesterUID: requesterUID
+                requesterUID: requesterUID,
+                linuxForceUnmount: false
             )
         }
 
@@ -354,7 +384,8 @@ extension UniversalInstallationView {
                 isSierra: false,
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
-                requesterUID: requesterUID
+                requesterUID: requesterUID,
+                linuxForceUnmount: false
             )
         }
 
@@ -373,7 +404,8 @@ extension UniversalInstallationView {
                 isSierra: false,
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
-                requesterUID: requesterUID
+                requesterUID: requesterUID,
+                linuxForceUnmount: false
             )
         }
 
@@ -391,7 +423,8 @@ extension UniversalInstallationView {
             isSierra: isSierra,
             needsCodesign: needsCodesign,
             requiresApplicationPathArg: isLegacySystem || isSierra,
-            requesterUID: requesterUID
+            requesterUID: requesterUID,
+            linuxForceUnmount: false
         )
     }
 

--- a/macUSB/Features/Installation/CreatorHelperLogic.swift
+++ b/macUSB/Features/Installation/CreatorHelperLogic.swift
@@ -49,8 +49,8 @@ extension UniversalInstallationView {
         processingIcon = "lock.shield.fill"
         isCancelled = false
         helperProgressPercent = 0
-        helperStageTitleKey = "Przygotowanie"
-        helperStatusKey = "Przygotowywanie operacji..."
+        helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+        helperStatusKey = HelperWorkflowLocalizationKeys.startingStatus
         helperCurrentStageKey = ""
         helperWriteSpeedText = "- MB/s"
         helperCopyProgressPercent = 0
@@ -125,8 +125,8 @@ extension UniversalInstallationView {
                             isProcessing = false
                             isHelperWorking = true
                             helperProgressPercent = 0
-                            helperStageTitleKey = "Uruchamianie procesu"
-                            helperStatusKey = "Rozpoczynanie..."
+                            helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                            helperStatusKey = HelperWorkflowLocalizationKeys.initializingStatus
                             helperTransferStageTotals = transferTotals
                         }
 
@@ -204,8 +204,8 @@ extension UniversalInstallationView {
                                                 workflowResultDetailMessage = nil
                                                 let forcedRequest = makeLinuxForceUnmountRequest(from: workflowRequest)
                                                 workflowRequest = forcedRequest
-                                                helperStageTitleKey = String(localized: "Uruchamianie procesu")
-                                                helperStatusKey = String(localized: "Rozpoczynanie...")
+                                                helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                                                helperStatusKey = HelperWorkflowLocalizationKeys.initializingStatus
                                                 helperCurrentStageKey = ""
                                                 helperProgressPercent = 0
                                                 helperCopyProgressPercent = 0
@@ -250,8 +250,8 @@ extension UniversalInstallationView {
                                     }
 
                                     log("Wykryto niezgodność kontraktu IPC helpera. Rozpoczynam automatyczne przeładowanie helpera.", category: "Installation")
-                                    helperStageTitleKey = "Rozpoczynanie..."
-                                    helperStatusKey = "Przygotowywanie operacji..."
+                                    helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                                    helperStatusKey = HelperWorkflowLocalizationKeys.startingStatus
 
                                     HelperServiceManager.shared.forceReloadForIPCContractMismatch { ready, recoveryMessage in
                                         guard ready else {
@@ -259,8 +259,8 @@ extension UniversalInstallationView {
                                             return
                                         }
 
-                                        helperStageTitleKey = "Rozpoczynanie..."
-                                        helperStatusKey = "Przygotowywanie operacji..."
+                                        helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                                        helperStatusKey = HelperWorkflowLocalizationKeys.startingStatus
                                         startHelperWorkflow(false)
                                     }
                                 },
@@ -272,8 +272,8 @@ extension UniversalInstallationView {
                                         }
                                         return
                                     }
-                                    helperStageTitleKey = "Rozpoczynanie..."
-                                    helperStatusKey = "Rozpoczynanie..."
+                                    helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                                    helperStatusKey = HelperWorkflowLocalizationKeys.initializingStatus
                                     helperCurrentStageKey = ""
                                     helperCopyProgressPercent = 0
                                     helperCopiedBytes = 0

--- a/macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift
+++ b/macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift
@@ -37,7 +37,8 @@ extension UniversalInstallationView {
             isSierra: false,
             needsCodesign: false,
             requiresApplicationPathArg: false,
-            requesterUID: requesterUID
+            requesterUID: requesterUID,
+            linuxForceUnmount: false
         )
     }
 }

--- a/macUSB/Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift
+++ b/macUSB/Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift
@@ -1,0 +1,80 @@
+import Foundation
+import AppKit
+import SwiftUI
+
+extension UniversalInstallationView {
+    func shouldPromptLinuxForceUnmountAlert(for result: HelperWorkflowResultPayload) -> Bool {
+        guard isLinuxWorkflow else { return false }
+        guard !result.success else { return false }
+        guard result.failedStage == "linux_unmount_target" else { return false }
+        guard let message = result.errorMessage?.lowercased() else { return false }
+        return message.contains("linux_unmount_busy_prompt")
+    }
+
+    func makeLinuxForceUnmountRequest(from request: HelperWorkflowRequestPayload) -> HelperWorkflowRequestPayload {
+        HelperWorkflowRequestPayload(
+            workflowKind: request.workflowKind,
+            systemName: request.systemName,
+            sourceAppPath: request.sourceAppPath,
+            originalImagePath: request.originalImagePath,
+            tempWorkPath: request.tempWorkPath,
+            targetVolumePath: request.targetVolumePath,
+            targetBSDName: request.targetBSDName,
+            targetLabel: request.targetLabel,
+            needsPreformat: request.needsPreformat,
+            isCatalina: request.isCatalina,
+            isSierra: request.isSierra,
+            needsCodesign: request.needsCodesign,
+            requiresApplicationPathArg: request.requiresApplicationPathArg,
+            requesterUID: request.requesterUID,
+            linuxForceUnmount: true
+        )
+    }
+
+    func showLinuxForceUnmountAlert(
+        onForce: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        let alert = NSAlert()
+        alert.icon = NSApp.applicationIconImage
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Nie można odmontować nośnika USB")
+        alert.informativeText = String(localized: "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika startowego Linux, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?")
+        alert.addButton(withTitle: String(localized: "Anuluj"))
+        alert.addButton(withTitle: String(localized: "Wymuś odmontowanie"))
+
+        let completionHandler = { (response: NSApplication.ModalResponse) in
+            if response == .alertSecondButtonReturn {
+                onForce()
+            } else {
+                onCancel()
+            }
+        }
+
+        if let window = NSApp.windows.first {
+            alert.beginSheetModal(for: window, completionHandler: completionHandler)
+        } else {
+            let response = alert.runModal()
+            completionHandler(response)
+        }
+    }
+
+    func performLinuxUnmountDeclinedCleanupAndCancel() {
+        helperCurrentStageKey = "cleanup_temp"
+        helperStageTitleKey = HelperWorkflowLocalizationKeys.cleanupTempTitle
+        helperStatusKey = HelperWorkflowLocalizationKeys.cleanupTempStatus
+        helperWriteSpeedText = "- MB/s"
+
+        withAnimation {
+            isHelperWorking = true
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            performEmergencyCleanupIfNeeded(tempURL: tempWorkURL)
+            DispatchQueue.main.async {
+                isHelperWorking = false
+                completeCancellationFlow()
+            }
+        }
+    }
+}

--- a/macUSB/Features/Installation/UniversalInstallationView.swift
+++ b/macUSB/Features/Installation/UniversalInstallationView.swift
@@ -64,6 +64,7 @@ struct UniversalInstallationView: View {
     @State var usbCheckTimer: Timer?
 
     @State var helperOperationFailed: Bool = false
+    @State var workflowResultDetailMessage: String? = nil
     
     @State var isCancelling: Bool = false
     @State var usbProcessStartedAt: Date?
@@ -439,6 +440,7 @@ struct UniversalInstallationView: View {
                     isCancelling: $isCancelling,
                     navigateToFinish: $navigateToFinish,
                     helperOperationFailed: $helperOperationFailed,
+                    workflowResultDetailMessage: $workflowResultDetailMessage,
                     didCancelCreation: $didCancelCreation,
                     creationStartedAt: $usbProcessStartedAt
                 ),

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -12950,6 +12950,9 @@
         }
       }
     },
+    "Nie można odmontować nośnika USB" : {
+
+    },
     "Nie przyznano wymaganej zgody na „Działanie w tle” dla narzędzia pomocniczego. Aplikacja może nie działać poprawnie." : {
       "localizations" : {
         "de" : {
@@ -16645,6 +16648,9 @@
           }
         }
       }
+    },
+    "Nośnik USB był używany przez inną aplikację. Nie wyrażono zgody na wymuszenie odmontowania, dlatego proces został przerwany. Zamknij aplikacje korzystające z nośnika i spróbuj ponownie." : {
+
     },
     "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia." : {
       "localizations" : {
@@ -25722,6 +25728,9 @@
         }
       }
     },
+    "Szczegóły błędu" : {
+
+    },
     "Szczegóły naprawy helpera" : {
       "localizations" : {
         "de" : {
@@ -25873,6 +25882,9 @@
           }
         }
       }
+    },
+    "Szczegóły przerwania" : {
+
     },
     "Szczegóły statusu helpera" : {
       "localizations" : {
@@ -28262,6 +28274,9 @@
         }
       }
     },
+    "Uruchamianie procesu" : {
+
+    },
     "Uruchom aplikację ponownie" : {
       "localizations" : {
         "de" : {
@@ -30630,6 +30645,9 @@
         }
       }
     },
+    "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika startowego Linux, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?" : {
+
+    },
     "Wybrany nośnik korzysta z formatu APFS. Aby kontynuować, sformatuj go ręcznie w Narzędziu dyskowym do dowolnego formatu innego niż APFS." : {
       "localizations" : {
         "de" : {
@@ -32335,6 +32353,9 @@
           }
         }
       }
+    },
+    "Wymuś odmontowanie" : {
+
     },
     "Wynik operacji" : {
       "localizations" : {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -4525,7 +4525,80 @@
       }
     },
     "Brak źródła obrazu Linux do utworzenia nośnika USB." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Linux-Image-Quelle zum Erstellen eines USB-Laufwerks verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Linux image source is available to create a USB drive."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay una imagen de Linux de origen disponible para crear una unidad USB."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune image source Linux n’est disponible pour créer un disque USB."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna immagine Linux di origine disponibile per creare un’unità USB."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USBメディアを作成するための Linux イメージのソースがありません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não há imagem de origem do Linux disponível para criar a unidade USB."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет исходного образа Linux для создания USB-носителя."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB sürücüsü oluşturmak için Linux görüntü kaynağı yok."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Немає вихідного образу Linux для створення USB-носія."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có nguồn ảnh đĩa Linux để tạo ổ USB."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用于创建 USB 驱动器的 Linux 镜像源。"
+          }
+        }
+      }
     },
     "Cały proces może potrwać kilka minut." : {
       "localizations" : {
@@ -8988,50 +9061,410 @@
     },
     "helper.workflow.initializing.status" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starting..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciando..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrage..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avvio..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開始中..."
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rozpoczynanie..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciando..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Başlatılıyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang bắt đầu..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在启动..."
           }
         }
       }
     },
     "helper.workflow.linux_raw_copy.status" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreiben des Linux-Images auf den Zieldatenträger..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Writing the Linux image to the target disk..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribiendo la imagen de Linux en el disco de destino..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écriture de l’image Linux sur le disque cible..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrittura dell’immagine Linux sul disco di destinazione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux イメージを対象ディスクに書き込み中..."
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zapisywanie obrazu Linux na dysku docelowym..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gravando a imagem Linux no disco de destino..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запись образа Linux на целевой диск..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux imajı hedef diske yazılıyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запис образу Linux на цільовий диск..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang ghi ảnh đĩa Linux vào ổ đích..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在将 Linux 镜像写入目标磁盘..."
           }
         }
       }
     },
     "helper.workflow.linux_raw_copy.title" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen des Linux-Mediums"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creating Linux media"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creando medio Linux"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Création du support Linux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creazione del supporto Linux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux メディアを作成中"
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tworzenie nośnika Linux"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criando mídia Linux"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создание носителя Linux"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux ortamı oluşturuluyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створення носія Linux"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tạo phương tiện Linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在创建 Linux 介质"
           }
         }
       }
     },
     "helper.workflow.linux_unmount_target.status" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aushängen des Zieldatenträgers..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unmounting target disk..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desmontando el disco de destino..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démontage du disque cible..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smontaggio del disco di destinazione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対象ディスクをアンマウント中..."
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Odmontowywanie dysku docelowego..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desmontando o disco de destino..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмонтирование целевого диска..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef diskin bağlantısı kesiliyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмонтування цільового диска..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tháo gắn kết ổ đích..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在卸载目标磁盘..."
           }
         }
       }
     },
     "helper.workflow.linux_unmount_target.title" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorbereiten des Zieldatenträgers"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing target disk"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando el disco de destino"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation du disque cible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione del disco di destinazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対象ディスクを準備中"
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Przygotowanie dysku docelowego"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando o disco de destino"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка целевого диска"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef disk hazırlanıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підготовка цільового диска"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang chuẩn bị ổ đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备目标磁盘"
           }
         }
       }
@@ -9858,20 +10291,164 @@
     },
     "helper.workflow.starting.status" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorbereiten des Vorgangs..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing operation..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando la operación..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de l’opération..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione dell’operazione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "処理を準備中..."
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Przygotowywanie operacji..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando a operação..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка операции..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşlem hazırlanıyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підготовка операції..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang chuẩn bị thao tác..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备操作..."
           }
         }
       }
     },
     "helper.workflow.starting.title" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starten des Vorgangs"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starting process"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciando el proceso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrage du processus"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avvio del processo"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロセスを開始中"
+          }
+        },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uruchamianie procesu"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciando o processo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск процесса"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Süreç başlatılıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запуск процесу"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang khởi chạy quy trình"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在启动流程"
           }
         }
       }
@@ -11479,7 +12056,80 @@
       }
     },
     "Linux - nierozpoznana dystrybucja" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - nicht erkannte Distribution"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - unrecognized distribution"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribución no reconocida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribution non reconnue"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribuzione non riconosciuta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - 未認識のディストリビューション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribuição não reconhecida"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - нераспознанный дистрибутив"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - tanınmayan dağıtım"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - нерозпізнаний дистрибутив"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - bản phân phối không xác định"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - 未识别的发行版"
+          }
+        }
+      }
     },
     "Lokalizacja" : {
       "localizations" : {
@@ -13021,7 +13671,80 @@
       }
     },
     "Nie można odmontować nośnika USB" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB-Laufwerk konnte nicht ausgehängt werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to unmount USB drive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo desmontar la unidad USB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de démonter le disque USB"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile smontare l’unità USB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB ドライブをアンマウントできません"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível desmontar a unidade USB"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось отмонтировать USB-накопитель"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB sürücüsünün bağlantısı kesilemedi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося відмонтувати USB-носій"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể tháo gắn kết ổ USB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法卸载 USB 驱动器"
+          }
+        }
+      }
     },
     "Nie przyznano wymaganej zgody na „Działanie w tle” dla narzędzia pomocniczego. Aplikacja może nie działać poprawnie." : {
       "localizations" : {
@@ -16720,7 +17443,80 @@
       }
     },
     "Nośnik USB był używany przez inną aplikację. Nie wyrażono zgody na wymuszenie odmontowania, dlatego proces został przerwany. Zamknij aplikacje korzystające z nośnika i spróbuj ponownie." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das USB-Laufwerk wurde von einer anderen App verwendet. Die Zustimmung zum erzwungenen Aushängen wurde nicht erteilt, daher wurde der Vorgang abgebrochen. Schließen Sie Apps, die dieses Laufwerk verwenden, und versuchen Sie es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The USB drive was in use by another app. Permission to forcibly unmount it was not granted, so the process was canceled. Close apps using this drive and try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La unidad USB estaba en uso por otra app. No se concedió permiso para forzar el desmontaje, por lo que el proceso se canceló. Cierra las apps que usan esta unidad e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le disque USB était utilisé par une autre app. L’autorisation de forcer le démontage n’a pas été accordée, le processus a donc été interrompu. Fermez les apps qui utilisent ce disque et réessayez."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’unità USB era in uso da un’altra app. Non è stata concessa l’autorizzazione a forzare lo smontaggio, quindi il processo è stato interrotto. Chiudi le app che usano questa unità e riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB ドライブは別のアプリで使用中でした。強制アンマウントへの同意が得られなかったため、処理を中止しました。このドライブを使用しているアプリを終了して、もう一度お試しください。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A unidade USB estava sendo usada por outro app. A permissão para forçar a desmontagem não foi concedida, então o processo foi interrompido. Feche os apps que usam essa unidade e tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB-носитель использовался другим приложением. Согласие на принудительное отмонтирование не было получено, поэтому процесс был прерван. Закройте приложения, использующие этот носитель, и попробуйте снова."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB sürücüsü başka bir uygulama tarafından kullanılıyordu. Zorla ayırma onayı verilmediği için işlem durduruldu. Bu sürücüyü kullanan uygulamaları kapatıp yeniden deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB-носій використовувався іншою програмою. Згоду на примусове відмонтування не надано, тому процес було перервано. Закрийте програми, що використовують цей носій, і спробуйте ще раз."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ổ USB đang được ứng dụng khác sử dụng. Không có quyền cho phép tháo gắn kết bắt buộc nên quá trình đã bị hủy. Hãy đóng các ứng dụng đang dùng ổ này rồi thử lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB 驱动器正被其他应用使用。由于未获准强制卸载，过程已中止。请关闭正在使用该驱动器的应用后重试。"
+          }
+        }
+      }
     },
     "Nośnik USB nie będzie zdatny do rozruchu, jeśli proces zostanie zatrzymany przed zakończeniem. Konieczne będzie ponowne przygotowanie urządzenia." : {
       "localizations" : {
@@ -25799,7 +26595,80 @@
       }
     },
     "Szczegóły błędu" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehlerdetails"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles del error"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détails de l’erreur"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettagli errore"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エラーの詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalhes do erro"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробности ошибки"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hata ayrıntıları"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деталі помилки"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chi tiết lỗi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "错误详情"
+          }
+        }
+      }
     },
     "Szczegóły naprawy helpera" : {
       "localizations" : {
@@ -25954,7 +26823,80 @@
       }
     },
     "Szczegóły przerwania" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Details zur Unterbrechung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Interruption details"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalles de la interrupción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détails de l’interruption"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dettagli dell’interruzione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中断の詳細"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detalhes da interrupção"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подробности прерывания"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kesinti ayrıntıları"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Деталі переривання"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chi tiết gián đoạn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中断详情"
+          }
+        }
+      }
     },
     "Szczegóły statusu helpera" : {
       "localizations" : {
@@ -30713,7 +31655,80 @@
       }
     },
     "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika startowego Linux, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das ausgewählte Laufwerk wird von einer anderen App verwendet. Um die Erstellung des Linux-Startmediums fortzusetzen, kann macUSB das Gerät zwangsweise aushängen. Nicht gespeicherte Daten auf diesem Laufwerk können verloren gehen. Möchten Sie das Aushängen erzwingen?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The selected drive is being used by another app. To continue creating Linux boot media, macUSB can forcibly unmount the device. Unsaved data on this drive may be lost. Do you want to forcibly unmount it?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La unidad seleccionada está siendo utilizada por otra app. Para continuar con la creación del medio de arranque Linux, macUSB puede forzar el desmontaje del dispositivo. Los datos no guardados en esta unidad podrían perderse. ¿Quieres forzar el desmontaje?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le disque sélectionné est utilisé par une autre app. Pour poursuivre la création du support de démarrage Linux, macUSB peut forcer le démontage de l’appareil. Les données non enregistrées sur ce disque peuvent être perdues. Voulez-vous forcer le démontage ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’unità selezionata è in uso da un’altra app. Per continuare la creazione del supporto di avvio Linux, macUSB può forzare lo smontaggio del dispositivo. I dati non salvati su questa unità potrebbero andare persi. Vuoi forzare lo smontaggio?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したドライブは別のアプリで使用中です。Linux 起動メディアの作成を続行するために、macUSB はデバイスを強制的にアンマウントできます。このドライブ上の未保存データは失われる可能性があります。強制アンマウントしますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A unidade selecionada está sendo usada por outro app. Para continuar criando a mídia de inicialização Linux, o macUSB pode forçar a desmontagem do dispositivo. Dados não salvos nessa unidade podem ser perdidos. Deseja forçar a desmontagem?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбранный носитель используется другим приложением. Чтобы продолжить создание загрузочного носителя Linux, macUSB может принудительно отмонтировать устройство. Несохранённые данные на этом носителе могут быть потеряны. Принудительно отмонтировать?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seçilen sürücü başka bir uygulama tarafından kullanılıyor. Linux önyükleme ortamı oluşturmayı sürdürmek için macUSB aygıtı zorla ayırabilir. Bu sürücüdeki kaydedilmemiş veriler kaybolabilir. Zorla ayırmak istiyor musunuz?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вибраний носій використовується іншою програмою. Щоб продовжити створення завантажувального носія Linux, macUSB може примусово відмонтувати пристрій. Незбережені дані на цьому носії можуть бути втрачені. Примусово відмонтувати?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ổ đã chọn đang được ứng dụng khác sử dụng. Để tiếp tục tạo phương tiện khởi động Linux, macUSB có thể buộc tháo gắn kết thiết bị. Dữ liệu chưa lưu trên ổ này có thể bị mất. Bạn có muốn buộc tháo gắn kết không?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所选驱动器正被其他应用使用。若要继续创建 Linux 启动介质，macUSB 可以强制卸载该设备。该驱动器上的未保存数据可能会丢失。要强制卸载吗？"
+          }
+        }
+      }
     },
     "Wybrany nośnik korzysta z formatu APFS. Aby kontynuować, sformatuj go ręcznie w Narzędziu dyskowym do dowolnego formatu innego niż APFS." : {
       "localizations" : {
@@ -32422,7 +33437,80 @@
       }
     },
     "Wymuś odmontowanie" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aushängen erzwingen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Force Unmount"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forzar desmontaje"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forcer le démontage"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forza smontaggio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "強制アンマウント"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forçar desmontagem"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Принудительно отмонтировать"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zorla ayır"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примусово відмонтувати"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buộc tháo gắn kết"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "强制卸载"
+          }
+        }
+      }
     },
     "Wynik operacji" : {
       "localizations" : {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -8986,6 +8986,56 @@
         }
       }
     },
+    "helper.workflow.initializing.status" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozpoczynanie..."
+          }
+        }
+      }
+    },
+    "helper.workflow.linux_raw_copy.status" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisywanie obrazu Linux na dysku docelowym..."
+          }
+        }
+      }
+    },
+    "helper.workflow.linux_raw_copy.title" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tworzenie nośnika Linux"
+          }
+        }
+      }
+    },
+    "helper.workflow.linux_unmount_target.status" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odmontowywanie dysku docelowego..."
+          }
+        }
+      }
+    },
+    "helper.workflow.linux_unmount_target.title" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przygotowanie dysku docelowego"
+          }
+        }
+      }
+    },
     "helper.workflow.ppc_format.status" : {
       "localizations" : {
         "de" : {
@@ -9802,6 +9852,26 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在创建安装介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.starting.status" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przygotowywanie operacji..."
+          }
+        }
+      }
+    },
+    "helper.workflow.starting.title" : {
+      "localizations" : {
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uruchamianie procesu"
           }
         }
       }
@@ -28273,9 +28343,6 @@
           }
         }
       }
-    },
-    "Uruchamianie procesu" : {
-
     },
     "Uruchom aplikację ponownie" : {
       "localizations" : {

--- a/macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift
+++ b/macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift
@@ -26,10 +26,13 @@ enum HelperWorkflowLocalizationKeys {
 
     static let createinstallmediaTitle = "helper.workflow.createinstallmedia.title"
     static let createinstallmediaStatus = "helper.workflow.createinstallmedia.status"
-    static let linuxUnmountTargetTitle = preformatTitle
-    static let linuxUnmountTargetStatus = "Odmontowywanie wybranego nośnika USB."
-    static let linuxRawCopyTitle = restoreTitle
-    static let linuxRawCopyStatus = "Przenoszenie obrazu systemu Linux na wybrany nośnik USB."
+    static let linuxUnmountTargetTitle = "helper.workflow.linux_unmount_target.title"
+    static let linuxUnmountTargetStatus = "helper.workflow.linux_unmount_target.status"
+    static let linuxRawCopyTitle = "helper.workflow.linux_raw_copy.title"
+    static let linuxRawCopyStatus = "helper.workflow.linux_raw_copy.status"
+    static let startingTitle = "helper.workflow.starting.title"
+    static let startingStatus = "helper.workflow.starting.status"
+    static let initializingStatus = "helper.workflow.initializing.status"
 
     static let catalinaCleanupTitle = "helper.workflow.catalina_cleanup.title"
     static let catalinaCleanupStatus = "helper.workflow.catalina_cleanup.status"
@@ -97,6 +100,13 @@ enum HelperWorkflowLocalizationExtractionAnchors {
         String(localized: "helper.workflow.ppc_restore.status"),
         String(localized: "helper.workflow.createinstallmedia.title"),
         String(localized: "helper.workflow.createinstallmedia.status"),
+        String(localized: "helper.workflow.linux_unmount_target.title"),
+        String(localized: "helper.workflow.linux_unmount_target.status"),
+        String(localized: "helper.workflow.linux_raw_copy.title"),
+        String(localized: "helper.workflow.linux_raw_copy.status"),
+        String(localized: "helper.workflow.starting.title"),
+        String(localized: "helper.workflow.starting.status"),
+        String(localized: "helper.workflow.initializing.status"),
         String(localized: "helper.workflow.catalina_cleanup.title"),
         String(localized: "helper.workflow.catalina_cleanup.status"),
         String(localized: "helper.workflow.catalina_copy.title"),

--- a/macUSB/Shared/Services/Helper/HelperIPC.swift
+++ b/macUSB/Shared/Services/Helper/HelperIPC.swift
@@ -23,6 +23,7 @@ struct HelperWorkflowRequestPayload: Codable {
     let needsCodesign: Bool
     let requiresApplicationPathArg: Bool
     let requesterUID: Int?
+    let linuxForceUnmount: Bool
 }
 
 struct HelperProgressEventPayload: Codable {

--- a/macUSB/Shared/Services/USBDriveLogic.swift
+++ b/macUSB/Shared/Services/USBDriveLogic.swift
@@ -348,7 +348,16 @@ struct USBDriveLogic {
         for url in urls {
             let bsd = getBSDName(from: url)
             guard !bsd.isEmpty, bsd != "unknown" else { continue }
-            result.insert(wholeDiskName(from: bsd))
+            let mountedWhole = wholeDiskName(from: bsd)
+            result.insert(mountedWhole)
+
+            // APFS volumes can be mounted through container identifiers that do not
+            // directly map to the physical external whole disk reported by diskutil list external.
+            // Add resolved physical store whole disk to avoid false "unreadable USB" classification.
+            if detectFileSystemFormat(forVolumeURL: url) == .apfs,
+               let resolvedWhole = resolveFormattingWholeDiskBSDName(forVolumeURL: url, fallbackBSDName: bsd) {
+                result.insert(wholeDiskName(from: resolvedWhole))
+            }
         }
         return result
     }

--- a/macUSBHelper/IPC/HelperIPC.swift
+++ b/macUSBHelper/IPC/HelperIPC.swift
@@ -23,6 +23,7 @@ struct HelperWorkflowRequestPayload: Codable {
     let needsCodesign: Bool
     let requiresApplicationPathArg: Bool
     let requesterUID: Int?
+    let linuxForceUnmount: Bool
 }
 
 struct HelperProgressEventPayload: Codable {

--- a/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
@@ -72,7 +72,9 @@ final class HelperWorkflowExecutor {
                 isUserCancelled: true
             )
         } catch HelperExecutionError.failed(let stage, let exitCode, let description) {
-            runBestEffortTempCleanupStage()
+            if !shouldDeferCleanupForLinuxUnmountPrompt(failedStage: stage, description: description) {
+                runBestEffortTempCleanupStage()
+            }
             return HelperWorkflowResultPayload(
                 workflowID: workflowID,
                 success: false,

--- a/macUSBHelper/Workflow/HelperWorkflowFileOperations.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowFileOperations.swift
@@ -6,6 +6,11 @@ extension HelperWorkflowExecutor {
         try throwIfCancelled()
         lastStageOutputLine = nil
 
+        if stage.key == "linux_unmount_target" {
+            try runLinuxUnmountTargetStage(stage)
+            return
+        }
+
         let process = Process()
         if let requesterUID = request.requesterUID, requesterUID > 0 {
             process.executableURL = URL(fileURLWithPath: "/bin/launchctl")

--- a/macUSBHelper/Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift
+++ b/macUSBHelper/Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    private static let linuxUnmountBusyPromptMarker = "linux_unmount_busy_prompt"
+
+    func shouldDeferCleanupForLinuxUnmountPrompt(failedStage: String, description: String) -> Bool {
+        guard failedStage == "linux_unmount_target" else { return false }
+        guard !request.linuxForceUnmount else { return false }
+        return description.lowercased().contains(Self.linuxUnmountBusyPromptMarker)
+    }
+
+    func runLinuxUnmountTargetStage(_ stage: WorkflowStage) throws {
+        let targetDevice = stage.arguments.last ?? ""
+        guard !targetDevice.isEmpty else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się ustalić urządzenia do odmontowania."
+            )
+        }
+
+        if request.linuxForceUnmount {
+            let status = try runLinuxUnmountCommand(
+                stage: stage,
+                arguments: ["unmountDisk", "force", targetDevice]
+            )
+            guard status.success else {
+                var description = "Wymuszone odmontowanie nośnika nie powiodło się (kod \(status.exitCode))."
+                if let line = status.lastLine {
+                    description += " Ostatni komunikat: \(line)"
+                }
+                throw HelperExecutionError.failed(stage: stage.key, exitCode: status.exitCode, description: description)
+            }
+            return
+        }
+
+        let retryDelaySeconds = 2
+        let retryCount = 3
+        let totalAttempts = retryCount + 1
+
+        for attempt in 1...totalAttempts {
+            let status = try runLinuxUnmountCommand(
+                stage: stage,
+                arguments: ["unmountDisk", targetDevice]
+            )
+
+            if status.success {
+                return
+            }
+
+            if status.isBusyFailure, attempt <= retryCount {
+                emitProgress(
+                    stageKey: stage.key,
+                    titleKey: stage.titleKey,
+                    percent: latestPercent,
+                    statusKey: stage.statusKey,
+                    logLine: "Linux unmount retry \(attempt)/\(retryCount): nośnik zajęty, ponawiam za \(retryDelaySeconds)s.",
+                    shouldAdvancePercent: false
+                )
+                try waitLinuxUnmountRetryDelay(seconds: retryDelaySeconds)
+                continue
+            }
+
+            if status.isBusyFailure {
+                let description = "Nie udało się odmontować nośnika, ponieważ jest używany przez inny proces. \(Self.linuxUnmountBusyPromptMarker)"
+                throw HelperExecutionError.failed(stage: stage.key, exitCode: status.exitCode, description: description)
+            }
+
+            var description = "Nie udało się odmontować nośnika (kod \(status.exitCode))."
+            if let line = status.lastLine {
+                description += " Ostatni komunikat: \(line)"
+            }
+            throw HelperExecutionError.failed(stage: stage.key, exitCode: status.exitCode, description: description)
+        }
+    }
+
+    private func runLinuxUnmountCommand(stage: WorkflowStage, arguments: [String]) throws -> (success: Bool, exitCode: Int32, isBusyFailure: Bool, lastLine: String?) {
+        let process = Process()
+        if let requesterUID = request.requesterUID, requesterUID > 0 {
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = ["asuser", "\(requesterUID)", "/usr/sbin/diskutil"] + arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+            process.arguments = arguments
+        }
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        stateQueue.sync {
+            activeProcess = process
+        }
+
+        var buffer = Data()
+        var isBusyFailure = false
+        var lastLine: String?
+
+        do {
+            try process.run()
+        } catch {
+            stateQueue.sync {
+                activeProcess = nil
+            }
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się uruchomić polecenia /usr/sbin/diskutil: \(error.localizedDescription)"
+            )
+        }
+
+        let handle = pipe.fileHandleForReading
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                break
+            }
+            buffer.append(chunk)
+            drainBufferedOutputLines(from: &buffer) { line in
+                lastStageOutputLine = line
+                lastLine = line
+                if isLinuxUnmountBusyLine(line) {
+                    isBusyFailure = true
+                }
+                emitProgress(
+                    stageKey: stage.key,
+                    titleKey: stage.titleKey,
+                    percent: latestPercent,
+                    statusKey: stage.statusKey,
+                    logLine: line,
+                    shouldAdvancePercent: false
+                )
+            }
+        }
+
+        if !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !line.isEmpty {
+            lastStageOutputLine = line
+            lastLine = line
+            if isLinuxUnmountBusyLine(line) {
+                isBusyFailure = true
+            }
+            emitProgress(
+                stageKey: stage.key,
+                titleKey: stage.titleKey,
+                percent: latestPercent,
+                statusKey: stage.statusKey,
+                logLine: line,
+                shouldAdvancePercent: false
+            )
+        }
+
+        process.waitUntilExit()
+        let exitCode = process.terminationStatus
+
+        stateQueue.sync {
+            activeProcess = nil
+        }
+
+        try throwIfCancelled()
+
+        return (
+            success: exitCode == 0,
+            exitCode: exitCode,
+            isBusyFailure: isBusyFailure,
+            lastLine: lastLine
+        )
+    }
+
+    private func waitLinuxUnmountRetryDelay(seconds: Int) throws {
+        guard seconds > 0 else { return }
+        for _ in 0..<(seconds * 10) {
+            try throwIfCancelled()
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+    }
+
+    private func isLinuxUnmountBusyLine(_ line: String) -> Bool {
+        let lowered = line.lowercased()
+        return lowered.contains("at least one volume could not be unmounted")
+            || lowered.contains("unmount was dissented by pid")
+            || lowered.contains("resource busy")
+            || lowered.contains("device busy")
+    }
+}


### PR DESCRIPTION
This PR hardens the Linux USB creation flow on top of feature/linux_usb by improving recovery when unmount operations are busy, preserving Linux mount path context during archive fallback detection, and fixing false unreadable USB warnings for mounted APFS media. It also adds a safer Linux source-size fallback based on file attributes, completes missing Linux workflow and unmount localization coverage, and aligns helper stage/status localization to key-based mapping so app and helper messaging remain consistent.

- Improves Linux-specific unmount retry and recovery behavior in app/helper workflow paths.
- Preserves mount path data used by Linux archive fallback detection.
- Fixes APFS readability false positives shown during analysis.
- Adds missing Linux workflow localizations and updates helper localization key handling.
- Updates runtime reference docs for helper, USB workflows, and localization contract.