### PR TITLE
Add safe USB ejection on finish summary screen

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -294,6 +294,7 @@ When branch creation is requested:
 - Do not use escaped newline sequences like `\n` in commit message text; use normal multi-line commit formatting only.
 - When creating commits from CLI, never pass `\n` inside a single `-m` value; use separate `-m` flags (title + body) or standard multi-line commit input.
 - If a commit includes updates to runtime reference docs under `docs/reference/`, `docs/CHANGELOG.md`, and/or `docs/AGENTS.md`, do not explicitly enumerate those documentation-file updates in the commit title or commit body.
+- In commit title/body descriptions, omit explicit listing of debug-only functionality that is not present in Release builds.
 
 ### Commit scope rules
 
@@ -337,6 +338,7 @@ When branch creation is requested:
 - Start with one clear, expanded paragraph explaining what changed and why.
 - If useful, add a short flat list of new features and/or fixes.
 - Do not include testing information in the PR description.
+- In PR title/description, omit explicit listing of debug-only functionality that is not present in Release builds.
 
 ### PR approval gate (mandatory)
 

--- a/docs/reference/features/usb/FINISH_AND_CLEANUP.md
+++ b/docs/reference/features/usb/FINISH_AND_CLEANUP.md
@@ -7,6 +7,14 @@ Finish screen must report:
 - relevant final metrics/status,
 - cleanup result state.
 - for Linux workflow failures, show a localized warning card (orange tone) with localized title + localized error description mapped from helper failure context (not raw helper error text).
+- after successful creation, show a localized eject-action card for safe ejection of the selected target whole-disk (`diskX`).
+- eject card behavior:
+  - use accent tone and an eject symbol,
+  - run safe eject for whole-disk target,
+  - disable action when target is no longer available,
+  - on successful eject, transition to localized success confirmation card,
+  - on eject failure, show localized error card and allow retry.
+- debug finish routes keep the eject card visible with a disabled `DEBUG` action.
 
 ## Cleanup Determinism
 

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -174,6 +174,7 @@
 				Features/Downloader/UI/MacOSDownloaderProcessView.swift,
 				Features/Downloader/UI/MacOSDownloaderSummaryView.swift,
 				Features/Downloader/UI/MacOSDownloaderWindowShellView.swift,
+				Features/Finish/FinishUSBEjectLogic.swift,
 				Features/Finish/FinishUSBView.swift,
 				Features/Installation/CreationProgressView.swift,
 				Features/Installation/CreatorHelperLogic.swift,
@@ -827,7 +828,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;
@@ -883,7 +884,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 20;
+				CURRENT_PROJECT_VERSION = 21;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;

--- a/macUSB/App/ContentView.swift
+++ b/macUSB/App/ContentView.swift
@@ -65,7 +65,8 @@ struct ContentView: View {
                             isPPC: false,
                             didFail: false,
                             cleanupTempWorkURL: debugCleanupTempWorkURL,
-                            shouldDetachMountPoint: false
+                            shouldDetachMountPoint: false,
+                            isDebugEjectMode: true
                         )
                     case .debugFinishUSBTigerSuccess:
                         FinishUSBView(
@@ -78,7 +79,8 @@ struct ContentView: View {
                             isPPC: true,
                             didFail: false,
                             cleanupTempWorkURL: debugTigerCleanupTempWorkURL,
-                            shouldDetachMountPoint: false
+                            shouldDetachMountPoint: false,
+                            isDebugEjectMode: true
                         )
                     case .debugFinishUSBLinuxSuccess:
                         FinishUSBView(
@@ -92,7 +94,8 @@ struct ContentView: View {
                             isLinuxWorkflow: true,
                             didFail: false,
                             cleanupTempWorkURL: debugLinuxCleanupTempWorkURL,
-                            shouldDetachMountPoint: false
+                            shouldDetachMountPoint: false,
+                            isDebugEjectMode: true
                         )
                     }
                 }

