### PR TITLE
Add manual Linux override in skip-analysis flow

### DIFF
--- a/docs/reference/features/analysis/ANALYSIS_COMPATIBILITY.md
+++ b/docs/reference/features/analysis/ANALYSIS_COMPATIBILITY.md
@@ -19,6 +19,7 @@ For Linux fallback:
 - detection is considered successful when Linux is recognized, including unknown distro case,
 - recognized Linux result unlocks shared install flow (`UniversalInstallationView -> CreationProgressView -> FinishUSBView`),
 - detected Linux state may present dedicated Linux icon resource (`linux.icns`) in analysis UI.
+- manual Linux force from `Opcje -> Pomiń analizowanie pliku -> Linux` is treated as Linux-recognized state for install handoff.
 
 ## Current Supported Routing Families
 
@@ -37,6 +38,7 @@ Linux fallback routing includes:
 
 - recognized Linux distro,
 - Linux with unknown distro (`Linux - nierozpoznana dystrybucja`).
+- manually forced Linux (`Linux`).
 
 ## Special Blocking Rule
 
@@ -69,6 +71,7 @@ Linux fallback should additionally log:
 - evidence summary used for recognition,
 - archive-reader diagnostics relevant to bounded execution (`bsdtar` timeout/errors),
 - install handoff readiness (`linuxSourceURL` present, capacity computed).
+- manual-force diagnostics when Linux is forced from menu.
 
 ## Update Trigger
 

--- a/docs/reference/features/analysis/LINUX_ANALYSIS_FLOW.md
+++ b/docs/reference/features/analysis/LINUX_ANALYSIS_FLOW.md
@@ -8,6 +8,7 @@ Linux detection is a fallback path in analysis, with install handoff enabled.
 
 - Primary path remains macOS installer detection.
 - Linux path runs when macOS installer metadata is not detected from `.iso` / `.cdr` sources.
+- Linux path can also be forced manually from `Opcje -> Pomiń analizowanie pliku -> Linux` after unsupported/unrecognized analysis.
 - Positive Linux detection unlocks USB selection and installer creation flow.
 
 ## Trigger and Entry
@@ -85,6 +86,13 @@ Linux recognition is shown as successful detection in analysis UI and enables in
 - installation workflow starts from shared summary/progress/finish UI,
 - Linux helper branch uses raw copy (`dd`) stages.
 
+Manual Linux force from menu sets Linux workflow state without distro recognition:
+
+- display name: `Linux`,
+- distro metadata: unresolved (no distro/version/edition),
+- icon: generic Linux fallback (`linux.icns`),
+- source handoff: selected file path is used as `linuxSourceURL`.
+
 Required USB capacity is computed from source file size:
 
 - source size `<= 6_000_000_000` bytes -> `8 GB`,
@@ -111,13 +119,20 @@ When Linux fallback runs, logs must include:
 - evidence summary (files/rules that produced the result),
 - archive-reader diagnostics for timeout/error cases.
 
+When manual Linux force runs, logs must include:
+
+- manual-force transition entry,
+- selected source path,
+- resolved source file size in bytes (when available),
+- selected USB threshold in GB only.
+
 ## Reset and Lifecycle Rules
 
 Linux analysis state must be reset on:
 
 - new file selection/drop,
 - full analysis reset,
-- explicit transitions that force macOS-only state (for example Tiger manual selection).
+- explicit transitions that force another workflow family (for example Tiger manual selection).
 
 Mount lifecycle behavior remains aligned with existing analysis behavior:
 

--- a/macUSB/App/macUSBApp.swift
+++ b/macUSB/App/macUSBApp.swift
@@ -118,6 +118,29 @@ struct macUSBApp: App {
                     }
                     .keyboardShortcut("t", modifiers: [.option, .command])
                     .disabled(!menuState.skipAnalysisEnabled)
