### PR TITLE
Add fixed Touch Bar branding and centralize app slogan

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -20,6 +20,7 @@ Use this map before reading feature-specific references:
 
 ### UI and visual consistency
 - `docs/reference/design/DESIGN_SYSTEM.md`
+- `docs/reference/platform/TOUCHBAR.md`
 
 ### Analysis and compatibility routing
 - `docs/reference/features/analysis/ANALYSIS_COMPATIBILITY.md`

--- a/docs/reference/core/FILE_STRUCTURE.md
+++ b/docs/reference/core/FILE_STRUCTURE.md
@@ -46,6 +46,10 @@
 - `macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift` — Linux helper request construction and start routing.
 - `macUSB/Features/Installation/Linux/CreationProgressLinuxMapping.swift` — Linux stage mapping for shared progress UI.
 
+### Shared UI layout
+
+- `macUSB/Shared/UI/TouchBar/TouchbarSupport.swift` — global, fixed Touch Bar configuration (app branding).
+
 ### Analysis docs
 
 - `docs/reference/features/analysis/ANALYSIS_COMPATIBILITY.md` — analysis contract and routing invariants.

--- a/docs/reference/platform/TOUCHBAR.md
+++ b/docs/reference/platform/TOUCHBAR.md
@@ -1,0 +1,21 @@
+# Touch Bar Contract
+
+## Goal
+
+The `macUSB` Touch Bar must always display exactly one branding element:
+- app icon,
+- bold `macUSB` name,
+- separator `-`,
+- full slogan shared with the `WelcomeView` screen.
+
+## Runtime Contract
+
+- The Touch Bar layout is global for the main app window and pinned to the left side.
+- The Touch Bar content does not change between views or workflow stages.
+- No additional buttons, actions, or dynamic elements are rendered.
+
+## Implementation
+
+- Module: `macUSB/Shared/UI/TouchBar/TouchbarSupport.swift`
+- Attachment point: `WindowConfigurator` in `macUSB/App/ContentView.swift`
+- Shared branding text source: `macUSB/Features/Welcome/AppBranding.swift`

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		A10000012F0000010000003E /* Workflow/Linux/HelperWorkflowLinuxStages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003B /* Workflow/Linux/HelperWorkflowLinuxStages.swift */; };
 		A10000012F0000010000003F /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003C /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift */; };
 		A10000012F00000100000040 /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000003D /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift */; };
-		A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */; };
 		A10000012F00000100000041 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */; };
+		A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */; };
 		B10000012F00000100000001 /* macUSB/Resources/Sounds/burn_complete.aif in Resources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */; };
 		C10000012F00000100000001 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */; };
 		D10000012F00000100000001 /* macUSB/Resources/Icons/Linux/Distros in Resources */ = {isa = PBXBuildFile; fileRef = D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */; };
@@ -106,8 +106,8 @@
 		A10000012F0000010000003B /* Workflow/Linux/HelperWorkflowLinuxStages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxStages.swift; sourceTree = "<group>"; };
 		A10000012F0000010000003C /* Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxProgressParsing.swift; sourceTree = "<group>"; };
 		A10000012F0000010000003D /* Workflow/Linux/HelperWorkflowLinuxDiskOps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxDiskOps.swift; sourceTree = "<group>"; };
-		A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift; sourceTree = "<group>"; };
 		A10000012F00000100000042 /* macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = macUSB/Resources/LaunchDaemons/com.kruszoneq.macusb.helper.debug.plist; sourceTree = "<group>"; };
+		A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift; sourceTree = "<group>"; };
 		B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = macUSB/Resources/Sounds/burn_complete.aif; sourceTree = "<group>"; };
 		C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift; sourceTree = "<group>"; };
 		D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */ = {isa = PBXFileReference; lastKnownFileType = folder; path = macUSB/Resources/Icons/Linux/Distros; sourceTree = "<group>"; };
@@ -180,6 +180,7 @@
 				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/UniversalInstallationView.swift,
+				Features/Welcome/AppBranding.swift,
 				Features/Welcome/WelcomeView.swift,
 				macUSBIcon.icon,
 				Resources/Icons/Linux/linux.icns,
@@ -223,6 +224,7 @@
 				Shared/UI/DesignTokens.swift,
 				Shared/UI/LiquidGlassCompatibility.swift,
 				Shared/UI/StatusCard.swift,
+				Shared/UI/TouchBar/TouchbarSupport.swift,
 			);
 			target = 0F94F4A42EDE3E510019F69A /* macUSB */;
 		};
@@ -271,6 +273,7 @@
 				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/UniversalInstallationView.swift,
+				Features/Welcome/AppBranding.swift,
 				Features/Welcome/WelcomeView.swift,
 				macUSBIcon.icon,
 				Resources/Localizable.xcstrings,
@@ -297,6 +300,7 @@
 				Shared/UI/DesignTokens.swift,
 				Shared/UI/LiquidGlassCompatibility.swift,
 				Shared/UI/StatusCard.swift,