--- a/macUSB/Features/Finish/FinishUSBEjectLogic.swift
+++ b/macUSB/Features/Finish/FinishUSBEjectLogic.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Combine
+
+@MainActor
+final class FinishUSBEjectLogic: ObservableObject {
+    enum State: Equatable {
+        case ready
+        case inProgress
+        case ejected
+        case unavailable
+        case failed
+        case debugDisabled
+    }
+
+    @Published private(set) var state: State = .unavailable
+    @Published private(set) var failureMessage: String?
+
+    private let targetWholeDiskBSDName: String?
+    private let isDebugMode: Bool
+    private var availabilityTimer: Timer?
+
+    init(targetWholeDiskBSDName: String?, isDebugMode: Bool) {
+        if let targetWholeDiskBSDName, !targetWholeDiskBSDName.isEmpty {
+            self.targetWholeDiskBSDName = USBDriveLogic.wholeDiskName(from: targetWholeDiskBSDName)
+        } else {
+            self.targetWholeDiskBSDName = nil
+        }
+        self.isDebugMode = isDebugMode
+    }
+
+    deinit {
+        availabilityTimer?.invalidate()
+    }
+
+    func prepareForPresentation() {
+        failureMessage = nil
+
+        if isDebugMode {
+            state = .debugDisabled
+            return
+        }
+
+        refreshAvailabilityState()
+    }
+
+    func startAvailabilityMonitoring() {
+        availabilityTimer?.invalidate()
+
+        availabilityTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.refreshAvailabilityStateIfNeeded()
+            }
+        }
+    }
+
+    func stopAvailabilityMonitoring() {
+        availabilityTimer?.invalidate()
+        availabilityTimer = nil
+    }
+
+    func performEject() {
+        guard !isDebugMode else {
+            state = .debugDisabled
+            return
+        }
+
+        guard state != .inProgress else { return }
+
+        guard let disk = targetWholeDiskBSDName else {
+            AppLogging.info("FinishEject: brak identyfikatora whole disk, oznaczam nośnik jako niedostępny.", category: "Installation")
+            state = .unavailable
+            return
+        }
+
+        guard isDiskAvailable(disk) else {
+            AppLogging.info("FinishEject: nośnik /dev/\(disk) nie jest już dostępny.", category: "Installation")
+            state = .unavailable
+            return
+        }
+
+        failureMessage = nil
+        state = .inProgress
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let result = Self.executeDiskutilEject(for: disk)
+
+            DispatchQueue.main.async {
+                if result.exitCode == 0 {
+                    AppLogging.info("FinishEject: pomyślnie wysunięto /dev/\(disk).", category: "Installation")
+                    self.state = .ejected
+                    self.failureMessage = nil
+                    return
+                }
+
+                if !self.isDiskAvailable(disk) {
+                    AppLogging.info("FinishEject: nośnik /dev/\(disk) został odłączony podczas operacji.", category: "Installation")
+                    self.state = .unavailable
+                    self.failureMessage = nil
+                    return
+                }
+
+                let stderrText = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                let fallbackMessage = "Zamknij aplikacje używające nośnika i spróbuj ponownie."
+                let localizedMessage = String(localized: "finish.eject.error.description")
+                let message = stderrText.isEmpty
+                    ? (localizedMessage == "finish.eject.error.description" ? fallbackMessage : localizedMessage)
+                    : stderrText
+
+                AppLogging.error(
+                    "FinishEject: nie udało się wysunąć /dev/\(disk), kod=\(result.exitCode), stderr=\(stderrText)",
+                    category: "Installation"
+                )
+
+                self.state = .failed
+                self.failureMessage = message
+            }
+        }
+    }
+
+    private func refreshAvailabilityState() {
+        guard !isDebugMode else {
+            state = .debugDisabled
+            return
+        }
+
+        guard let disk = targetWholeDiskBSDName else {
+            state = .unavailable
+            return
+        }
+
+        state = isDiskAvailable(disk) ? .ready : .unavailable
+    }
+
+    private func refreshAvailabilityStateIfNeeded() {
+        guard !isDebugMode else { return }
+
+        switch state {
+        case .ready, .failed:
+            guard let disk = targetWholeDiskBSDName else {
+                state = .unavailable
+                failureMessage = nil
+                return
+            }
+
+            if !isDiskAvailable(disk) {
+                AppLogging.info("FinishEject: wykryto odłączenie nośnika /dev/\(disk), dezaktywuję akcję wysuwania.", category: "Installation")
+                state = .unavailable
+                failureMessage = nil
+            }
+        case .inProgress, .ejected, .unavailable, .debugDisabled:
+            break
+        }
+    }
+
+    private func isDiskAvailable(_ wholeDiskBSDName: String) -> Bool {
+        let devicePath = "/dev/\(wholeDiskBSDName)"
+        return FileManager.default.fileExists(atPath: devicePath)
+    }
+
+    nonisolated private static func executeDiskutilEject(for wholeDiskBSDName: String) -> (exitCode: Int32, stderr: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+        process.arguments = ["eject", "/dev/\(wholeDiskBSDName)"]
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return (1, error.localizedDescription)
+        }
+
+        process.waitUntilExit()
+
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
+
+        return (process.terminationStatus, stderrText)
+    }
+}