+                    Divider()
+                    Button(String(localized: "Linux")) {
+                        let alert = NSAlert()
+                        alert.alertStyle = .informational
+                        alert.icon = NSApp.applicationIconImage
+                        alert.messageText = String(localized: "Tworzenie USB z Linux")
+                        alert.informativeText = String(localized: "Dla wybranego pliku zostanie pominięta analiza i rozpoznanie dystrybucji. Aplikacja wymusi rozpoznanie pliku jako „Linux”, aby umożliwić zapis USB w trybie Linux. Czy chcesz kontynuować?")
+                        alert.addButton(withTitle: String(localized: "Nie"))
+                        alert.addButton(withTitle: String(localized: "Tak"))
+                        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+                            alert.beginSheetModal(for: window) { response in
+                                if response == .alertSecondButtonReturn {
+                                    NotificationCenter.default.post(name: .macUSBStartLinuxManualSelection, object: nil)
+                                }
+                            }
+                        } else {
+                            let response = alert.runModal()
+                            if response == .alertSecondButtonReturn {
+                                NotificationCenter.default.post(name: .macUSBStartLinuxManualSelection, object: nil)
+                            }
+                        }
+                    }
+                    .disabled(!menuState.skipAnalysisEnabled)
                 } label: {
                     Label(String(localized: "Pomiń analizowanie pliku"), systemImage: "doc.text.magnifyingglass")
                 }