+				Shared/UI/TouchBar/TouchbarSupport.swift,
 			);
 			target = 0F94F4BD2EDE3E520019F69A /* macUSBUITests */;
 		};

--- a/macUSB/App/ContentView.swift
+++ b/macUSB/App/ContentView.swift
@@ -215,6 +215,9 @@ struct WindowConfigurator: NSViewRepresentable {
                 
                 // Ustawienie tytułu
                 window.title = "macUSB"
+
+                // Staly Touch Bar dla calej aplikacji niezaleznie od widoku.
+                TouchbarSupport.shared.install(on: window)
             }
         }
         return view

--- a/macUSB/Features/Welcome/AppBranding.swift
+++ b/macUSB/Features/Welcome/AppBranding.swift
@@ -1,0 +1,13 @@
+enum MacUSBBranding {
+    static let appName = "macUSB"
+    static let sloganPrimary = "Download. Flash. Boot."
+    static let sloganSecondary = "The all-in-one USB creator for Mac"
+
+    static var welcomeSlogan: String {
+        "\(sloganPrimary)\n\(sloganSecondary)"
+    }
+
+    static var touchBarSlogan: String {
+        "\(sloganPrimary) \(sloganSecondary)"
+    }
+}

--- a/macUSB/Features/Welcome/WelcomeView.swift
+++ b/macUSB/Features/Welcome/WelcomeView.swift
@@ -30,11 +30,11 @@ struct WelcomeView: View {
                     .frame(width: 128, height: 128)
             }
 
-            Text("macUSB")
+            Text(MacUSBBranding.appName)
                 .font(.system(size: 40 * MacUSBDesignTokens.headlineScale(for: visualMode), weight: .semibold))
             
             // Opis z obsługą tłumaczeń
-            Text(verbatim: "Download. Flash. Boot.\nThe all-in-one macOS USB creator")
+            Text(verbatim: MacUSBBranding.welcomeSlogan)
                 .font(.system(size: 17 * MacUSBDesignTokens.subheadlineScale(for: visualMode), weight: .regular))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)

--- a/macUSB/Shared/UI/TouchBar/TouchbarSupport.swift
+++ b/macUSB/Shared/UI/TouchBar/TouchbarSupport.swift
@@ -1,0 +1,69 @@
+import AppKit
+
+final class TouchbarSupport: NSObject, NSTouchBarDelegate {
+    static let shared = TouchbarSupport()
+
+    private let brandingItemIdentifier = NSTouchBarItem.Identifier("com.kruszoneq.macusb.touchbar.branding")
+
+    private override init() {
+        super.init()
+    }
+
+    func install(on window: NSWindow) {
+        window.touchBar = makeTouchBar()
+    }
+
+    func makeTouchBar() -> NSTouchBar {
+        let touchBar = NSTouchBar()
+        touchBar.delegate = self
+        touchBar.customizationIdentifier = NSTouchBar.CustomizationIdentifier("com.kruszoneq.macusb.touchbar")
+        touchBar.defaultItemIdentifiers = [brandingItemIdentifier, .flexibleSpace]
+        touchBar.customizationAllowedItemIdentifiers = []
+        return touchBar
+    }
+
+    func touchBar(_ touchBar: NSTouchBar, makeItemForIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
+        guard identifier == brandingItemIdentifier else { return nil }
+
+        let item = NSCustomTouchBarItem(identifier: brandingItemIdentifier)
+        item.customizationLabel = "macUSB Branding"
+        item.view = makeBrandingView()
+        return item
+    }
+
+    private func makeBrandingView() -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 8
+
+        let imageView = NSImageView()
+        imageView.image = NSApplication.shared.applicationIconImage
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            imageView.widthAnchor.constraint(equalToConstant: 20),
+            imageView.heightAnchor.constraint(equalToConstant: 20)
+        ])
+
+        let label = NSTextField(labelWithAttributedString: makeBrandingText())
+        label.lineBreakMode = .byTruncatingTail
+
+        stack.addArrangedSubview(imageView)
+        stack.addArrangedSubview(label)
+        return stack
+    }
+
+    private func makeBrandingText() -> NSAttributedString {
+        let text = NSMutableAttributedString(
+            string: MacUSBBranding.appName,
+            attributes: [.font: NSFont.boldSystemFont(ofSize: 13)]
+        )
+        let suffix = NSAttributedString(
+            string: " - \(MacUSBBranding.touchBarSlogan)",
+            attributes: [.font: NSFont.systemFont(ofSize: 13)]
+        )
+        text.append(suffix)
+        return text
+    }
+}


### PR DESCRIPTION
This PR introduces a dedicated Touch Bar support module that keeps branding visible and consistent across the app flow by always rendering the app icon, name, and slogan in a fixed left-aligned layout. It also centralizes the branding text in the Welcome feature and updates the slogan wording so both Welcome and Touch Bar present the same message.

- Added reusable Touch Bar branding view and integrated it into app content flow.
- Centralized branding constants in the Welcome feature.
- Updated Touch Bar-related runtime reference docs and file-structure docs for the new module.