--- a/macUSB/Features/Finish/FinishUSBView.swift
+++ b/macUSB/Features/Finish/FinishUSBView.swift
@@ -19,6 +19,8 @@ struct FinishUSBView: View {
     let detectedSystemIcon: NSImage?
     let resultDetailMessage: String?
     let linuxErrorPresentation: LinuxWorkflowErrorPresentation?
+    let targetWholeDiskBSDName: String?
+    let isDebugEjectMode: Bool
     
     @State private var isCleaning: Bool = true
     @State private var cleanupSuccess: Bool = false
@@ -26,6 +28,7 @@ struct FinishUSBView: View {
     @State private var didPlayResultSound: Bool = false
     @State private var didSendBackgroundNotification: Bool = false
     @State private var completionDurationText: String? = nil
+    @StateObject private var ejectLogic: FinishUSBEjectLogic
 
     init(
         systemName: String,
@@ -40,7 +43,9 @@ struct FinishUSBView: View {
         shouldDetachMountPoint: Bool = true,
         detectedSystemIcon: NSImage? = nil,
         resultDetailMessage: String? = nil,
-        linuxErrorPresentation: LinuxWorkflowErrorPresentation? = nil
+        linuxErrorPresentation: LinuxWorkflowErrorPresentation? = nil,
+        targetWholeDiskBSDName: String? = nil,
+        isDebugEjectMode: Bool = false
     ) {
         self.systemName = systemName
         self.mountPoint = mountPoint
@@ -55,6 +60,14 @@ struct FinishUSBView: View {
         self.detectedSystemIcon = detectedSystemIcon
         self.resultDetailMessage = resultDetailMessage
         self.linuxErrorPresentation = linuxErrorPresentation
+        self.targetWholeDiskBSDName = targetWholeDiskBSDName
+        self.isDebugEjectMode = isDebugEjectMode
+        _ejectLogic = StateObject(
+            wrappedValue: FinishUSBEjectLogic(
+                targetWholeDiskBSDName: targetWholeDiskBSDName,
+                isDebugMode: isDebugEjectMode
+            )
+        )
     }
     
     private var isSnowLeopard: Bool {
@@ -69,6 +82,32 @@ struct FinishUSBView: View {
     private var isCancelledResult: Bool { didCancel }
     private var isFailedResult: Bool { didFail && !didCancel }
     private var isSuccessResult: Bool { !didFail && !didCancel }
+    private var shouldShowEjectSection: Bool {
+        guard isSuccessResult else { return false }
+        if isDebugEjectMode { return true }
+        return targetWholeDiskBSDName != nil
+    }
+    private func finishEjectText(_ key: String, _ defaultValue: String) -> String {
+        let localized = Bundle.main.localizedString(forKey: key, value: nil, table: nil)
+        return localized == key ? defaultValue : localized
+    }
+    private var ejectActionButtonLabel: String {
+        if ejectLogic.state == .debugDisabled {
+            return finishEjectText("finish.eject.button.debug", "DEBUG")
+        }
+        if ejectLogic.state == .failed {
+            return finishEjectText("finish.eject.error.retry", "Spróbuj ponownie")
+        }
+        return finishEjectText("finish.eject.button.action", "Wysuń nośnik")
+    }
+    private var isEjectActionEnabled: Bool {
+        switch ejectLogic.state {
+        case .ready, .failed:
+            return true
+        case .inProgress, .unavailable, .ejected, .debugDisabled:
+            return false
+        }
+    }
     private var sectionIconFont: Font { .title3 }
     private var primaryResultTone: MacUSBSurfaceTone {
         if isCancelledResult { return .warning }
@@ -207,6 +246,11 @@ struct FinishUSBView: View {
                         }
                     }
 
+                    if shouldShowEjectSection {
+                        finishEjectSection
+                            .animation(.easeInOut(duration: 0.3), value: ejectLogic.state)
+                    }
+
                     if isSuccessResult && isPPC && !isSnowLeopard {
                         StatusCard(tone: .subtle, density: .compact) {
                             VStack(alignment: .leading, spacing: 10) {
@@ -328,12 +372,113 @@ struct FinishUSBView: View {
         )
         .onAppear {
             menuState.setDownloaderAccessBlocked(true, reason: downloaderBlockReason)
+            ejectLogic.prepareForPresentation()
+            ejectLogic.startAvailabilityMonitoring()
             playResultSoundOnce()
             performCleanupWithDelay()
             sendSystemNotificationIfInactive()
         }
         .onDisappear {
             menuState.setDownloaderAccessBlocked(false, reason: downloaderBlockReason)
+            ejectLogic.stopAvailabilityMonitoring()
+        }
+    }
+
+    @ViewBuilder
+    private var finishEjectSection: some View {
+        switch ejectLogic.state {
+        case .ejected:
+            StatusCard(tone: .success, density: .compact) {
+                HStack(alignment: .center) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(sectionIconFont)
+                        .foregroundColor(.green)
+                        .frame(width: MacUSBDesignTokens.iconColumnWidth)
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(finishEjectText("finish.eject.success.title", "Nośnik został bezpiecznie wysunięty"))
+                            .font(.headline)
+                            .foregroundColor(.green)
+                        Text(finishEjectText("finish.eject.success.description", "Możesz teraz odłączyć nośnik USB."))
+                            .font(.subheadline)
+                            .foregroundColor(.green.opacity(0.85))
+                    }
+                    Spacer()
+                }
+            }
+            .transition(.opacity.combined(with: .move(edge: .top)))
+
+        default:
+            VStack(spacing: MacUSBDesignTokens.sectionGroupSpacing) {
+                if ejectLogic.state == .failed {
+                    StatusCard(tone: .error, density: .compact) {
+                        HStack(alignment: .center) {
+                            Image(systemName: "xmark.octagon.fill")
+                                .font(sectionIconFont)
+                                .foregroundColor(.red)
+                                .frame(width: MacUSBDesignTokens.iconColumnWidth)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(finishEjectText("finish.eject.error.title", "Nie można wysunąć nośnika"))
+                                    .font(.headline)
+                                    .foregroundColor(.red)
+                                Text(ejectLogic.failureMessage ?? finishEjectText("finish.eject.error.description", "Zamknij aplikacje używające nośnika i spróbuj ponownie."))
+                                    .font(.subheadline)
+                                    .foregroundColor(.red.opacity(0.85))
+                            }
+                            Spacer()
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+
+                StatusCard(tone: .active, density: .compact) {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(alignment: .center) {
+                            Image(systemName: "eject.fill")
+                                .font(sectionIconFont)
+                                .foregroundColor(.accentColor)
+                                .frame(width: MacUSBDesignTokens.iconColumnWidth)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(
+                                    ejectLogic.state == .unavailable
+                                    ? finishEjectText("finish.eject.unavailable.title", "Nośnik nie jest już dostępny")
+                                    : finishEjectText("finish.eject.card.title", "Bezpiecznie wysuń nośnik USB")
+                                )
+                                .font(.headline)
+                                .foregroundColor(.accentColor)
+                                Text(
+                                    ejectLogic.state == .unavailable
+                                    ? finishEjectText("finish.eject.unavailable.description", "Nośnik został odłączony lub wysunięty poza aplikacją.")
+                                    : finishEjectText("finish.eject.card.description", "Po zakończeniu pracy wysuń nośnik przed odłączeniem od komputera.")
+                                )
+                                .font(.subheadline)
+                                .foregroundColor(.accentColor.opacity(0.9))
+                            }
+                            Spacer()
+                        }
+
+                        Button(action: {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                ejectLogic.performEject()
+                            }
+                        }) {
+                            HStack {
+                                Text(ejectActionButtonLabel)
+                                if ejectLogic.state == .inProgress {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Image(systemName: "eject")
+                                }
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(8)
+                        }
+                        .macUSBPrimaryButtonStyle(isEnabled: isEjectActionEnabled)
+                        .disabled(!isEjectActionEnabled)
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
     }
     // --- LOGIKA ---

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -27,6 +27,7 @@ struct CreationProgressView: View {
     let isPPC: Bool
     let isLinuxWorkflow: Bool
     let shouldDetachMountPoint: Bool
+    let targetWholeDiskBSDName: String?
     let needsPreformat: Bool
     let onReset: () -> Void
     let onCancelRequested: () -> Void
@@ -175,7 +176,8 @@ struct CreationProgressView: View {
                     shouldDetachMountPoint: shouldDetachMountPoint,
                     detectedSystemIcon: detectedSystemIcon,
                     resultDetailMessage: workflowResultDetailMessage,
-                    linuxErrorPresentation: workflowResultErrorPresentation
+                    linuxErrorPresentation: workflowResultErrorPresentation,
+                    targetWholeDiskBSDName: targetWholeDiskBSDName
                 ),
                 isActive: $navigateToFinish
             ) { EmptyView() }

--- a/macUSB/Features/Installation/UniversalInstallationView.swift
+++ b/macUSB/Features/Installation/UniversalInstallationView.swift
@@ -76,6 +76,10 @@ struct UniversalInstallationView: View {
     var tempWorkURL: URL {
         return FileManager.default.temporaryDirectory.appendingPathComponent("macUSB_temp")
     }
+    private var targetWholeDiskBSDNameForFinish: String? {
+        guard let targetDrive else { return nil }
+        return USBDriveLogic.wholeDiskName(from: targetDrive.device)
+    }
 
     private var showsIdleActions: Bool {
         !isProcessing && !isHelperWorking && !isCancelled && !isUSBDisconnectedLock && !isCancelling
@@ -445,6 +449,7 @@ struct UniversalInstallationView: View {
                     isPPC: isPPC,
                     isLinuxWorkflow: isLinuxWorkflow,
                     shouldDetachMountPoint: shouldDetachMountPointAfterFinish,
+                    targetWholeDiskBSDName: targetWholeDiskBSDNameForFinish,
                     needsPreformat: (targetDrive?.needsFormatting ?? false) && !isPPC,
                     onReset: {
                         NotificationCenter.default.post(name: .macUSBResetToStart, object: nil)

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -6835,6 +6835,918 @@
         }
       }
     },
+    "finish.eject.button.action" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenträger auswerfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eject Drive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expulsar unidad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Éjecter le disque"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espelli unità"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブを取り出す"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysuń nośnik"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejetar dispositivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Извлечь накопитель"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücüyü çıkar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вийняти накопичувач"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tháo ổ đĩa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弹出驱动器"
+          }
+        }
+      }
+    },
+    "finish.eject.button.debug" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG"
+          }
+        }
+      }
+    },
+    "finish.eject.card.description" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Werfen Sie den Datenträger nach Abschluss aus, bevor Sie ihn vom Computer trennen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "After finishing, eject the drive before disconnecting it from your Mac."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cuando termines, expulsa la unidad antes de desconectarla del ordenador."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une fois terminé, éjectez le disque avant de le déconnecter de votre Mac."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al termine, espelli l’unità prima di scollegarla dal computer."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作業が完了したら、コンピュータから取り外す前にドライブを取り出してください。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Po zakończeniu pracy wysuń nośnik przed odłączeniem od komputera."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ao terminar, ejete o dispositivo antes de desconectá-lo do computador."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "После завершения извлеките накопитель перед отключением от компьютера."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşiniz bittiğinde sürücüyü bilgisayardan ayırmadan önce çıkarın."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Після завершення вийміть накопичувач перед від’єднанням від комп’ютера."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sau khi hoàn tất, hãy tháo ổ đĩa trước khi ngắt kết nối khỏi máy tính."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成后，请先弹出驱动器，再将其从电脑断开连接。"
+          }
+        }
+      }
+    },
+    "finish.eject.card.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB-Datenträger sicher auswerfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Safely eject the USB drive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Expulsa de forma segura la unidad USB"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Éjectez le disque USB en toute sécurité"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espelli in sicurezza l’unità USB"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USBドライブを安全に取り出す"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bezpiecznie wysuń nośnik USB"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ejete o dispositivo USB com segurança"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Безопасно извлеките USB-накопитель"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB sürücüsünü güvenle çıkar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Безпечно вийміть USB-накопичувач"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tháo ổ USB an toàn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全弹出 USB 驱动器"
+          }
+        }
+      }
+    },
+    "finish.eject.error.description" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schließen Sie Apps, die den Datenträger verwenden, und versuchen Sie es erneut."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close apps using the drive and try again."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cierra las apps que usan la unidad e inténtalo de nuevo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermez les apps qui utilisent le disque, puis réessayez."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiudi le app che usano l’unità e riprova."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブを使用中のアプリを閉じて、もう一度お試しください。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamknij aplikacje używające nośnika i spróbuj ponownie."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feche os apps que usam o dispositivo e tente novamente."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закройте приложения, использующие накопитель, и попробуйте снова."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücüyü kullanan uygulamaları kapatıp tekrar deneyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закрийте програми, що використовують накопичувач, і спробуйте ще раз."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đóng các ứng dụng đang sử dụng ổ đĩa rồi thử lại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请关闭正在使用该驱动器的应用，然后重试。"
+          }
+        }
+      }
+    },
+    "finish.eject.error.retry" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erneut versuchen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Try Again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Intentar de nuevo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Riprova"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "再試行"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spróbuj ponownie"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tentar novamente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторить"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tekrar Dene"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спробувати ще раз"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thử lại"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        }
+      }
+    },
+    "finish.eject.error.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenträger konnte nicht ausgeworfen werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unable to eject the drive"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se puede expulsar la unidad"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d’éjecter le disque"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile espellere l’unità"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブを取り出せません"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie można wysunąć nośnika"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível ejetar o dispositivo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удается извлечь накопитель"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücü çıkarılamıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдається вийняти накопичувач"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể tháo ổ đĩa"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法弹出驱动器"
+          }
+        }
+      }
+    },
+    "finish.eject.success.description" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sie können den USB-Datenträger jetzt trennen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can now disconnect the USB drive."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ahora puedes desconectar la unidad USB."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez maintenant déconnecter le disque USB."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora puoi scollegare l’unità USB."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USBドライブを取り外せます。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Możesz teraz odłączyć nośnik USB."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agora você pode desconectar o dispositivo USB."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Теперь можно отключить USB-накопитель."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Artık USB sürücüsünü bağlantıdan ayırabilirsiniz."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тепер можна від’єднати USB-накопичувач."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bây giờ bạn có thể ngắt kết nối USB."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "现在可以断开 USB 驱动器。"
+          }
+        }
+      }
+    },
+    "finish.eject.success.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenträger wurde sicher ausgeworfen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The drive was safely ejected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La unidad se expulsó de forma segura"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le disque a été éjecté en toute sécurité"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’unità è stata espulsa in sicurezza"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブは安全に取り出されました"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nośnik został bezpiecznie wysunięty"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O dispositivo foi ejetado com segurança"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопитель безопасно извлечен"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücü güvenle çıkarıldı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопичувач безпечно вийнято"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ổ đĩa đã được tháo an toàn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动器已安全弹出"
+          }
+        }
+      }
+    },
+    "finish.eject.unavailable.description" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Datenträger wurde außerhalb der App getrennt oder ausgeworfen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The drive was disconnected or ejected outside the app."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La unidad se desconectó o se expulsó fuera de la app."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le disque a été déconnecté ou éjecté en dehors de l’app."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’unità è stata scollegata o espulsa fuori dall’app."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブはアプリの外で取り外されたか、取り出されました。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nośnik został odłączony lub wysunięty poza aplikacją."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O dispositivo foi desconectado ou ejetado fora do app."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопитель был отключен или извлечен вне приложения."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücü uygulama dışında bağlantıdan ayrıldı veya çıkarıldı."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопичувач було від’єднано або вийнято поза застосунком."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ổ đĩa đã bị ngắt kết nối hoặc tháo bên ngoài ứng dụng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动器已在应用外断开连接或弹出。"
+          }
+        }
+      }
+    },
+    "finish.eject.unavailable.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Datenträger ist nicht mehr verfügbar"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The drive is no longer available"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La unidad ya no está disponible"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le disque n’est plus disponible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L’unità non è più disponibile"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ドライブは利用できません"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nośnik nie jest już dostępny"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O dispositivo não está mais disponível"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопитель больше недоступен"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sürücü artık kullanılamıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Накопичувач більше недоступний"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ổ đĩa không còn khả dụng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驱动器已不可用"
+          }
+        }
+      }
+    },
     "Français" : {
       "localizations" : {
         "de" : {
@@ -9709,416 +10621,6 @@
         }
       }
     },