--- a/macUSB/Features/Analysis/AnalysisNotifications.swift
+++ b/macUSB/Features/Analysis/AnalysisNotifications.swift
@@ -3,6 +3,7 @@ import Foundation
 extension Notification.Name {
     static let macUSBResetToStart = Notification.Name("macUSB.resetToStart")
     static let macUSBStartTigerMultiDVD = Notification.Name("macUSB.startTigerMultiDVD")
+    static let macUSBStartLinuxManualSelection = Notification.Name("macUSB.startLinuxManualSelection")
     static let macUSBDebugGoToBigSurSummary = Notification.Name("macUSB.debugGoToBigSurSummary")
     static let macUSBDebugGoToTigerSummary = Notification.Name("macUSB.debugGoToTigerSummary")
     static let macUSBDebugGoToLinuxSummary = Notification.Name("macUSB.debugGoToLinuxSummary")

--- a/macUSB/Features/Analysis/Logic/Linux/AnalysisLogicLinuxLifecycle.swift
+++ b/macUSB/Features/Analysis/Logic/Linux/AnalysisLogicLinuxLifecycle.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import SwiftUI
 
 private enum LinuxDistroIconCatalog {
     static let names: [String] = [
@@ -86,6 +87,60 @@ private enum LinuxDistroIconCatalog {
 }
 
 extension AnalysisLogic {
+    func forceLinuxManualSelection() {
+        guard let sourceURL = self.selectedFileUrl else {
+            self.logError("Nie można wymusić rozpoznania Linux: brak wybranego pliku.")
+            return
+        }
+
+        self.log("Ręcznie wybrano tryb Linux (pominięcie analizy pliku).")
+
+        withAnimation {
+            self.isAnalyzing = false
+            self.userSkippedAnalysis = true
+            self.resetLinuxDetectionState()
+
+            self.isLinuxDetected = true
+            self.isLinuxDistributionRecognized = false
+            self.linuxDisplayName = "Linux"
+            self.linuxSourceURL = sourceURL
+
+            self.recognizedVersion = "Linux"
+            self.sourceAppURL = nil
+            self.detectedSystemIcon = loadLinuxDetectedSystemIcon(for: nil)
+
+            self.isSystemDetected = true
+            self.showUnsupportedMessage = false
+            self.showUSBSection = false
+
+            self.needsCodesign = true
+            self.isLegacyDetected = false
+            self.isRestoreLegacy = false
+            self.isCatalina = false
+            self.isSierra = false
+            self.isMavericks = false
+            self.isUnsupportedSierra = false
+            self.isPPC = false
+            self.legacyArchInfo = nil
+            self.selectedDrive = nil
+            self.capacityCheckFinished = false
+        }
+
+        if let values = try? sourceURL.resourceValues(forKeys: [.fileSizeKey]),
+           let fileSize = values.fileSize {
+            let fileSizeBytes = Int64(fileSize)
+            let requiredGB = linuxRequiredUSBCapacityGB(fromFileSizeBytes: fileSizeBytes)
+            self.requiredUSBCapacityGB = requiredGB
+            self.log("Linux manual source size: \(fileSizeBytes) bytes")
+            self.log("Linux manual required USB threshold: \(requiredGB) GB")
+        } else {
+            self.requiredUSBCapacityGB = nil
+            self.logError("Nie udało się odczytać rozmiaru pliku dla ręcznego trybu Linux. Minimalna pojemność USB pozostaje nierozstrzygnięta (-- GB).")
+        }
+
+        self.log("Ustawiono ręczne rozpoznanie Linux: recognizedVersion=\(self.recognizedVersion), source=\(sourceURL.path)")
+    }
+
     private func linuxRequiredUSBCapacityGB(fromFileSizeBytes fileSizeBytes: Int64) -> Int {
         if fileSizeBytes > 14_000_000_000 {
             return 32

--- a/macUSB/Features/Analysis/SystemAnalysisView.swift
+++ b/macUSB/Features/Analysis/SystemAnalysisView.swift
@@ -138,6 +138,15 @@ struct SystemAnalysisView: View {
         guard let installerURL = AnalysisSelectionHandoff.shared.consumePendingInstallerURL() else { return }
         logic.applySelectedURLAndStartAnalysis(installerURL)
     }
+
+    private func handleViewAppear() {
+        logic.refreshDrives()
+        updateMenuState()
+        consumePendingDownloaderInstallerAndAnalyze()
+        if logic.shouldShowMavericksDialog {
+            presentMavericksDialog()
+        }
+    }
     
     private var fileRequirementsBox: some View {
         StatusCard(tone: .neutral, density: .compact) {
@@ -446,14 +455,14 @@ struct SystemAnalysisView: View {
         .onReceive(NotificationCenter.default.publisher(for: .macUSBStartTigerMultiDVD)) { _ in
             logic.forceTigerMultiDVDSelection()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .macUSBStartLinuxManualSelection)) { _ in
+            logic.forceLinuxManualSelection()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .macUSBApplyPendingDownloaderInstaller)) { _ in
             consumePendingDownloaderInstallerAndAnalyze()
         }
         .onAppear {
-            logic.refreshDrives()
-            updateMenuState()
-            consumePendingDownloaderInstallerAndAnalyze()
-            if logic.shouldShowMavericksDialog { presentMavericksDialog() }
+            handleViewAppear()
         }
         .navigationTitle("Konfiguracja źródła i celu")
         .navigationBarBackButtonHidden(true)

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -4525,7 +4525,80 @@
       }
     },
     "Brak źródła obrazu Linux do utworzenia nośnika USB." : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Linux-Imagequelle zum Erstellen eines USB-Laufwerks verfügbar."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Linux image source is available to create a USB drive."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No hay una imagen de Linux de origen disponible para crear una unidad USB."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune image source de Linux n’est disponible pour créer une clé USB."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nessuna immagine sorgente Linux disponibile per creare un'unità USB."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USBドライブを作成するためのLinuxイメージがありません。"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nenhuma imagem de origem do Linux está disponível para criar uma unidade USB."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет исходного образа Linux для создания USB-накопителя."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB ortamı oluşturmak için Linux imaj kaynağı bulunamadı."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Немає вихідного образу Linux для створення USB-носія."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không có ảnh đĩa nguồn Linux để tạo ổ USB."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有可用于创建 USB 驱动器的 Linux 源镜像。"
+          }
+        }
+      }
     },
     "Cały proces może potrwać kilka minut." : {
       "localizations" : {
@@ -5530,6 +5603,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "将跳过所选镜像的版本验证。应用程序将强制识别该文件为 “Mac OS X Tiger 10.4”，以允许挂载并写入 USB。您想继续吗？"
+          }
+        }
+      }
+    },
+    "Dla wybranego pliku zostanie pominięta analiza i rozpoznanie dystrybucji. Aplikacja wymusi rozpoznanie pliku jako „Linux”, aby umożliwić zapis USB w trybie Linux. Czy chcesz kontynuować?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Analyse und Distributionserkennung wird für die ausgewählte Datei übersprungen. Die Anwendung erzwingt die Erkennung der Datei als „Linux“, um das Schreiben auf USB im Linux-Modus zu ermöglichen. Möchten Sie fortfahren?"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analysis and distribution detection will be skipped for the selected file. The application will force recognition of the file as “Linux” to enable writing to USB in Linux mode. Do you want to continue?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se omitirá el análisis y el reconocimiento de la distribución para el archivo seleccionado. La aplicación forzará el reconocimiento del archivo como «Linux» para permitir la escritura en USB en modo Linux. ¿Desea continuar?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’analyse et la détection de la distribution seront ignorées pour le fichier sélectionné. L’application forcera la reconnaissance du fichier comme « Linux » pour permettre l’écriture sur USB en mode Linux. Voulez-vous continuer ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Per il file selezionato verranno ignorate l'analisi e il riconoscimento della distribuzione. L'applicazione forzerà il riconoscimento del file come \"Linux\" per consentire la scrittura su USB in modalità Linux. Vuoi continuare?"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したファイルでは、解析とディストリビューションの検出がスキップされます。アプリケーションはファイルを「Linux」として強制的に認識し、LinuxモードでUSBに書き込めるようにします。続けますか？"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A análise e o reconhecimento da distribuição serão ignorados para o arquivo selecionado. O aplicativo forçará o reconhecimento do arquivo como \"Linux\" para permitir a gravação em USB no modo Linux. Deseja continuar?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для выбранного файла будут пропущены анализ и распознавание дистрибутива. Приложение принудительно распознает файл как «Linux», чтобы разрешить запись на USB в режиме Linux. Вы хотите продолжить?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seçilen dosya için analiz ve dağıtımın algılanması atlanacaktır. Uygulama, Linux modunda USB’ye yazmayı mümkün kılmak için dosyanın “Linux” olarak tanınmasını zorlayacaktır. Devam etmek istiyor musunuz?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Для вибраного файлу аналіз і розпізнавання дистрибутива буде пропущено. Програма примусово розпізнає файл як «Linux», щоб дозволити запис на USB у режимі Linux. Ви хочете продовжити?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Việc phân tích và nhận diện bản phân phối sẽ được bỏ qua đối với tệp đã chọn. Ứng dụng sẽ buộc nhận diện tệp là \"Linux\" để cho phép ghi USB ở chế độ Linux. Bạn có muốn tiếp tục không?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将跳过对所选文件的分析和发行版识别。应用程序将强制将该文件识别为“Linux”，以便在 Linux 模式下写入 USB。您想继续吗？"
           }
         }
       }