-    "installation.error.card.warning.title" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Erstellung des Mediums konnte nicht abgeschlossen werden"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't complete media creation"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo completar la creación del medio"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La création du support n'a pas pu être terminée"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile completare la creazione del supporto"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メディアの作成を完了できませんでした"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się ukończyć tworzenia nośnika"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível concluir a criação da mídia"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось завершить создание носителя"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ortam oluşturma tamamlanamadı"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося завершити створення носія"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể hoàn tất việc tạo phương tiện"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法完成介质创建"
-          }
-        }
-      }
-    },
-    "installation.error.linux.verify_write.generic" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Verifizierung des Linux-Mediums ist fehlgeschlagen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linux media write verification failed."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La verificación de escritura del medio Linux falló."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La vérification de l'écriture du support Linux a échoué."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La verifica della scrittura del supporto Linux non è riuscita."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linuxメディアの書き込み検証に失敗しました。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weryfikacja zapisu nośnika Linux zakończyła się błędem."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A verificação da gravação da mídia Linux falhou."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Проверка записи на носитель Linux завершилась ошибкой."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linux ortamı yazma doğrulaması başarısız oldu."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Перевірка запису на носій Linux завершилася помилкою."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quá trình xác minh ghi phương tiện Linux đã thất bại."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linux 介质写入验证失败。"
-          }
-        }
-      }
-    },
-    "installation.error.linux.verify_write.mismatch" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Es konnte nicht bestätigt werden, dass die Daten auf dem USB-Medium mit dem Quellabbild übereinstimmen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't confirm that data on the USB drive matches the source image."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudo confirmar que los datos del medio USB coincidan con la imagen de origen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de confirmer que les données du support USB correspondent à l'image source."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è stato possibile confermare che i dati sul supporto USB corrispondano all'immagine di origine."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USBメディア上のデータがソースイメージと一致することを確認できませんでした。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się potwierdzić zgodności danych na nośniku USB z obrazem źródłowym."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível confirmar que os dados na mídia USB correspondem à imagem de origem."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось подтвердить, что данные на USB-носителе соответствуют исходному образу."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "USB ortamındaki verilerin kaynak imajla eşleştiği doğrulanamadı."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося підтвердити відповідність даних на USB-носії вихідному образу."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể xác nhận dữ liệu trên thiết bị USB khớp với ảnh nguồn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法确认 USB 介质上的数据与源镜像一致。"
-          }
-        }
-      }
-    },
-    "installation.error.linux.verify_write.short_read" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Während der Verifizierung konnten nicht alle Daten vom USB-Medium gelesen werden."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Couldn't read all data from the USB drive during verification."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pudieron leer todos los datos del medio USB durante la verificación."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible de lire l'intégralité des données du support USB pendant la vérification."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non è stato possibile leggere tutti i dati dal supporto USB durante la verifica."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "検証中にUSBメディアからすべてのデータを読み取れませんでした。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się odczytać pełnych danych z nośnika USB podczas weryfikacji."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível ler todos os dados da mídia USB durante a verificação."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось прочитать полный объем данных с USB-носителя во время проверки."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doğrulama sırasında USB ortamından tüm veriler okunamadı."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося прочитати повний обсяг даних з USB-носія під час перевірки."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể đọc đầy đủ dữ liệu từ thiết bị USB trong quá trình xác minh."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "验证期间无法从 USB 介质读取完整数据。"
-          }
-        }
-      }
-    },
-    "installation.error.workflow.generic" : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Der Vorgang konnte nicht abgeschlossen werden. Versuche es erneut und überprüfe das ausgewählte USB-Medium."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The operation couldn't be completed. Try again and check the selected USB drive."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La operación finalizó con un error. Inténtalo de nuevo y verifica el medio USB seleccionado."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'opération n'a pas pu être terminée. Réessaie et vérifie le support USB sélectionné."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'operazione non può essere completata. Riprova e verifica il supporto USB selezionato."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作を完了できませんでした。再試行し、選択したUSBメディアを確認してください。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Operacja zakończyła się błędem. Spróbuj ponownie i sprawdź wybrany nośnik USB."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível concluir a operação. Tente novamente e verifique a mídia USB selecionada."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось завершить операцию. Повторите попытку и проверьте выбранный USB-носитель."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "İşlem bir hatayla tamamlandı. Yeniden deneyin ve seçilen USB ortamını kontrol edin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося завершити операцію. Спробуйте ще раз і перевірте вибраний USB-носій."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thao tác không thể hoàn tất. Hãy thử lại và kiểm tra thiết bị USB đã chọn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "操作未能完成。请重试并检查所选 USB 介质。"
-          }
-        }
-      }
-    },
     "helper.workflow.ppc_format.status" : {
       "localizations" : {
         "de" : {
@@ -11489,6 +11991,416 @@
         }
       }
     },
+    "installation.error.card.warning.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Erstellung des Mediums konnte nicht abgeschlossen werden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't complete media creation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo completar la creación del medio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La création du support n'a pas pu être terminée"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossibile completare la creazione del supporto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メディアの作成を完了できませんでした"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się ukończyć tworzenia nośnika"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível concluir a criação da mídia"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось завершить создание носителя"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ortam oluşturma tamamlanamadı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося завершити створення носія"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể hoàn tất việc tạo phương tiện"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法完成介质创建"
+          }
+        }
+      }
+    },
+    "installation.error.linux.verify_write.generic" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Verifizierung des Linux-Mediums ist fehlgeschlagen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux media write verification failed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La verificación de escritura del medio Linux falló."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La vérification de l'écriture du support Linux a échoué."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La verifica della scrittura del supporto Linux non è riuscita."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linuxメディアの書き込み検証に失敗しました。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weryfikacja zapisu nośnika Linux zakończyła się błędem."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A verificação da gravação da mídia Linux falhou."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка записи на носитель Linux завершилась ошибкой."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux ortamı yazma doğrulaması başarısız oldu."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірка запису на носій Linux завершилася помилкою."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quá trình xác minh ghi phương tiện Linux đã thất bại."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux 介质写入验证失败。"
+          }
+        }
+      }
+    },
+    "installation.error.linux.verify_write.mismatch" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es konnte nicht bestätigt werden, dass die Daten auf dem USB-Medium mit dem Quellabbild übereinstimmen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't confirm that data on the USB drive matches the source image."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo confirmar que los datos del medio USB coincidan con la imagen de origen."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de confirmer que les données du support USB correspondent à l'image source."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato possibile confermare che i dati sul supporto USB corrispondano all'immagine di origine."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USBメディア上のデータがソースイメージと一致することを確認できませんでした。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się potwierdzić zgodności danych na nośniku USB z obrazem źródłowym."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível confirmar que os dados na mídia USB correspondem à imagem de origem."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось подтвердить, что данные на USB-носителе соответствуют исходному образу."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "USB ortamındaki verilerin kaynak imajla eşleştiği doğrulanamadı."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося підтвердити відповідність даних на USB-носії вихідному образу."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể xác nhận dữ liệu trên thiết bị USB khớp với ảnh nguồn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法确认 USB 介质上的数据与源镜像一致。"
+          }
+        }
+      }
+    },
+    "installation.error.linux.verify_write.short_read" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Während der Verifizierung konnten nicht alle Daten vom USB-Medium gelesen werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn't read all data from the USB drive during verification."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudieron leer todos los datos del medio USB durante la verificación."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de lire l'intégralité des données du support USB pendant la vérification."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non è stato possibile leggere tutti i dati dal supporto USB durante la verifica."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検証中にUSBメディアからすべてのデータを読み取れませんでした。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie udało się odczytać pełnych danych z nośnika USB podczas weryfikacji."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível ler todos os dados da mídia USB durante a verificação."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось прочитать полный объем данных с USB-носителя во время проверки."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doğrulama sırasında USB ortamından tüm veriler okunamadı."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося прочитати повний обсяг даних з USB-носія під час перевірки."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không thể đọc đầy đủ dữ liệu từ thiết bị USB trong quá trình xác minh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证期间无法从 USB 介质读取完整数据。"
+          }
+        }
+      }
+    },
+    "installation.error.workflow.generic" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Vorgang konnte nicht abgeschlossen werden. Versuche es erneut und überprüfe das ausgewählte USB-Medium."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The operation couldn't be completed. Try again and check the selected USB drive."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La operación finalizó con un error. Inténtalo de nuevo y verifica el medio USB seleccionado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'opération n'a pas pu être terminée. Réessaie et vérifie le support USB sélectionné."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'operazione non può essere completata. Riprova e verifica il supporto USB selezionato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作を完了できませんでした。再試行し、選択したUSBメディアを確認してください。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Operacja zakończyła się błędem. Spróbuj ponownie i sprawdź wybrany nośnik USB."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível concluir a operação. Tente novamente e verifique a mídia USB selecionada."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось завершить операцию. Повторите попытку и проверьте выбранный USB-носитель."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "İşlem bir hatayla tamamlandı. Yeniden deneyin ve seçilen USB ortamını kontrol edin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося завершити операцію. Спробуйте ще раз і перевірте вибраний USB-носій."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thao tác không thể hoàn tất. Hãy thử lại và kiểm tra thiết bị USB đã chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作未能完成。请重试并检查所选 USB 介质。"
+          }
+        }
+      }
+    },
     "Instrukcja bootowania z nośnika USB (GitHub)" : {
       "localizations" : {
         "de" : {
@@ -11713,6 +12625,88 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "语言"
+          }
+        }
+      }
+    },
+    "Komunikat o nieczytelności nośnika w trakcie tworzenia." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinweis zur Nichtlesbarkeit des Mediums während der Erstellung"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message about unreadable media during creation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensaje sobre la imposibilidad de leer el disco durante la creación"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Message sur la non-lisibilité du disque pendant la création"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Messaggio sul supporto non leggibile durante la creazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "作成中に表示されるディスク読み取り不可メッセージ"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Komunikat o nieczytelności nośnika w trakcie tworzenia."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mensagem sobre mídia não legível durante a criação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сообщение о нечитаемом носителе во время создания"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oluşturma sırasında okunamayan ortamla ilgili ileti"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повідомлення про нечитабельність носія під час створення"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thông báo về ổ đĩa không thể đọc trong khi tạo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建过程中的磁盘不可读提示"
           }
         }
       }