@@ -11408,8 +11557,157 @@
         }
       }
     },
+    "Linux" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux"
+          }
+        }
+      }
+    },
     "Linux - nierozpoznana dystrybucja" : {
-
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - nicht erkannte Distribution"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - unrecognized distribution"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribución no reconocida"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribution non reconnue"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribuzione non riconosciuta"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - 不明なディストリビューション"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - distribuição não reconhecida"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - нераспознанный дистрибутив"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - tanınmayan dağıtım"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - нерозпізнаний дистрибутив"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - bản phân phối không được nhận diện"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux - 未识别的发行版"
+          }
+        }
+      }
     },
     "Lokalizacja" : {
       "localizations" : {
@@ -27795,6 +28093,82 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "介质创建已中止"
+          }
+        }
+      }
+    },
+    "Tworzenie USB z Linux" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux-USB erstellen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creating Linux USB"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creando USB de Linux"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Création de la clé USB Linux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creazione di USB da Linux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux USBを作成中"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criando USB do Linux"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создание USB с Linux"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux'tan USB oluşturma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створення USB з Linux"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo USB từ Linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在创建 Linux USB"
           }
         }
       }


### PR DESCRIPTION
This PR adds a manual Linux option under Options → Skip file analysis so users can continue with Linux USB creation when automatic detection fails. It introduces a confirmation dialog, routes the action through a dedicated notification and analysis-state override, applies Linux icon and capacity handling required for Linux workflow handoff, and updates analysis reference docs to describe the new behavior. It also adds localized copy for the new Linux UI strings across supported languages and includes a small analysis-view refactor needed to keep the integrated flow stable.