@@ -20925,6 +21919,88 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "已下载数据"
+          }
+        }
+      }
+    },
+    "Podczas tworzenia nośnika startowego Linux system macOS może wyświetlić komunikat: „Dołączony dysk nie jest czytelny dla tego komputera.” Jest to spodziewane zachowanie. Aby kontynuować, w tym oknie wybierz „Ignoruj”." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beim Erstellen eines Linux-Startmediums kann macOS diese Meldung anzeigen: „Das angeschlossene Medium konnte von diesem Computer nicht gelesen werden.“ Dieses Verhalten ist zu erwarten. Um fortzufahren, wähle in diesem Fenster „Ignorieren“."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "While creating Linux boot media, macOS may show this message: “The disk you attached was not readable by this computer.” This is expected behavior. To continue, choose “Ignore” in that window."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durante la creación de un medio de arranque Linux, macOS puede mostrar este mensaje: «El ordenador no ha podido leer el disco conectado.» Este comportamiento es esperado. Para continuar, selecciona «Ignorar» en esa ventana."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pendant la création d’un support de démarrage Linux, macOS peut afficher le message suivant : « Le disque que vous avez connecté n’est pas lisible par cet ordinateur. » Ce comportement est attendu. Pour continuer, choisissez « Ignorer » dans cette fenêtre."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durante la creazione di un supporto di avvio Linux, macOS può mostrare il seguente messaggio: «Il disco collegato non può essere letto da questo computer.» Si tratta di un comportamento previsto. Per continuare, in questa finestra scegli «Ignora»."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux起動メディアの作成中に、macOSが次のメッセージを表示する場合があります:「接続したディスクは、このコンピュータで読み取れないディスクでした。」これは想定内の動作です。続けるには、このウインドウで「無視」を選択してください。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podczas tworzenia nośnika startowego Linux system macOS może wyświetlić komunikat: „Dołączony dysk nie jest czytelny dla tego komputera.” Jest to spodziewane zachowanie. Aby kontynuować, w tym oknie wybierz „Ignoruj”."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Durante a criação de uma mídia de inicialização Linux, o macOS pode mostrar a seguinte mensagem: “O disco que você conectou não pôde ser lido por este computador.” Esse comportamento é esperado. Para continuar, selecione “Ignorar” nessa janela."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Во время создания загрузочного носителя Linux macOS может показать сообщение: «Подключенный Вами диск нельзя прочитать на этом компьютере.» Это ожидаемое поведение. Чтобы продолжить, в этом окне выберите «Пропустить»."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux önyükleme ortamı oluşturulurken macOS şu iletiyi gösterebilir: “Taktığınız disk bu bilgisayar tarafından okunamadı.” Bu beklenen bir davranıştır. Devam etmek için bu pencerede “Yok Say” seçeneğini seçin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під час створення завантажувального носія Linux macOS може показати таке повідомлення: «Цей компʼютер не може прочитати підʼєднаний вами диск.» Це очікувана поведінка. Щоб продовжити, у цьому вікні виберіть «Ігнорувати»."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trong khi tạo phương tiện khởi động Linux, macOS có thể hiển thị thông báo: “Máy tính này không thể đọc được ổ đĩa bạn đưa vào.” Đây là hành vi dự kiến. Để tiếp tục, trong cửa sổ này hãy chọn “Bỏ qua”."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在创建 Linux 启动介质时，macOS 可能会显示以下提示：“此电脑不能读取你连接的磁盘。”这是预期行为。要继续，请在该窗口中选择“忽略”。"
           }
         }
       }
@@ -35622,170 +36698,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Українська"
-          }
-        }
-      }
-    },
-    "Komunikat o nieczytelności nośnika w trakcie tworzenia." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hinweis zur Nichtlesbarkeit des Mediums während der Erstellung"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message about unreadable media during creation"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensaje sobre la imposibilidad de leer el disco durante la creación"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Message sur la non-lisibilité du disque pendant la création"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Messaggio sul supporto non leggibile durante la creazione"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "作成中に表示されるディスク読み取り不可メッセージ"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Komunikat o nieczytelności nośnika w trakcie tworzenia."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mensagem sobre mídia não legível durante a criação"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сообщение о нечитаемом носителе во время создания"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oluşturma sırasında okunamayan ortamla ilgili ileti"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Повідомлення про нечитабельність носія під час створення"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thông báo về ổ đĩa không thể đọc trong khi tạo"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "创建过程中的磁盘不可读提示"
-          }
-        }
-      }
-    },
-    "Podczas tworzenia nośnika startowego Linux system macOS może wyświetlić komunikat: „Dołączony dysk nie jest czytelny dla tego komputera.” Jest to spodziewane zachowanie. Aby kontynuować, w tym oknie wybierz „Ignoruj”." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Beim Erstellen eines Linux-Startmediums kann macOS diese Meldung anzeigen: „Das angeschlossene Medium konnte von diesem Computer nicht gelesen werden.“ Dieses Verhalten ist zu erwarten. Um fortzufahren, wähle in diesem Fenster „Ignorieren“."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "While creating Linux boot media, macOS may show this message: “The disk you attached was not readable by this computer.” This is expected behavior. To continue, choose “Ignore” in that window."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durante la creación de un medio de arranque Linux, macOS puede mostrar este mensaje: «El ordenador no ha podido leer el disco conectado.» Este comportamiento es esperado. Para continuar, selecciona «Ignorar» en esa ventana."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pendant la création d’un support de démarrage Linux, macOS peut afficher le message suivant : « Le disque que vous avez connecté n’est pas lisible par cet ordinateur. » Ce comportement est attendu. Pour continuer, choisissez « Ignorer » dans cette fenêtre."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durante la creazione di un supporto di avvio Linux, macOS può mostrare il seguente messaggio: «Il disco collegato non può essere letto da questo computer.» Si tratta di un comportamento previsto. Per continuare, in questa finestra scegli «Ignora»."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linux起動メディアの作成中に、macOSが次のメッセージを表示する場合があります:「接続したディスクは、このコンピュータで読み取れないディスクでした。」これは想定内の動作です。続けるには、このウインドウで「無視」を選択してください。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podczas tworzenia nośnika startowego Linux system macOS może wyświetlić komunikat: „Dołączony dysk nie jest czytelny dla tego komputera.” Jest to spodziewane zachowanie. Aby kontynuować, w tym oknie wybierz „Ignoruj”."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durante a criação de uma mídia de inicialização Linux, o macOS pode mostrar a seguinte mensagem: “O disco que você conectou não pôde ser lido por este computador.” Esse comportamento é esperado. Para continuar, selecione “Ignorar” nessa janela."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Во время создания загрузочного носителя Linux macOS может показать сообщение: «Подключенный Вами диск нельзя прочитать на этом компьютере.» Это ожидаемое поведение. Чтобы продолжить, в этом окне выберите «Пропустить»."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Linux önyükleme ortamı oluşturulurken macOS şu iletiyi gösterebilir: “Taktığınız disk bu bilgisayar tarafından okunamadı.” Bu beklenen bir davranıştır. Devam etmek için bu pencerede “Yok Say” seçeneğini seçin."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Під час створення завантажувального носія Linux macOS може показати таке повідомлення: «Цей компʼютер не може прочитати підʼєднаний вами диск.» Це очікувана поведінка. Щоб продовжити, у цьому вікні виберіть «Ігнорувати»."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trong khi tạo phương tiện khởi động Linux, macOS có thể hiển thị thông báo: “Máy tính này không thể đọc được ổ đĩa bạn đưa vào.” Đây là hành vi dự kiến. Để tiếp tục, trong cửa sổ này hãy chọn “Bỏ qua”."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在创建 Linux 启动介质时，macOS 可能会显示以下提示：“此电脑不能读取你连接的磁盘。”这是预期行为。要继续，请在该窗口中选择“忽略”。"
           }
         }
       }


### PR DESCRIPTION
This change adds a safe whole-disk USB ejection flow to the finish summary screen after successful media creation. It introduces dedicated ejection state handling, user-facing success and error transitions, availability checks for disconnected media, and updates localization/resources so the new summary flow is correctly rendered across supported languages.