### PR TITLE
Add dedicated Windows USB creation workflow across app and helper

### DIFF
--- a/docs/reference/core/FILE_STRUCTURE.md
+++ b/docs/reference/core/FILE_STRUCTURE.md
@@ -45,6 +45,10 @@
 - `macUSB/Features/Installation/Linux/CreatorLinuxLogic.swift` — Linux-specific summary/cleanup helpers.
 - `macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift` — Linux helper request construction and start routing.
 - `macUSB/Features/Installation/Linux/CreationProgressLinuxMapping.swift` — Linux stage mapping for shared progress UI.
+- `macUSB/Features/Installation/Windows/CreatorWindowsLabelLogic.swift` — Windows target volume-label mapping policy.
+- `macUSB/Features/Installation/Windows/CreatorWindowsHelperLogic.swift` — Windows helper request construction and workflow start routing.
+- `macUSB/Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift` — Windows unmount-busy prompt/retry recovery flow.
+- `macUSB/Features/Installation/Windows/CreationProgressWindowsMapping.swift` — Windows stage mapping for shared progress UI.
 
 ### Shared UI layout
 
@@ -79,6 +83,7 @@
 - `macUSBHelper/Service/*`
 - `macUSBHelper/Workflow/*`
 - `macUSBHelper/Workflow/Linux/*` — Linux raw-copy stage builder, parser, and disk ops.
+- `macUSBHelper/Workflow/Windows/*` — Windows ISO-copy stage builder, source/target preparation, progress parsing, and verification.
 - `macUSBHelper/DownloaderAssembly/*`
 
 ## Localization catalog

--- a/docs/reference/features/analysis/WINDOWS_ANALYSIS_FLOW.md
+++ b/docs/reference/features/analysis/WINDOWS_ANALYSIS_FLOW.md
@@ -9,7 +9,7 @@ Windows detection is a fallback path in analysis between macOS and Linux.
 - Primary path remains macOS installer detection.
 - Windows path runs for `.iso` only when macOS installer metadata is not detected from mounted image.
 - If Windows is not recognized, flow continues to Linux fallback.
-- This iteration does not add Windows USB-creation workflow.
+- Supported Windows detection unlocks dedicated Windows USB-creation workflow.
 
 ## Trigger and Entry
 
@@ -122,7 +122,7 @@ Fallback icon behavior:
 Current workflow gating:
 
 - supported Windows detection is shown as successful detection state in analysis card,
-- proceed to installation remains blocked in this iteration (no Windows creation flow yet),
+- proceed to installation is enabled for supported Windows images,
 - unsupported Windows detection follows unsupported presentation path,
 - unsupported requirement info message is family-aware:
   - desktop uses `Windows 8 + EFI` requirement wording,
@@ -139,7 +139,6 @@ When Windows fallback runs, logs include:
 
 ## Non-goals
 
-- No Windows creation flow in this iteration.
 - No release-channel marketing version extraction (`22H2`, `25H2`).
 - No fallback based only on volume label when mounted metadata is unavailable.
 

--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -25,8 +25,8 @@ Linux raw-copy stages:
 Windows workflow stages:
 - `windows_prepare_source` — source ISO validation, hidden mount, FAT32-limit scan, WIM split decision (indeterminate stage),
 - `windows_prepare_target` — target USB unmount with retry/force prompt path and FAT32/MBR formatting (indeterminate stage),
-- `windows_create_media` — ISO file copy to USB (`rsync`) with determinate progress,
-- `windows_split_wim` — conditional `install.wim` split via `wimlib-imagex` with determinate progress (stage appears only when needed),
+- `windows_create_media` — ISO file copy to USB (`rsync`) with determinate progress + write speed,
+- `windows_split_wim` — conditional `install.wim` split via `wimlib-imagex` with determinate progress + write speed (stage appears only when needed),
 - `windows_verify_media` — boot file and structure validation (`boot.wim`, UEFI markers, `install.wim`/`install.swm`) (indeterminate stage),
 - `windows_cleanup_temp` — deterministic cleanup of temp files and helper-managed hidden image mount,
 - `finalize` — terminal state transition.

--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -13,12 +13,22 @@ Workflow selection must respect analyzed compatibility flags.
 - PPC dedicated formatting/restore path
 - Catalina and Sierra dedicated handling where required
 - Linux raw-copy path (`dd`)
+- Windows ISO copy path (FAT32/MBR + optional WIM split)
 
 Linux raw-copy stages:
 - `linux_unmount_target` — target USB unmount (indeterminate stage),
 - `linux_raw_copy` — raw image copy to whole disk (`/dev/rdiskX`) with progress + write speed,
 - `linux_verify_write` — post-write verification by comparing SHA-256 of source image with SHA-256 of first `N` bytes on target raw disk (`N = source image size`) (indeterminate stage),
 - `cleanup_temp` — deterministic temp cleanup,
+- `finalize` — terminal state transition.
+
+Windows workflow stages:
+- `windows_prepare_source` — source ISO validation, hidden mount, FAT32-limit scan, WIM split decision (indeterminate stage),
+- `windows_prepare_target` — target USB unmount with retry/force prompt path and FAT32/MBR formatting (indeterminate stage),
+- `windows_create_media` — ISO file copy to USB (`rsync`) with determinate progress,
+- `windows_split_wim` — conditional `install.wim` split via `wimlib-imagex` with determinate progress (stage appears only when needed),
+- `windows_verify_media` — boot file and structure validation (`boot.wim`, UEFI markers, `install.wim`/`install.swm`) (indeterminate stage),
+- `windows_cleanup_temp` — deterministic cleanup of temp files and helper-managed hidden image mount,
 - `finalize` — terminal state transition.
 
 Linux auto-mount guard invariant:
@@ -37,6 +47,8 @@ Linux summary screen (`UniversalInstallationView`) should show an informational 
 - No terminal fallback privileged execution path.
 - Stage progression shown in UI must remain deterministic.
 - Linux raw-copy must target whole-disk device, never a partition node.
+- Windows workflow must copy installer files 1:1 from ISO payload (no UEFI fallback file synthesis).
+- Windows target format must be `MS-DOS (FAT32)` + `MBR`.
 
 ## Power Management Invariant
 

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -29,6 +29,12 @@
 		A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */; };
 		A10000012F00000100000045 /* Workflow/Linux/HelperWorkflowLinuxVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000046 /* Workflow/Linux/HelperWorkflowLinuxVerification.swift */; };
 		A10000012F00000100000048 /* Workflow/Linux/HelperWorkflowLinuxMountGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000047 /* Workflow/Linux/HelperWorkflowLinuxMountGuard.swift */; };
+		A10000012F00000100000049 /* Workflow/Windows/HelperWorkflowWindowsStages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */; };
+		A10000012F0000010000004B /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */; };
+		A10000012F0000010000004D /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */; };
+		A10000012F0000010000004F /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */; };
+		A10000012F00000100000051 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */; };
+		A10000012F00000100000053 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */; };
 		B10000012F00000100000001 /* macUSB/Resources/Sounds/burn_complete.aif in Resources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */; };
 		C10000012F00000100000001 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */; };
 		D10000012F00000100000001 /* macUSB/Resources/Icons/Linux/Distros in Resources */ = {isa = PBXBuildFile; fileRef = D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */; };
@@ -112,6 +118,12 @@
 		A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift; sourceTree = "<group>"; };
 		A10000012F00000100000046 /* Workflow/Linux/HelperWorkflowLinuxVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxVerification.swift; sourceTree = "<group>"; };
 		A10000012F00000100000047 /* Workflow/Linux/HelperWorkflowLinuxMountGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Linux/HelperWorkflowLinuxMountGuard.swift; sourceTree = "<group>"; };
+		A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsStages.swift; sourceTree = "<group>"; };
+		A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift; sourceTree = "<group>"; };
+		A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift; sourceTree = "<group>"; };
+		A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift; sourceTree = "<group>"; };
+		A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift; sourceTree = "<group>"; };
+		A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift; sourceTree = "<group>"; };
 		B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = macUSB/Resources/Sounds/burn_complete.aif; sourceTree = "<group>"; };
 		C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift; sourceTree = "<group>"; };
 		D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */ = {isa = PBXFileReference; lastKnownFileType = folder; path = macUSB/Resources/Icons/Linux/Distros; sourceTree = "<group>"; };
@@ -190,10 +202,14 @@
 				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/Linux/LinuxWorkflowErrorPresentation.swift,
+				Features/Installation/Windows/CreationProgressWindowsMapping.swift,
+				Features/Installation/Windows/CreatorWindowsHelperLogic.swift,
+				Features/Installation/Windows/CreatorWindowsLabelLogic.swift,
+				Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift,
 				Features/Installation/UniversalInstallationView.swift,
 				Features/Welcome/AppBranding.swift,
 				Features/Welcome/WelcomeView.swift,
-				macUSBIcon.icon,
+				Resources/Assets.xcassets,
 				Resources/Icons/Linux/linux.icns,
 				Resources/Icons/OS/os_10_7_lion.icns,
 				Resources/Icons/OS/os_10_8_mountain_lion.icns,
@@ -287,10 +303,14 @@
 				Features/Installation/Linux/CreatorLinuxUnmountRecoveryLogic.swift,
 				Features/Installation/Linux/LinuxInstallationFlowContext.swift,
 				Features/Installation/Linux/LinuxWorkflowErrorPresentation.swift,
+				Features/Installation/Windows/CreationProgressWindowsMapping.swift,
+				Features/Installation/Windows/CreatorWindowsHelperLogic.swift,
+				Features/Installation/Windows/CreatorWindowsLabelLogic.swift,
+				Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift,
 				Features/Installation/UniversalInstallationView.swift,
 				Features/Welcome/AppBranding.swift,
 				Features/Welcome/WelcomeView.swift,
-				macUSBIcon.icon,
+				Resources/Assets.xcassets,
 				Resources/Localizable.xcstrings,
 				Shared/Localization/HelperWorkflowLocalizationKeys.swift,
 				Shared/Models/Models.swift,
@@ -431,6 +451,12 @@
 				A10000012F00000100000043 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift */,
 				A10000012F00000100000046 /* Workflow/Linux/HelperWorkflowLinuxVerification.swift */,
 				A10000012F00000100000047 /* Workflow/Linux/HelperWorkflowLinuxMountGuard.swift */,
+				A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */,
+				A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */,
+				A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */,
+				A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */,
+				A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */,
+				A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */,
 				A10000012F00000100000029 /* DownloaderAssembly/DownloaderAssemblyExecutor.swift */,
 				A10000012F0000010000002A /* DownloaderAssembly/DownloaderAssemblyProcess.swift */,
 				C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */,
@@ -665,6 +691,12 @@
 				A10000012F00000100000044 /* Workflow/Linux/HelperWorkflowLinuxUnmountLogic.swift in Sources */,
 				A10000012F00000100000045 /* Workflow/Linux/HelperWorkflowLinuxVerification.swift in Sources */,
 				A10000012F00000100000048 /* Workflow/Linux/HelperWorkflowLinuxMountGuard.swift in Sources */,
+				A10000012F00000100000049 /* Workflow/Windows/HelperWorkflowWindowsStages.swift in Sources */,
+				A10000012F0000010000004B /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift in Sources */,
+				A10000012F0000010000004D /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift in Sources */,
+				A10000012F0000010000004F /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift in Sources */,
+				A10000012F00000100000051 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift in Sources */,
+				A10000012F00000100000053 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift in Sources */,
 				A10000012F00000100000039 /* DownloaderAssembly/DownloaderAssemblyExecutor.swift in Sources */,
 				A10000012F0000010000003A /* DownloaderAssembly/DownloaderAssemblyProcess.swift in Sources */,
 			);
@@ -827,7 +859,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = macUSBIcon;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				AUTOMATION_APPLE_EVENTS = YES;
@@ -883,7 +915,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = macUSBIcon;
+					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				AUTOMATION_APPLE_EVENTS = YES;

--- a/macUSB/Features/Analysis/AnalysisLogic.swift
+++ b/macUSB/Features/Analysis/AnalysisLogic.swift
@@ -47,6 +47,7 @@ final class AnalysisLogic: ObservableObject {
     @Published var isWindowsARM: Bool = false
     @Published var windowsHasEFI: Bool = false
     @Published var isWindowsWorkflowSupported: Bool = false
+    @Published var windowsWillSplitWIM: Bool = false
 
     @Published var availableDrives: [USBDrive] = []
     @Published var hasUnreadableExternalUSBMedia: Bool = false

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
@@ -156,7 +156,11 @@ extension AnalysisLogic {
                                 if let mountedImagePath {
                                     self.log("Nie rozpoznano instalatora macOS. Przechodzę do procesu rozpoznawania Windows (z zamontowanego obrazu).")
                                     if let windowsResult = self.detectWindows(fromMountPath: mountedImagePath, sourceURL: url) {
-                                        self.applyWindowsDetectionResult(windowsResult, sourceURL: url)
+                                        self.applyWindowsDetectionResult(
+                                            windowsResult,
+                                            sourceURL: url,
+                                            mountedImagePath: mountedImagePath
+                                        )
                                         self.completeImageAnalysisRunIfCurrent(analysisRunID, reason: "Rozpoznano obraz Windows z zamontowanego źródła")
                                         return
                                     }

--- a/macUSB/Features/Analysis/Logic/Windows/AnalysisLogicWindowsLifecycle.swift
+++ b/macUSB/Features/Analysis/Logic/Windows/AnalysisLogicWindowsLifecycle.swift
@@ -2,6 +2,8 @@ import Foundation
 import AppKit
 
 extension AnalysisLogic {
+    private static let windowsFAT32LimitBytes: Int64 = 4_294_967_295
+
     var windowsFallbackSymbolName: String {
         if #available(macOS 11.0, *), NSImage(systemSymbolName: "pc", accessibilityDescription: nil) != nil {
             return "pc"
@@ -40,9 +42,10 @@ extension AnalysisLogic {
         self.isWindowsARM = false
         self.windowsHasEFI = false
         self.isWindowsWorkflowSupported = false
+        self.windowsWillSplitWIM = false
     }
 
-    func applyWindowsDetectionResult(_ result: WindowsDetectionResult, sourceURL: URL) {
+    func applyWindowsDetectionResult(_ result: WindowsDetectionResult, sourceURL: URL, mountedImagePath: String?) {
         self.isWindowsDetected = true
         self.windowsFamily = result.family
         self.windowsServicePack = result.servicePack
@@ -50,6 +53,7 @@ extension AnalysisLogic {
         self.isWindowsARM = result.isARM
         self.windowsHasEFI = result.efiStatus.hasEFI
         self.isWindowsWorkflowSupported = result.isSupported
+        self.windowsWillSplitWIM = result.isSupported && detectWindowsWimSplitNeed(mountedImagePath: mountedImagePath)
 
         self.recognizedVersion = result.displayName
         self.sourceAppURL = nil
@@ -80,7 +84,38 @@ extension AnalysisLogic {
         self.log("Rozpoznano obraz Windows: \(result.displayName)")
         self.log("Windows support gate: supported=\(result.isSupported ? "TAK" : "NIE"), reason=\(result.supportReason.rawValue), hasEFI=\(result.efiStatus.hasEFI ? "TAK" : "NIE")")
         self.log("Windows workflow flag: isWindowsWorkflowSupported=\(self.isWindowsWorkflowSupported ? "TAK" : "NIE")")
+        self.log("Windows workflow split-wim flag: \(self.windowsWillSplitWIM ? "TAK" : "NIE")")
         self.log("Windows source file: \(sourceURL.path)")
         AppLogging.separator()
+    }
+
+    private func detectWindowsWimSplitNeed(mountedImagePath: String?) -> Bool {
+        guard let mountedImagePath, !mountedImagePath.isEmpty else {
+            return false
+        }
+
+        let sourcesCandidates = [
+            URL(fileURLWithPath: mountedImagePath).appendingPathComponent("sources"),
+            URL(fileURLWithPath: mountedImagePath).appendingPathComponent("Sources")
+        ]
+
+        for sourcesPath in sourcesCandidates where FileManager.default.fileExists(atPath: sourcesPath.path) {
+            let wimCandidates = [
+                sourcesPath.appendingPathComponent("install.wim"),
+                sourcesPath.appendingPathComponent("INSTALL.WIM")
+            ]
+
+            for wimPath in wimCandidates {
+                guard FileManager.default.fileExists(atPath: wimPath.path) else { continue }
+                guard let attributes = try? FileManager.default.attributesOfItem(atPath: wimPath.path),
+                      let sizeValue = attributes[.size] as? NSNumber else {
+                    continue
+                }
+
+                return sizeValue.int64Value > Self.windowsFAT32LimitBytes
+            }
+        }
+
+        return false
     }
 }

--- a/macUSB/Features/Analysis/SystemAnalysisView.swift
+++ b/macUSB/Features/Analysis/SystemAnalysisView.swift
@@ -14,6 +14,8 @@ struct SystemAnalysisView: View {
     @State private var selectedDriveForInstallationSnapshot: USBDrive? = nil
     @State private var linuxFlowContextSnapshot: LinuxInstallationFlowContext? = nil
     @State private var windowsWorkflowSupportedSnapshot: Bool = false
+    @State private var windowsMountedSourcePathSnapshot: String? = nil
+    @State private var windowsWillSplitWIMSnapshot: Bool = false
     @State private var navigateToInstall: Bool = false
     @State private var isDragTargeted: Bool = false
     @State private var analysisWindowHandler: AnalysisWindowHandler?
@@ -378,6 +380,8 @@ struct SystemAnalysisView: View {
                         originalImageURL: logic.selectedFileUrl,
                         linuxFlowContext: linuxFlowContextSnapshot,
                         isWindowsWorkflow: windowsWorkflowSupportedSnapshot,
+                        windowsMountedSourcePath: windowsMountedSourcePathSnapshot,
+                        windowsWillSplitWim: windowsWillSplitWIMSnapshot,
                         needsCodesign: logic.needsCodesign,
                         isLegacySystem: logic.isLegacyDetected,
                         isRestoreLegacy: logic.isRestoreLegacy,
@@ -466,6 +470,8 @@ struct SystemAnalysisView: View {
                     selectedDriveForInstallationSnapshot = logic.selectedDriveForInstallation
                     linuxFlowContextSnapshot = logic.linuxInstallationFlowContext
                     windowsWorkflowSupportedSnapshot = logic.isWindowsWorkflowSupported
+                    windowsMountedSourcePathSnapshot = logic.mountedDMGPath
+                    windowsWillSplitWIMSnapshot = logic.windowsWillSplitWIM
                     isTabLocked = true
                     navigateToInstall = true
                 }) {
@@ -491,6 +497,8 @@ struct SystemAnalysisView: View {
             selectedDriveForInstallationSnapshot = nil
             linuxFlowContextSnapshot = nil
             windowsWorkflowSupportedSnapshot = false
+            windowsMountedSourcePathSnapshot = nil
+            windowsWillSplitWIMSnapshot = false
             MenuState.shared.skipAnalysisEnabled = false
             MenuState.shared.skipLinuxManualSelectionEnabled = false
         }

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -26,6 +26,8 @@ struct CreationProgressView: View {
     let isMavericks: Bool
     let isPPC: Bool
     let isLinuxWorkflow: Bool
+    let isWindowsWorkflow: Bool
+    let windowsWillSplitWimExpected: Bool
     let shouldDetachMountPoint: Bool
     let targetWholeDiskBSDName: String?
     let needsPreformat: Bool
@@ -66,6 +68,10 @@ struct CreationProgressView: View {
     private var stageDescriptors: [CreationStageDescriptor] {
         if isLinuxWorkflow {
             return CreationProgressLinuxMapping.stageKeys.map(stageDescriptor(for:))
+        }
+        if isWindowsWorkflow {
+            let includeSplit = windowsWillSplitWimExpected || normalizedStageKey(helperCurrentStageKey) == CreationProgressWindowsMapping.splitWimStageKey
+            return CreationProgressWindowsMapping.stageKeys(includeSplitWim: includeSplit).map(stageDescriptor(for:))
         }
 
         var stageKeys: [String] = ["prepare_source"]
@@ -301,6 +307,9 @@ struct CreationProgressView: View {
     }
 
     private func pendingIconForStage(_ stageKey: String) -> String {
+        if let icon = CreationProgressWindowsMapping.pendingIcon(for: stageKey) {
+            return icon
+        }
         if let icon = CreationProgressLinuxMapping.pendingIcon(for: stageKey) {
             return icon
         }
@@ -328,6 +337,9 @@ struct CreationProgressView: View {
     }
 
     private func activeIconForStage(_ stageKey: String) -> String {
+        if let icon = CreationProgressWindowsMapping.activeIcon(for: stageKey) {
+            return icon
+        }
         if let icon = CreationProgressLinuxMapping.activeIcon(for: stageKey) {
             return icon
         }
@@ -355,6 +367,9 @@ struct CreationProgressView: View {
     }
 
     private func shouldShowWriteSpeed(for stageKey: String) -> Bool {
+        if CreationProgressWindowsMapping.showsWriteSpeed(for: stageKey) {
+            return true
+        }
         if CreationProgressLinuxMapping.showsWriteSpeed(for: stageKey) {
             return true
         }
@@ -368,6 +383,9 @@ struct CreationProgressView: View {
     }
 
     private func shouldShowCopyProgress(for stageKey: String) -> Bool {
+        if CreationProgressWindowsMapping.showsCopyProgress(for: stageKey) {
+            return true
+        }
         if CreationProgressLinuxMapping.showsCopyProgress(for: stageKey) {
             return true
         }
@@ -406,6 +424,11 @@ struct CreationProgressView: View {
     }
 
     private func normalizedStageKey(_ rawStageKey: String) -> String {
+        let windowsNormalized = CreationProgressWindowsMapping.canonicalStageKey(rawStageKey)
+        if windowsNormalized != rawStageKey {
+            return windowsNormalized
+        }
+
         let linuxNormalized = CreationProgressLinuxMapping.canonicalStageKey(rawStageKey)
         if linuxNormalized != rawStageKey {
             return linuxNormalized

--- a/macUSB/Features/Installation/CreatorHelperLogic.swift
+++ b/macUSB/Features/Installation/CreatorHelperLogic.swift
@@ -354,11 +354,7 @@ extension UniversalInstallationView {
                                     helperTransferMonitoringTargetVolumePath = workflowRequest.targetVolumePath
                                     helperTransferMonitoringLastKnownPath = workflowRequest.targetVolumePath
                                     MenuState.shared.updateDebugCopiedData(bytes: 0)
-                                    if isWindowsWorkflow {
-                                        helperWriteSpeedText = "- MB/s"
-                                    } else {
-                                        startHelperWriteSpeedMonitoring(for: drive)
-                                    }
+                                    startHelperWriteSpeedMonitoring(for: drive)
                                     log("Uruchomiono helper workflow: \(workflowID)")
                                 }
                             )
@@ -634,6 +630,11 @@ extension UniversalInstallationView {
             : helperTransferMonitoringWholeDiskBSDName
 
         sampleHelperWriteSpeed(for: monitoredWholeDisk)
+        // Windows uses helper-reported determinate progress for copy/split stages,
+        // so skip speed-based transfer fallback updates that could overwrite it.
+        if isWindowsWorkflow {
+            return
+        }
         sampleHelperTransferProgress(stageKey: helperCurrentStageKey)
     }
 

--- a/macUSB/Features/Installation/CreatorHelperLogic.swift
+++ b/macUSB/Features/Installation/CreatorHelperLogic.swift
@@ -25,15 +25,6 @@ extension UniversalInstallationView {
         startCreationProcessWithHelper()
     }
 
-    func startWindowsCreationProcessWithHelper() {
-        log(
-            "WindowsInstallFlow: start workflow (source=\(sourceAppURL.path), target=\(targetDrive?.device ?? "brak"))",
-            category: "WindowsInstallFlow"
-        )
-        // Dedicated Windows workflow will be implemented separately.
-        startCreationProcessWithHelper()
-    }
-
     func startCreationProcessWithHelper() {
         guard let drive = targetDrive else {
             navigateToCreationProgress = false
@@ -183,6 +174,12 @@ extension UniversalInstallationView {
                                             category: "LinuxInstallFlow"
                                         )
                                     }
+                                    if isWindowsWorkflow, previousStageKey != normalizedStageKey {
+                                        log(
+                                            "WindowsInstallFlow: stage transition \(previousStageKey.isEmpty ? "<start>" : previousStageKey) -> \(normalizedStageKey)",
+                                            category: "WindowsInstallFlow"
+                                        )
+                                    }
                                     helperProgressPercent = max(helperProgressPercent, min(event.percent, 100))
                                     if let localization = HelperWorkflowLocalizationKeys.presentation(for: normalizedStageKey) {
                                         helperStageTitleKey = localization.titleKey
@@ -192,16 +189,23 @@ extension UniversalInstallationView {
                                         helperStatusKey = event.statusKey
                                     }
 
-                                    handleTransferStageTransition(
-                                        from: previousStageKey,
-                                        to: normalizedStageKey,
-                                        drive: drive
-                                    )
+                                    if isWindowsWorkflow {
+                                        updateWindowsCopyProgressFromHelperPercent(
+                                            stageKey: normalizedStageKey,
+                                            overallPercent: event.percent
+                                        )
+                                    } else {
+                                        handleTransferStageTransition(
+                                            from: previousStageKey,
+                                            to: normalizedStageKey,
+                                            drive: drive
+                                        )
 
-                                    if isFormattingHelperStage(normalizedStageKey) {
-                                        helperWriteSpeedText = "- MB/s"
-                                    } else if isFormattingHelperStage(previousStageKey) {
-                                        sampleHelperStageMetrics(for: drive)
+                                        if isFormattingHelperStage(normalizedStageKey) {
+                                            helperWriteSpeedText = "- MB/s"
+                                        } else if isFormattingHelperStage(previousStageKey) {
+                                            sampleHelperStageMetrics(for: drive)
+                                        }
                                     }
                                 },
                                 onCompletion: { result in
@@ -243,6 +247,33 @@ extension UniversalInstallationView {
                                         )
                                         return
                                     }
+                                    if shouldPromptWindowsForceUnmountAlert(for: result) {
+                                        showWindowsForceUnmountAlert(
+                                            onForce: {
+                                                workflowResultDetailMessage = nil
+                                                workflowResultErrorPresentation = nil
+                                                let forcedRequest = makeWindowsForceUnmountRequest(from: workflowRequest)
+                                                workflowRequest = forcedRequest
+                                                helperStageTitleKey = HelperWorkflowLocalizationKeys.startingTitle
+                                                helperStatusKey = HelperWorkflowLocalizationKeys.initializingStatus
+                                                helperCurrentStageKey = ""
+                                                helperProgressPercent = 0
+                                                helperCopyProgressPercent = 0
+                                                helperWriteSpeedText = "- MB/s"
+                                                withAnimation {
+                                                    isHelperWorking = true
+                                                }
+                                                log("WindowsInstallFlow: użytkownik wyraził zgodę na wymuszenie odmontowania nośnika.", category: "WindowsInstallFlow")
+                                                startHelperWorkflow(true)
+                                            },
+                                            onCancel: {
+                                                workflowResultDetailMessage = String(localized: "Nośnik USB był używany przez inną aplikację. Nie wyrażono zgody na wymuszenie odmontowania, dlatego proces został przerwany. Zamknij aplikacje korzystające z nośnika i spróbuj ponownie.")
+                                                log("WindowsInstallFlow: użytkownik odmówił wymuszonego odmontowania nośnika.", category: "WindowsInstallFlow")
+                                                performWindowsUnmountDeclinedCleanupAndCancel()
+                                            }
+                                        )
+                                        return
+                                    }
 
                                     helperOperationFailed = !result.success
                                     if result.success {
@@ -263,6 +294,12 @@ extension UniversalInstallationView {
                                         log(
                                             "LinuxInstallFlow: workflow zakończony (success=\(result.success ? "TAK" : "NIE"), cancelled=\(result.isUserCancelled ? "TAK" : "NIE"), failedStage=\(result.failedStage ?? "brak"))",
                                             category: "LinuxInstallFlow"
+                                        )
+                                    }
+                                    if isWindowsWorkflow {
+                                        log(
+                                            "WindowsInstallFlow: workflow zakończony (success=\(result.success ? "TAK" : "NIE"), cancelled=\(result.isUserCancelled ? "TAK" : "NIE"), failedStage=\(result.failedStage ?? "brak"))",
+                                            category: "WindowsInstallFlow"
                                         )
                                     }
 
@@ -317,7 +354,11 @@ extension UniversalInstallationView {
                                     helperTransferMonitoringTargetVolumePath = workflowRequest.targetVolumePath
                                     helperTransferMonitoringLastKnownPath = workflowRequest.targetVolumePath
                                     MenuState.shared.updateDebugCopiedData(bytes: 0)
-                                    startHelperWriteSpeedMonitoring(for: drive)
+                                    if isWindowsWorkflow {
+                                        helperWriteSpeedText = "- MB/s"
+                                    } else {
+                                        startHelperWriteSpeedMonitoring(for: drive)
+                                    }
                                     log("Uruchomiono helper workflow: \(workflowID)")
                                 }
                             )
@@ -352,6 +393,9 @@ extension UniversalInstallationView {
         if isLinuxWorkflow {
             return try prepareLinuxHelperWorkflowRequest(for: drive)
         }
+        if isWindowsWorkflow {
+            return prepareWindowsHelperWorkflowRequest(for: drive)
+        }
 
         let fileManager = FileManager.default
         let requesterUID = Int(getuid())
@@ -384,7 +428,9 @@ extension UniversalInstallationView {
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
                 requesterUID: requesterUID,
-                linuxForceUnmount: false
+                linuxForceUnmount: false,
+                windowsForceUnmount: false,
+                windowsMountedSourcePath: nil
             )
         }
 
@@ -413,7 +459,9 @@ extension UniversalInstallationView {
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
                 requesterUID: requesterUID,
-                linuxForceUnmount: false
+                linuxForceUnmount: false,
+                windowsForceUnmount: false,
+                windowsMountedSourcePath: nil
             )
         }
 
@@ -433,7 +481,9 @@ extension UniversalInstallationView {
                 needsCodesign: false,
                 requiresApplicationPathArg: false,
                 requesterUID: requesterUID,
-                linuxForceUnmount: false
+                linuxForceUnmount: false,
+                windowsForceUnmount: false,
+                windowsMountedSourcePath: nil
             )
         }
 
@@ -452,7 +502,9 @@ extension UniversalInstallationView {
             needsCodesign: needsCodesign,
             requiresApplicationPathArg: isLegacySystem || isSierra,
             requesterUID: requesterUID,
-            linuxForceUnmount: false
+            linuxForceUnmount: false,
+            windowsForceUnmount: false,
+            windowsMountedSourcePath: nil
         )
     }
 
@@ -766,6 +818,9 @@ extension UniversalInstallationView {
             if let imageBytes = sizeInBytes(at: request.sourceAppPath) {
                 totals["linux_raw_copy"] = imageBytes
             }
+
+        case .windows:
+            break
         }
 
         return totals
@@ -918,6 +973,11 @@ extension UniversalInstallationView {
     }
 
     private func canonicalStageKeyForPresentation(_ stageKey: String) -> String {
+        let windowsCanonical = CreationProgressWindowsMapping.canonicalStageKey(stageKey)
+        if windowsCanonical != stageKey {
+            return windowsCanonical
+        }
+
         let linuxCanonical = CreationProgressLinuxMapping.canonicalStageKey(stageKey)
         if linuxCanonical != stageKey {
             return linuxCanonical

--- a/macUSB/Features/Installation/CreatorLogic.swift
+++ b/macUSB/Features/Installation/CreatorLogic.swift
@@ -135,6 +135,11 @@ extension UniversalInstallationView {
     }
 
     func unmountSourceImageIfNeeded() {
+        if isWindowsWorkflow {
+            log("Unmount Windows image: pomijam (obsługa mountu po stronie helpera).")
+            return
+        }
+
         if let linuxMountPoint = linuxFlowContext?.mountPointURLForCleanup {
             let mountPath = linuxMountPoint.path
             log("Unmount Linux image: próba odmontowania \(mountPath)")

--- a/macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift
+++ b/macUSB/Features/Installation/Linux/CreatorLinuxHelperLogic.swift
@@ -39,7 +39,9 @@ extension UniversalInstallationView {
             needsCodesign: false,
             requiresApplicationPathArg: false,
             requesterUID: requesterUID,
-            linuxForceUnmount: false
+            linuxForceUnmount: false,
+            windowsForceUnmount: false,
+            windowsMountedSourcePath: nil
         )
     }
 }

--- a/macUSB/Features/Installation/Linux/CreatorLinuxLogic.swift
+++ b/macUSB/Features/Installation/Linux/CreatorLinuxLogic.swift
@@ -14,6 +14,10 @@ extension UniversalInstallationView {
             return linuxMountPointURLForCleanup
         }
 
+        if isWindowsWorkflow {
+            return FileManager.default.temporaryDirectory.appendingPathComponent("macUSB_windows_no_mount")
+        }
+
         if isLinuxWorkflow {
             return FileManager.default.temporaryDirectory.appendingPathComponent("macUSB_linux_no_mount")
         }
@@ -22,6 +26,10 @@ extension UniversalInstallationView {
     }
 
     var shouldDetachMountPointAfterFinish: Bool {
+        if isWindowsWorkflow {
+            return false
+        }
+
         if isLinuxWorkflow {
             return linuxMountPointURLForCleanup != nil
         }
@@ -31,6 +39,14 @@ extension UniversalInstallationView {
     func performEmergencyCleanupIfNeeded(tempURL: URL) {
         if let mountPoint = linuxMountPointURLForCleanup {
             performEmergencyCleanup(mountPoint: mountPoint, tempURL: tempURL)
+            return
+        }
+
+        if isWindowsWorkflow {
+            log("Cleanup Windows: pomijam odmontowanie źródła (obsługa mountu po stronie helpera).")
+            if FileManager.default.fileExists(atPath: tempURL.path) {
+                try? FileManager.default.removeItem(at: tempURL)
+            }
             return
         }
 

--- a/macUSB/Features/Installation/UniversalInstallationView.swift
+++ b/macUSB/Features/Installation/UniversalInstallationView.swift
@@ -13,6 +13,8 @@ struct UniversalInstallationView: View {
     let originalImageURL: URL?
     let linuxFlowContext: LinuxInstallationFlowContext?
     let isWindowsWorkflow: Bool
+    let windowsMountedSourcePath: String?
+    let windowsWillSplitWim: Bool
     
     // Flagi
     let needsCodesign: Bool
@@ -248,6 +250,10 @@ struct UniversalInstallationView: View {
                                         Text("• Pliki obrazu Linux zostaną przygotowane")
                                         Text("• Wybrany nośnik USB zostanie odmontowany")
                                         Text("• Obraz Linux zostanie zapisany na nośniku USB")
+                                    } else if isWindowsWorkflow {
+                                        Text("• Obraz Windows zostanie zweryfikowany i przygotowany do kopiowania")
+                                        Text("• Wybrany nośnik USB zostanie odmontowany i sformatowany do MBR/FAT32")
+                                        Text("• Pliki instalacyjne Windows zostaną skopiowane i zweryfikowane")
                                     } else if isRestoreLegacy {
                                         Text("• Obraz z systemem zostanie skopiowany i zweryfikowany")
                                         Text("• Nośnik USB zostanie sformatowany")
@@ -456,6 +462,8 @@ struct UniversalInstallationView: View {
                     isMavericks: isMavericks,
                     isPPC: isPPC,
                     isLinuxWorkflow: isLinuxWorkflow,
+                    isWindowsWorkflow: isWindowsWorkflow,
+                    windowsWillSplitWimExpected: windowsWillSplitWim,
                     shouldDetachMountPoint: shouldDetachMountPointAfterFinish,
                     targetWholeDiskBSDName: targetWholeDiskBSDNameForFinish,
                     needsPreformat: (targetDrive?.needsFormatting ?? false) && !isPPC,

--- a/macUSB/Features/Installation/Windows/CreationProgressWindowsMapping.swift
+++ b/macUSB/Features/Installation/Windows/CreationProgressWindowsMapping.swift
@@ -63,7 +63,7 @@ enum CreationProgressWindowsMapping {
     }
 
     static func showsWriteSpeed(for stageKey: String) -> Bool {
-        false
+        stageKey == createStageKey || stageKey == splitWimStageKey
     }
 
     static func isTransferStage(_ stageKey: String) -> Bool {

--- a/macUSB/Features/Installation/Windows/CreationProgressWindowsMapping.swift
+++ b/macUSB/Features/Installation/Windows/CreationProgressWindowsMapping.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+enum CreationProgressWindowsMapping {
+    static let splitWimStageKey = "windows_split_wim"
+    static let createStageKey = "windows_create_media"
+
+    static func stageKeys(includeSplitWim: Bool) -> [String] {
+        var keys: [String] = [
+            "windows_prepare_source",
+            "windows_prepare_target",
+            "windows_create_media"
+        ]
+
+        if includeSplitWim {
+            keys.append(splitWimStageKey)
+        }
+
+        keys.append("windows_verify_media")
+        keys.append("windows_cleanup_temp")
+        return keys
+    }
+
+    static func pendingIcon(for stageKey: String) -> String? {
+        switch stageKey {
+        case "windows_prepare_source":
+            return "doc.badge.gearshape"
+        case "windows_prepare_target":
+            return "eject"
+        case "windows_create_media":
+            return "square.and.arrow.down"
+        case "windows_split_wim":
+            return "doc.on.doc"
+        case "windows_verify_media":
+            return "checkmark.seal"
+        case "windows_cleanup_temp":
+            return "trash"
+        default:
+            return nil
+        }
+    }
+
+    static func activeIcon(for stageKey: String) -> String? {
+        switch stageKey {
+        case "windows_prepare_source":
+            return "doc.badge.gearshape.fill"
+        case "windows_prepare_target":
+            return "eject.fill"
+        case "windows_create_media":
+            return "square.and.arrow.down.fill"
+        case "windows_split_wim":
+            return "doc.on.doc.fill"
+        case "windows_verify_media":
+            return "checkmark.seal.fill"
+        case "windows_cleanup_temp":
+            return "trash.fill"
+        default:
+            return nil
+        }
+    }
+
+    static func showsCopyProgress(for stageKey: String) -> Bool {
+        stageKey == createStageKey || stageKey == splitWimStageKey
+    }
+
+    static func showsWriteSpeed(for stageKey: String) -> Bool {
+        false
+    }
+
+    static func isTransferStage(_ stageKey: String) -> Bool {
+        false
+    }
+
+    static func canonicalStageKey(_ stageKey: String) -> String {
+        stageKey
+    }
+
+    static func stageRange(for stageKey: String) -> (start: Double, end: Double)? {
+        switch stageKey {
+        case "windows_create_media":
+            return (40, 80)
+        case "windows_split_wim":
+            return (80, 95)
+        default:
+            return nil
+        }
+    }
+
+    static func copyPercent(from overallPercent: Double, stageKey: String) -> Double? {
+        guard let range = stageRange(for: stageKey), range.end > range.start else {
+            return nil
+        }
+
+        let clampedOverall = min(max(overallPercent, range.start), range.end)
+        let normalized = ((clampedOverall - range.start) / (range.end - range.start)) * 100.0
+        return min(max(normalized, 0), 99)
+    }
+}

--- a/macUSB/Features/Installation/Windows/CreatorWindowsHelperLogic.swift
+++ b/macUSB/Features/Installation/Windows/CreatorWindowsHelperLogic.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension UniversalInstallationView {
+    func startWindowsCreationProcessWithHelper() {
+        log(
+            "WindowsInstallFlow: start workflow (source=\(sourceAppURL.path), mounted=\(windowsMountedSourcePath ?? "brak"), target=\(targetDrive?.device ?? "brak"))",
+            category: "WindowsInstallFlow"
+        )
+        startCreationProcessWithHelper()
+    }
+
+    func prepareWindowsHelperWorkflowRequest(for drive: USBDrive) -> HelperWorkflowRequestPayload {
+        let helperTargetBSDName = resolveHelperTargetBSDName(for: drive)
+        let requesterUID = Int(getuid())
+        let targetLabel = windowsTargetVolumeLabel()
+
+        log(
+            "WindowsInstallFlow: przygotowano helper request (source=\(sourceAppURL.path), mounted=\(windowsMountedSourcePath ?? "brak"), targetBSD=\(helperTargetBSDName), label=\(targetLabel))",
+            category: "WindowsInstallFlow"
+        )
+
+        return HelperWorkflowRequestPayload(
+            workflowKind: .windows,
+            systemName: systemName,
+            sourceAppPath: sourceAppURL.path,
+            originalImagePath: originalImageURL?.path,
+            tempWorkPath: tempWorkURL.path,
+            targetVolumePath: drive.url.path,
+            targetBSDName: helperTargetBSDName,
+            targetLabel: targetLabel,
+            needsPreformat: false,
+            isCatalina: false,
+            isSierra: false,
+            needsCodesign: false,
+            requiresApplicationPathArg: false,
+            requesterUID: requesterUID,
+            linuxForceUnmount: false,
+            windowsForceUnmount: false,
+            windowsMountedSourcePath: windowsMountedSourcePath
+        )
+    }
+
+    func updateWindowsCopyProgressFromHelperPercent(stageKey: String, overallPercent: Double) {
+        guard isWindowsWorkflow else { return }
+        guard let percent = CreationProgressWindowsMapping.copyPercent(from: overallPercent, stageKey: stageKey) else {
+            helperCopyProgressPercent = 0
+            return
+        }
+        helperCopyProgressPercent = percent
+    }
+}

--- a/macUSB/Features/Installation/Windows/CreatorWindowsLabelLogic.swift
+++ b/macUSB/Features/Installation/Windows/CreatorWindowsLabelLogic.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension UniversalInstallationView {
+    func windowsTargetVolumeLabel() -> String {
+        let normalized = systemName.lowercased()
+
+        if normalized.contains("server 2025") {
+            return "SRV25-MU"
+        }
+        if normalized.contains("server 2022") {
+            return "SRV22-MU"
+        }
+        if normalized.contains("server 2019") {
+            return "SRV19-MU"
+        }
+        if normalized.contains("server 2016") {
+            return "SRV16-MU"
+        }
+        if normalized.contains("server 2012") {
+            return "SRV12-MU"
+        }
+
+        if normalized.contains("windows 11") {
+            return "WIN11-MU"
+        }
+        if normalized.contains("windows 10") {
+            return "WIN10-MU"
+        }
+        if normalized.contains("windows 8.1") {
+            return "WIN81-MU"
+        }
+        if normalized.contains("windows 8") {
+            return "WIN8-MU"
+        }
+
+        return "WIN10-MU"
+    }
+}

--- a/macUSB/Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift
+++ b/macUSB/Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift
@@ -8,7 +8,8 @@ extension UniversalInstallationView {
         guard !result.success else { return false }
         guard result.failedStage == "windows_prepare_target" else { return false }
         guard let message = result.errorMessage?.lowercased() else { return false }
-        return message.contains("windows_unmount_busy_prompt")
+        return message.contains("windows_unmount_force_prompt")
+            || message.contains("windows_unmount_busy_prompt")
     }
 
     func makeWindowsForceUnmountRequest(from request: HelperWorkflowRequestPayload) -> HelperWorkflowRequestPayload {

--- a/macUSB/Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift
+++ b/macUSB/Features/Installation/Windows/CreatorWindowsUnmountRecoveryLogic.swift
@@ -3,15 +3,15 @@ import AppKit
 import SwiftUI
 
 extension UniversalInstallationView {
-    func shouldPromptLinuxForceUnmountAlert(for result: HelperWorkflowResultPayload) -> Bool {
-        guard isLinuxWorkflow else { return false }
+    func shouldPromptWindowsForceUnmountAlert(for result: HelperWorkflowResultPayload) -> Bool {
+        guard isWindowsWorkflow else { return false }
         guard !result.success else { return false }
-        guard result.failedStage == "linux_unmount_target" else { return false }
+        guard result.failedStage == "windows_prepare_target" else { return false }
         guard let message = result.errorMessage?.lowercased() else { return false }
-        return message.contains("linux_unmount_busy_prompt")
+        return message.contains("windows_unmount_busy_prompt")
     }
 
-    func makeLinuxForceUnmountRequest(from request: HelperWorkflowRequestPayload) -> HelperWorkflowRequestPayload {
+    func makeWindowsForceUnmountRequest(from request: HelperWorkflowRequestPayload) -> HelperWorkflowRequestPayload {
         HelperWorkflowRequestPayload(
             workflowKind: request.workflowKind,
             systemName: request.systemName,
@@ -27,13 +27,13 @@ extension UniversalInstallationView {
             needsCodesign: request.needsCodesign,
             requiresApplicationPathArg: request.requiresApplicationPathArg,
             requesterUID: request.requesterUID,
-            linuxForceUnmount: true,
-            windowsForceUnmount: request.windowsForceUnmount,
+            linuxForceUnmount: request.linuxForceUnmount,
+            windowsForceUnmount: true,
             windowsMountedSourcePath: request.windowsMountedSourcePath
         )
     }
 
-    func showLinuxForceUnmountAlert(
+    func showWindowsForceUnmountAlert(
         onForce: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
@@ -41,7 +41,7 @@ extension UniversalInstallationView {
         alert.icon = NSApp.applicationIconImage
         alert.alertStyle = .warning
         alert.messageText = String(localized: "Nie można odmontować nośnika USB")
-        alert.informativeText = String(localized: "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika startowego Linux, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?")
+        alert.informativeText = String(localized: "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika Windows, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?")
         alert.addButton(withTitle: String(localized: "Anuluj"))
         alert.addButton(withTitle: String(localized: "Wymuś odmontowanie"))
 
@@ -61,10 +61,10 @@ extension UniversalInstallationView {
         }
     }
 
-    func performLinuxUnmountDeclinedCleanupAndCancel() {
-        helperCurrentStageKey = "cleanup_temp"
-        helperStageTitleKey = HelperWorkflowLocalizationKeys.cleanupTempTitle
-        helperStatusKey = HelperWorkflowLocalizationKeys.cleanupTempStatus
+    func performWindowsUnmountDeclinedCleanupAndCancel() {
+        helperCurrentStageKey = "windows_cleanup_temp"
+        helperStageTitleKey = HelperWorkflowLocalizationKeys.windowsCleanupTempTitle
+        helperStatusKey = HelperWorkflowLocalizationKeys.windowsCleanupTempStatus
         helperWriteSpeedText = "- MB/s"
 
         withAnimation {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -779,6 +779,9 @@
         }
       }
     },
+    "• Obraz Windows zostanie zweryfikowany i przygotowany do kopiowania" : {
+
+    },
     "• Obraz z systemem zostanie skopiowany i zweryfikowany" : {
       "localizations" : {
         "de" : {
@@ -854,6 +857,9 @@
           }
         }
       }
+    },
+    "• Pliki instalacyjne Windows zostaną skopiowane i zweryfikowane" : {
+
     },
     "• Pliki instalacyjne zostaną skopiowane" : {
       "localizations" : {
@@ -1766,6 +1772,9 @@
           }
         }
       }
+    },
+    "• Wybrany nośnik USB zostanie odmontowany i sformatowany do MBR/FAT32" : {
+
     },
     "• Wybrany plik musi zawierać instalator macOS, Windows lub Linux" : {
       "localizations" : {
@@ -12100,6 +12109,990 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "正在启动流程"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_cleanup_temp.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen temporaerer Dateien, um Speicherplatz freizugeben."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Removing temporary files and finalizing the process..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminacion de archivos temporales para liberar espacio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suppression des fichiers temporaires pour liberer de l'espace."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rimozione di file temporanei per liberare spazio."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空き容量を確保するため一時ファイルを削除しています。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuwanie plików tymczasowych i finalizowanie procesu..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remocao de arquivos temporarios para liberar espaco."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удаление временных файлов для освобождения места."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yer açmak için geçici dosyaları kaldırma."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалення тимчасових файлів, щоб звільнити місце."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa các tập tin tạm thời để giải phóng dung lượng."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在删除临时文件以释放空间。"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_cleanup_temp.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aufraeumen temporaerer Dateien"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cleaning up temporary files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpieza de archivos temporales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nettoyage des fichiers temporaires"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pulizia dei file temporanei"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一時ファイルの整理"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Porządkowanie plików tymczasowych"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limpeza de arquivos temporarios"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очистка временных файлов"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geçici dosyaları temizleme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Очищення тимчасових файлів"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dọn dẹp các tập tin tạm thời"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在清理临时文件"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_create_media.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreiben des Linux-Images auf den Zieldatenträger..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copying Windows installer files to the USB media..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribiendo la imagen de Linux en el disco de destino..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écriture de l’image Linux sur le disque cible..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrittura dell’immagine Linux sul disco di destinazione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux イメージを対象ディスクに書き込み中..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kopiowanie plików instalatora Windows na nośnik USB..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gravando a imagem Linux no disco de destino..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запись образа Linux на целевой диск..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux imajı hedef diske yazılıyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запис образу Linux на цільовий диск..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang ghi ảnh đĩa Linux vào ổ đích..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在将 Linux 镜像写入目标磁盘..."
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_create_media.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen des Linux-Mediums"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creating Windows media"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creando medio Linux"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Création du support Linux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creazione del supporto Linux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux メディアを作成中"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tworzenie nośnika Windows"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criando mídia Linux"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создание носителя Linux"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux ortamı oluşturuluyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створення носія Linux"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tạo phương tiện Linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在创建 Linux 介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_prepare_source.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorbereiten der Quelldateien fuer einen sicheren Ablauf."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validating the ISO source, mounting the image, and checking FAT32 limits..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparacion de los archivos de origen para un proceso seguro."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparation des fichiers source pour un deroulement securise."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione dei file di origine per un flusso di lavoro sicuro."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安全に処理を進めるためソースファイルを準備しています。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weryfikowanie źródła ISO, montowanie obrazu i sprawdzanie ograniczeń FAT32..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparacao dos arquivos de origem para um fluxo seguro."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка исходных файлов для безопасного выполнения процесса."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Güvenli bir iş akışı için kaynak dosyaları hazırlamak."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підготовка вихідних файлів для безпечного робочого процесу."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chuẩn bị các tập tin nguồn cho một quy trình làm việc an toàn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备源文件，以确保流程安全进行。"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_prepare_source.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorbereiten der Installationsdateien"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing installer files"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparacion de los archivos del instalador"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparation des fichiers d'installation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione dei file di installazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストーラファイルの準備"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przygotowywanie plików instalatora"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparacao dos arquivos do instalador"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка файлов установщика"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurulum dosyalarının hazırlanması"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підготовка файлів інсталятора"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang chuẩn bị file cài đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备安装器文件"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_prepare_target.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aushängen des Zieldatenträgers..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unmounting the USB device and preparing MBR/FAT32 format..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desmontando el disco de destino..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démontage du disque cible..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Smontaggio del disco di destinazione..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対象ディスクをアンマウント中..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odmontowywanie nośnika USB i przygotowywanie formatu MBR/FAT32..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desmontando o disco de destino..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отмонтирование целевого диска..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef diskin bağlantısı kesiliyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмонтування цільового диска..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang tháo gắn kết ổ đích..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在卸载目标磁盘..."
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_prepare_target.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vorbereiten des Zieldatenträgers"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparing target disk"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando el disco de destino"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation du disque cible"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparazione del disco di destinazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対象ディスクを準備中"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Przygotowanie dysku docelowego"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preparando o disco de destino"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подготовка целевого диска"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hedef disk hazırlanıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підготовка цільового диска"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang chuẩn bị ổ đích"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在准备目标磁盘"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_split_wim.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uebertragen des Systemabbilds auf das ausgewaehlte USB-Medium."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splitting install.wim into FAT32-compatible segments..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia de la imagen del sistema al medio USB seleccionado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfert de l'image systeme vers le support USB selectionne."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trasferimento dell'immagine del sistema sul supporto USB selezionato."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択したUSBメディアへシステムイメージを転送しています。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dzielenie pliku install.wim na segmenty zgodne z FAT32..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferencia da imagem do sistema para a midia USB selecionada."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перенос образа системы на выбранный USB-носитель."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sistem görüntüsünün seçilen USB ortamına aktarılması."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перенесення образу системи на вибраний носій USB."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Truyền hình ảnh hệ thống sang phương tiện USB đã chọn."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在将系统镜像传输到所选 USB 介质。"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_split_wim.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellen des Installationsmediums"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Splitting the Windows installer file"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creacion del medio de instalacion"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creation du support d'installation"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creazione del supporto di installazione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "インストールメディアの作成"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dzielenie pliku instalacyjnego Windows"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Criacao da midia de instalacao"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создание установочного носителя"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurulum medyası oluşturma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Створення інсталяційного носія"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tạo phương tiện cài đặt"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在创建安装介质"
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_verify_media.status" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prüfen der Übereinstimmung zwischen Quellimage und USB-Datenträger..."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking boot files and Windows installer structure..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comprobando la coherencia de datos entre la imagen de origen y el medio USB..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification de la cohérence des données entre l’image source et le support USB..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica della coerenza dei dati tra l’immagine sorgente e il supporto USB..."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソースイメージとUSBメディアのデータ整合性を確認中..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sprawdzanie plików rozruchowych i struktury instalatora Windows..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificando a consistência dos dados entre a imagem de origem e a mídia USB..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка соответствия данных между исходным образом и USB-носителем..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kaynak imaj ile USB ortamı arasındaki veri tutarlılığı denetleniyor..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірка відповідності даних між вихідним образом і USB-носієм..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang kiểm tra tính nhất quán dữ liệu giữa ảnh nguồn và thiết bị USB..."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查源镜像与 USB 介质之间的数据一致性..."
+          }
+        }
+      }
+    },
+    "helper.workflow.windows_verify_media.title" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifizieren des Linux-Mediums"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifying Windows media"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificando el medio Linux"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérification du support Linux"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verifica del supporto Linux"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linuxメディアを検証中"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weryfikowanie nośnika Windows"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificando mídia Linux"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Проверка носителя Linux"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Linux ortamı doğrulanıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірка носія Linux"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang xác minh phương tiện Linux"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在验证 Linux 介质"
           }
         }
       }
@@ -34191,6 +35184,9 @@
           }
         }
       }
+    },
+    "Wybrany nośnik jest używany przez inną aplikację. Aby kontynuować tworzenie nośnika Windows, macUSB może wymusić odmontowanie urządzenia. Niezapisane dane na tym nośniku mogą zostać utracone. Czy chcesz wymusić odmontowanie?" : {
+
     },
     "Wybrany nośnik korzysta z formatu APFS. Aby kontynuować, sformatuj go ręcznie w Narzędziu dyskowym do dowolnego formatu innego niż APFS." : {
       "localizations" : {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -3410,6 +3410,89 @@
         }
       }
     },
+    "analysis.windows.unknown.display_name" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unbekanntes Windows"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown Windows"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows desconocido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows inconnu"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows sconosciuto"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明なWindows"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nieznany Windows"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Windows desconhecido"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неизвестная версия Windows"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bilinmeyen Windows sürümü"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідома версія Windows"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phiên bản Windows không xác định"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知的 Windows 版本"
+          }
+        }
+      }
+    },
     "analysis.windows.unsupported_edition.description" : {
       "comment" : "Unsupported Windows edition message",
       "extractionState" : "stale",

--- a/macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift
+++ b/macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift
@@ -32,6 +32,18 @@ enum HelperWorkflowLocalizationKeys {
     static let linuxRawCopyStatus = "helper.workflow.linux_raw_copy.status"
     static let linuxVerifyWriteTitle = "helper.workflow.linux_verify_write.title"
     static let linuxVerifyWriteStatus = "helper.workflow.linux_verify_write.status"
+    static let windowsPrepareSourceTitle = "helper.workflow.windows_prepare_source.title"
+    static let windowsPrepareSourceStatus = "helper.workflow.windows_prepare_source.status"
+    static let windowsPrepareTargetTitle = "helper.workflow.windows_prepare_target.title"
+    static let windowsPrepareTargetStatus = "helper.workflow.windows_prepare_target.status"
+    static let windowsCreateMediaTitle = "helper.workflow.windows_create_media.title"
+    static let windowsCreateMediaStatus = "helper.workflow.windows_create_media.status"
+    static let windowsSplitWimTitle = "helper.workflow.windows_split_wim.title"
+    static let windowsSplitWimStatus = "helper.workflow.windows_split_wim.status"
+    static let windowsVerifyMediaTitle = "helper.workflow.windows_verify_media.title"
+    static let windowsVerifyMediaStatus = "helper.workflow.windows_verify_media.status"
+    static let windowsCleanupTempTitle = "helper.workflow.windows_cleanup_temp.title"
+    static let windowsCleanupTempStatus = "helper.workflow.windows_cleanup_temp.status"
     static let startingTitle = "helper.workflow.starting.title"
     static let startingStatus = "helper.workflow.starting.status"
     static let initializingStatus = "helper.workflow.initializing.status"
@@ -71,6 +83,18 @@ enum HelperWorkflowLocalizationKeys {
             return HelperWorkflowStageLocalization(titleKey: linuxRawCopyTitle, statusKey: linuxRawCopyStatus)
         case "linux_verify_write":
             return HelperWorkflowStageLocalization(titleKey: linuxVerifyWriteTitle, statusKey: linuxVerifyWriteStatus)
+        case "windows_prepare_source":
+            return HelperWorkflowStageLocalization(titleKey: windowsPrepareSourceTitle, statusKey: windowsPrepareSourceStatus)
+        case "windows_prepare_target":
+            return HelperWorkflowStageLocalization(titleKey: windowsPrepareTargetTitle, statusKey: windowsPrepareTargetStatus)
+        case "windows_create_media":
+            return HelperWorkflowStageLocalization(titleKey: windowsCreateMediaTitle, statusKey: windowsCreateMediaStatus)
+        case "windows_split_wim":
+            return HelperWorkflowStageLocalization(titleKey: windowsSplitWimTitle, statusKey: windowsSplitWimStatus)
+        case "windows_verify_media":
+            return HelperWorkflowStageLocalization(titleKey: windowsVerifyMediaTitle, statusKey: windowsVerifyMediaStatus)
+        case "windows_cleanup_temp":
+            return HelperWorkflowStageLocalization(titleKey: windowsCleanupTempTitle, statusKey: windowsCleanupTempStatus)
         case "catalina_cleanup":
             return HelperWorkflowStageLocalization(titleKey: catalinaCleanupTitle, statusKey: catalinaCleanupStatus)
         case "catalina_copy":
@@ -110,6 +134,18 @@ enum HelperWorkflowLocalizationExtractionAnchors {
         String(localized: "helper.workflow.linux_raw_copy.status"),
         String(localized: "helper.workflow.linux_verify_write.title"),
         String(localized: "helper.workflow.linux_verify_write.status"),
+        String(localized: "helper.workflow.windows_prepare_source.title"),
+        String(localized: "helper.workflow.windows_prepare_source.status"),
+        String(localized: "helper.workflow.windows_prepare_target.title"),
+        String(localized: "helper.workflow.windows_prepare_target.status"),
+        String(localized: "helper.workflow.windows_create_media.title"),
+        String(localized: "helper.workflow.windows_create_media.status"),
+        String(localized: "helper.workflow.windows_split_wim.title"),
+        String(localized: "helper.workflow.windows_split_wim.status"),
+        String(localized: "helper.workflow.windows_verify_media.title"),
+        String(localized: "helper.workflow.windows_verify_media.status"),
+        String(localized: "helper.workflow.windows_cleanup_temp.title"),
+        String(localized: "helper.workflow.windows_cleanup_temp.status"),
         String(localized: "helper.workflow.starting.title"),
         String(localized: "helper.workflow.starting.status"),
         String(localized: "helper.workflow.initializing.status"),

--- a/macUSB/Shared/Services/Helper/HelperIPC.swift
+++ b/macUSB/Shared/Services/Helper/HelperIPC.swift
@@ -6,6 +6,7 @@ enum HelperWorkflowKind: String, Codable {
     case mavericks
     case ppc
     case linux
+    case windows
 }
 
 struct HelperWorkflowRequestPayload: Codable {
@@ -24,6 +25,8 @@ struct HelperWorkflowRequestPayload: Codable {
     let requiresApplicationPathArg: Bool
     let requesterUID: Int?
     let linuxForceUnmount: Bool
+    let windowsForceUnmount: Bool
+    let windowsMountedSourcePath: String?
 }
 
 struct HelperProgressEventPayload: Codable {

--- a/macUSBHelper/IPC/HelperIPC.swift
+++ b/macUSBHelper/IPC/HelperIPC.swift
@@ -6,6 +6,7 @@ enum HelperWorkflowKind: String, Codable {
     case mavericks
     case ppc
     case linux
+    case windows
 }
 
 struct HelperWorkflowRequestPayload: Codable {
@@ -24,6 +25,8 @@ struct HelperWorkflowRequestPayload: Codable {
     let requiresApplicationPathArg: Bool
     let requesterUID: Int?
     let linuxForceUnmount: Bool
+    let windowsForceUnmount: Bool
+    let windowsMountedSourcePath: String?
 }
 
 struct HelperProgressEventPayload: Codable {

--- a/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
@@ -26,6 +26,11 @@ final class HelperWorkflowExecutor {
     var windowsWimlibExecutablePath: String?
     var windowsPreparedTargetVolumePath: String?
     var windowsCopyStageTotalBytes: Int64?
+    var windowsRsyncProgressMode: String?
+    var windowsLegacyRsyncCurrentFilePath: String?
+    var windowsLegacyRsyncCurrentFileSizeBytes: Int64 = 0
+    var windowsLegacyRsyncCompletedBytes: Int64 = 0
+    var windowsLegacyRsyncToCheckUsesProcessedCount: Bool?
     var currentStageKey: String?
 
     init(request: HelperWorkflowRequestPayload, workflowID: String, sendEvent: @escaping (HelperProgressEventPayload) -> Void) {

--- a/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
@@ -15,6 +15,17 @@ final class HelperWorkflowExecutor {
     var lastStageOutputLine: String?
     var linuxSourceImageSizeBytes: Int64?
     var linuxMountGuard: HelperWorkflowLinuxMountGuard?
+    var windowsMountedByHelper = false
+    var windowsMountedImageDevice: String?
+    var windowsActiveSourceMountPath: String?
+    var windowsInstallWimPath: String?
+    var windowsInstallWimRelativePath: String?
+    var windowsInstallWimSizeBytes: Int64?
+    var windowsShouldSplitWim = false
+    var windowsHasInstallESD = false
+    var windowsWimlibExecutablePath: String?
+    var windowsPreparedTargetVolumePath: String?
+    var windowsCopyStageTotalBytes: Int64?
     var currentStageKey: String?
 
     init(request: HelperWorkflowRequestPayload, workflowID: String, sendEvent: @escaping (HelperProgressEventPayload) -> Void) {
@@ -50,6 +61,9 @@ final class HelperWorkflowExecutor {
             try startLinuxMountGuardIfNeeded(stages: stages)
 
             for stage in stages {
+                if shouldSkipWindowsStage(stage) {
+                    continue
+                }
                 currentStageKey = stage.key
                 try throwIfCancelled()
                 if stage.key == "catalina_copy" {
@@ -107,7 +121,8 @@ final class HelperWorkflowExecutor {
             if linuxMountGuardReleaseReason == "verify_failed" {
                 stopLinuxMountGuardIfNeeded(reason: "verify_failed")
             }
-            if !shouldDeferCleanupForLinuxUnmountPrompt(failedStage: stage, description: description) {
+            if !shouldDeferCleanupForLinuxUnmountPrompt(failedStage: stage, description: description)
+                && !shouldDeferCleanupForWindowsUnmountPrompt(failedStage: stage, description: description) {
                 runBestEffortTempCleanupStage()
             }
             return HelperWorkflowResultPayload(

--- a/macUSBHelper/Workflow/HelperWorkflowFileOperations.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowFileOperations.swift
@@ -14,6 +14,26 @@ extension HelperWorkflowExecutor {
             try runLinuxVerifyWriteStage(stage)
             return
         }
+        if stage.key == "windows_prepare_source" {
+            try runWindowsPrepareSourceStage(stage)
+            return
+        }
+        if stage.key == "windows_prepare_target" {
+            try runWindowsPrepareTargetStage(stage)
+            return
+        }
+        if stage.key == "windows_create_media" {
+            try runWindowsCreateMediaStage(stage)
+            return
+        }
+        if stage.key == "windows_split_wim" {
+            try runWindowsSplitWimStage(stage)
+            return
+        }
+        if stage.key == "windows_verify_media" {
+            try runWindowsVerifyMediaStage(stage)
+            return
+        }
 
         let process = Process()
         if let requesterUID = request.requesterUID, requesterUID > 0 {
@@ -87,9 +107,18 @@ extension HelperWorkflowExecutor {
         }
     }
     func runBestEffortTempCleanupStage() {
-        let stageKey = "cleanup_temp"
-        let stageTitleKey = HelperWorkflowLocalizationKeys.cleanupTempTitle
-        let statusKey = HelperWorkflowLocalizationKeys.cleanupTempStatus
+        let stageKey: String
+        let stageTitleKey: String
+        let statusKey: String
+        if request.workflowKind == .windows {
+            stageKey = "windows_cleanup_temp"
+            stageTitleKey = HelperWorkflowLocalizationKeys.windowsCleanupTempTitle
+            statusKey = HelperWorkflowLocalizationKeys.windowsCleanupTempStatus
+        } else {
+            stageKey = "cleanup_temp"
+            stageTitleKey = HelperWorkflowLocalizationKeys.cleanupTempTitle
+            statusKey = HelperWorkflowLocalizationKeys.cleanupTempStatus
+        }
         let stageStart = max(latestPercent, 99)
 
         emitProgress(
@@ -98,6 +127,10 @@ extension HelperWorkflowExecutor {
             percent: stageStart,
             statusKey: statusKey
         )
+
+        if request.workflowKind == .windows {
+            detachWindowsMountedSourceIfNeeded()
+        }
 
         guard !request.tempWorkPath.isEmpty else {
             emitProgress(

--- a/macUSBHelper/Workflow/HelperWorkflowProgressParsing.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowProgressParsing.swift
@@ -20,6 +20,13 @@ extension HelperWorkflowExecutor {
         emit(stage: stage, percent: percent, statusKey: stage.statusKey, logLine: line)
     }
     func extractToolPercent(from line: String, stageKey: String) -> Double? {
+        if stageKey == "windows_create_media" {
+            return extractWindowsCopyProgressPercent(from: line)
+        }
+        if stageKey == "windows_split_wim" {
+            return extractWindowsWimSplitProgressPercent(from: line)
+        }
+
         if stageKey == "createinstallmedia" {
             let lowered = line.lowercased()
             if lowered.contains("erasing disk") {

--- a/macUSBHelper/Workflow/HelperWorkflowStages.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowStages.swift
@@ -174,6 +174,9 @@ extension HelperWorkflowExecutor {
 
         case .linux:
             context = try prepareLinuxWorkflowContext()
+
+        case .windows:
+            context = PreparedWorkflowContext(sourcePath: request.sourceAppPath, postInstallSourceAppPath: nil)
         }
 
         emitProgress(
@@ -368,6 +371,9 @@ extension HelperWorkflowExecutor {
 
         case .linux:
             stages.append(contentsOf: try buildLinuxWorkflowStages(using: context))
+
+        case .windows:
+            stages.append(contentsOf: try buildWindowsWorkflowStages(using: context))
         }
 
         return stages

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift
@@ -6,9 +6,16 @@ extension HelperWorkflowExecutor {
             return nil
         }
 
-        // Expected rsync progress2 row: "<bytes_done> <percent>% ..."
+        let mode = windowsRsyncProgressMode ?? ""
+        if mode == "progress2" {
+            return parseWindowsRsyncProgress2Percent(line: line, totalBytes: totalBytes)
+        }
+        return parseWindowsRsyncLegacyPercent(line: line, totalBytes: totalBytes)
+    }
+
+    private func parseWindowsRsyncProgress2Percent(line: String, totalBytes: Int64) -> Double? {
         guard let progressRegex = try? NSRegularExpression(
-            pattern: #"^\s*([0-9][0-9,\.]*)\s+([0-9]{1,3})%\s+"#
+            pattern: #"^\s*([0-9][0-9,\.]*[KMGTPkmgpt]?)\s+([0-9]{1,3})%\s+"#
         ) else {
             return nil
         }
@@ -16,19 +23,157 @@ extension HelperWorkflowExecutor {
         let range = NSRange(line.startIndex..<line.endIndex, in: line)
         guard let match = progressRegex.firstMatch(in: line, options: [], range: range),
               match.numberOfRanges >= 2,
-              let bytesRange = Range(match.range(at: 1), in: line) else {
-            return nil
-        }
-
-        let rawBytes = String(line[bytesRange])
-            .replacingOccurrences(of: ",", with: "")
-            .replacingOccurrences(of: ".", with: "")
-
-        guard let copiedBytes = Int64(rawBytes), copiedBytes >= 0 else {
+              let bytesRange = Range(match.range(at: 1), in: line),
+              let copiedBytes = parseRsyncProgressTokenToBytes(String(line[bytesRange])) else {
             return nil
         }
 
         let computed = (Double(copiedBytes) / Double(totalBytes)) * 100.0
         return min(max(computed, 0), 99)
+    }
+
+    private func parseWindowsRsyncLegacyPercent(line: String, totalBytes: Int64) -> Double? {
+        if let filePath = parseWindowsLegacyRsyncFilePathLine(line: line) {
+            windowsLegacyRsyncCurrentFilePath = filePath
+            windowsLegacyRsyncCurrentFileSizeBytes = resolveWindowsSourceFileSize(forRsyncPath: filePath) ?? 0
+            return nil
+        }
+
+        if let fileListPercent = parseWindowsLegacyRsyncFileListPercent(line: line) {
+            return min(max(fileListPercent, 0), 99)
+        }
+
+        // Legacy rsync mode for Windows copy should track file-list progress
+        // (`to-check`/`to-chk`) instead of per-file byte lines, to avoid jumps
+        // when one large file is followed by many small files.
+        _ = totalBytes
+        return nil
+    }
+
+    private func parseWindowsLegacyRsyncFileListPercent(line: String) -> Double? {
+        guard let progressRegex = try? NSRegularExpression(
+            pattern: #"\((?:xfer#([0-9]+),\s*)?(?:to-check|to-chk|ir-chk)=([0-9]+)/([0-9]+)\)"#
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = progressRegex.firstMatch(in: line, options: [], range: range),
+              match.numberOfRanges >= 4,
+              let valueRange = Range(match.range(at: 2), in: line),
+              let totalRange = Range(match.range(at: 3), in: line),
+              let observedValue = Int(line[valueRange]),
+              let totalCount = Int(line[totalRange]),
+              totalCount > 0 else {
+            return nil
+        }
+
+        let xferCount: Int? = {
+            guard let xferRange = Range(match.range(at: 1), in: line) else { return nil }
+            return Int(line[xferRange])
+        }()
+
+        if windowsLegacyRsyncToCheckUsesProcessedCount == nil,
+           let xferCount {
+            let processedCandidate = observedValue
+            let remainingCandidate = max(0, totalCount - observedValue)
+            let processedDistance = abs(processedCandidate - xferCount)
+            let remainingDistance = abs(remainingCandidate - xferCount)
+            windowsLegacyRsyncToCheckUsesProcessedCount = processedDistance <= remainingDistance
+        }
+
+        let usesProcessedCount = windowsLegacyRsyncToCheckUsesProcessedCount ?? true
+        let processedCount = usesProcessedCount
+            ? observedValue
+            : max(0, totalCount - observedValue)
+
+        return (Double(processedCount) / Double(totalCount)) * 100.0
+    }
+
+    private func parseWindowsLegacyRsyncFilePathLine(line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lowered = trimmed.lowercased()
+        if lowered == "sending incremental file list"
+            || lowered.hasPrefix("sent ")
+            || lowered.hasPrefix("total size is ")
+            || lowered.hasPrefix("speedup is ")
+            || lowered.hasPrefix("number of files:")
+            || lowered.hasPrefix("number of files transferred:")
+            || lowered.hasPrefix("total transferred file size:")
+            || lowered.hasPrefix("literal data:")
+            || lowered.hasPrefix("matched data:")
+            || lowered.hasPrefix("file list size:")
+            || lowered.hasPrefix("file list generation time:")
+            || lowered.hasPrefix("file list transfer time:")
+            || lowered.hasPrefix("total bytes sent:")
+            || lowered.hasPrefix("total bytes received:") {
+            return nil
+        }
+
+        if line.range(of: #"^\s*[0-9][0-9,\.]*[KMGTPkmgpt]?\s+[0-9]{1,3}%\s+"#, options: .regularExpression) != nil {
+            return nil
+        }
+
+        if trimmed == "." || trimmed == "./" {
+            return nil
+        }
+
+        return trimmed
+    }
+
+    private func parseRsyncProgressTokenToBytes(_ token: String) -> Int64? {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let suffix = trimmed.last, "KMGTPkmgpt".contains(suffix) {
+            let numberPart = String(trimmed.dropLast()).replacingOccurrences(of: ",", with: ".")
+            guard let value = Double(numberPart), value.isFinite, value >= 0 else { return nil }
+
+            let multiplier: Double
+            switch suffix.uppercased() {
+            case "K": multiplier = 1_000
+            case "M": multiplier = 1_000_000
+            case "G": multiplier = 1_000_000_000
+            case "T": multiplier = 1_000_000_000_000
+            case "P": multiplier = 1_000_000_000_000_000
+            default: return nil
+            }
+
+            let bytes = value * multiplier
+            guard bytes.isFinite, bytes >= 0 else { return nil }
+            return Int64(bytes.rounded())
+        }
+
+        let digitsOnly = trimmed
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: ".", with: "")
+        guard let bytes = Int64(digitsOnly), bytes >= 0 else {
+            return nil
+        }
+        return bytes
+    }
+
+    private func resolveWindowsSourceFileSize(forRsyncPath path: String) -> Int64? {
+        guard let sourceMountPath = windowsActiveSourceMountPath else { return nil }
+
+        let sanitizedRelativePath: String
+        if path.hasPrefix("./") {
+            sanitizedRelativePath = String(path.dropFirst(2))
+        } else {
+            sanitizedRelativePath = path
+        }
+
+        guard !sanitizedRelativePath.isEmpty else { return nil }
+        let candidate = URL(fileURLWithPath: sourceMountPath)
+            .appendingPathComponent(sanitizedRelativePath)
+            .path
+        guard let attributes = try? fileManager.attributesOfItem(atPath: candidate),
+              let sizeValue = attributes[.size] as? NSNumber else {
+            return nil
+        }
+
+        return sizeValue.int64Value
     }
 }

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    func extractWindowsCopyProgressPercent(from line: String) -> Double? {
+        guard let totalBytes = windowsCopyStageTotalBytes, totalBytes > 0 else {
+            return nil
+        }
+
+        // Expected rsync progress2 row: "<bytes_done> <percent>% ..."
+        guard let progressRegex = try? NSRegularExpression(
+            pattern: #"^\s*([0-9][0-9,\.]*)\s+([0-9]{1,3})%\s+"#
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = progressRegex.firstMatch(in: line, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let bytesRange = Range(match.range(at: 1), in: line) else {
+            return nil
+        }
+
+        let rawBytes = String(line[bytesRange])
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: ".", with: "")
+
+        guard let copiedBytes = Int64(rawBytes), copiedBytes >= 0 else {
+            return nil
+        }
+
+        let computed = (Double(copiedBytes) / Double(totalBytes)) * 100.0
+        return min(max(computed, 0), 99)
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift
@@ -1,0 +1,347 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    private static let windowsFAT32LimitBytes: Int64 = 4_294_967_295
+
+    func runWindowsPrepareSourceStage(_ stage: WorkflowStage) throws {
+        guard fileManager.fileExists(atPath: request.sourceAppPath) else {
+            throw HelperExecutionError.invalidRequest("Nie znaleziono źródłowego pliku ISO Windows.")
+        }
+
+        let mountedSourcePath = try prepareWindowsSourceMountPath(stage: stage)
+        windowsActiveSourceMountPath = mountedSourcePath
+
+        let sourceURL = URL(fileURLWithPath: mountedSourcePath)
+        let sourcesDirectory = resolveWindowsSourcesDirectory(in: sourceURL)
+        guard fileManager.fileExists(atPath: sourcesDirectory.path) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Źródłowy obraz nie wygląda jak instalator Windows: brak katalogu sources/Sources."
+            )
+        }
+        let sourceUEFIStatus = evaluateWindowsUEFIStatus(in: sourceURL)
+
+        guard sourceUEFIStatus.hasBootEntry else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "W obrazie źródłowym nie znaleziono wymaganych plików UEFI (EFI/BOOT/BOOTX64.EFI lub EFI/BOOT/BOOTAA64.EFI)."
+            )
+        }
+
+        guard sourceUEFIStatus.hasMicrosoftBootDirectory else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "W obrazie źródłowym nie znaleziono katalogu EFI/Microsoft/Boot."
+            )
+        }
+
+        let installWimInfo = resolveWindowsInstallWimInfo(in: sourcesDirectory)
+        let installEsdInfo = resolveWindowsInstallEsdInfo(in: sourcesDirectory)
+        windowsInstallWimPath = installWimInfo?.path
+        windowsInstallWimRelativePath = installWimInfo?.relativePath
+        windowsInstallWimSizeBytes = installWimInfo?.size
+        windowsHasInstallESD = installEsdInfo != nil
+
+        let oversizedNonWimFiles = try findWindowsOversizedFiles(
+            in: sourceURL,
+            excludedFilePath: installWimInfo?.path
+        )
+
+        if !oversizedNonWimFiles.isEmpty {
+            let listed = oversizedNonWimFiles.prefix(5).joined(separator: ", ")
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Źródłowy obraz zawiera pliki większe niż limit FAT32 (inne niż install.wim): \(listed)."
+            )
+        }
+
+        let shouldSplitWim = (installWimInfo?.size ?? 0) > Self.windowsFAT32LimitBytes
+        windowsShouldSplitWim = shouldSplitWim
+        windowsCopyStageTotalBytes = try computeWindowsCopyPayloadBytes(
+            in: sourceURL,
+            excludedFilePath: shouldSplitWim ? installWimInfo?.path : nil
+        )
+
+        if shouldSplitWim {
+            guard let executable = resolveExecutablePath(named: "wimlib-imagex") else {
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Plik install.wim przekracza limit FAT32, ale nie znaleziono polecenia wimlib-imagex. Zainstaluj wimlib i spróbuj ponownie."
+                )
+            }
+            windowsWimlibExecutablePath = executable
+        }
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows source prepared: mount=\(mountedSourcePath), splitWIM=\(shouldSplitWim ? "yes" : "no"), hasESD=\(windowsHasInstallESD ? "yes" : "no"), copyBytes=\(windowsCopyStageTotalBytes ?? -1)",
+            shouldAdvancePercent: false
+        )
+    }
+
+    func prepareWindowsSourceMountPath(stage: WorkflowStage) throws -> String {
+        if let mounted = request.windowsMountedSourcePath,
+           !mounted.isEmpty,
+           fileManager.fileExists(atPath: mounted),
+           (
+                fileManager.fileExists(atPath: URL(fileURLWithPath: mounted).appendingPathComponent("sources").path)
+                || fileManager.fileExists(atPath: URL(fileURLWithPath: mounted).appendingPathComponent("Sources").path)
+           ) {
+            windowsMountedByHelper = false
+            windowsMountedImageDevice = nil
+            emitProgress(
+                stageKey: stage.key,
+                titleKey: stage.titleKey,
+                percent: latestPercent,
+                statusKey: stage.statusKey,
+                logLine: "Windows source mount reused from analysis: \(mounted)",
+                shouldAdvancePercent: false
+            )
+            return mounted
+        }
+
+        let attachResult = try attachWindowsSourceISO(stage: stage)
+        windowsMountedByHelper = true
+        windowsMountedImageDevice = attachResult.device
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows source mounted as hidden volume: \(attachResult.mountPath)",
+            shouldAdvancePercent: false
+        )
+        return attachResult.mountPath
+    }
+
+    func attachWindowsSourceISO(stage: WorkflowStage) throws -> (device: String, mountPath: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+        process.arguments = ["attach", "-nobrowse", "-readonly", request.sourceAppPath]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się uruchomić hdiutil attach: \(error.localizedDescription)"
+            )
+        }
+
+        process.waitUntilExit()
+
+        let stdoutData = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        let stderrData = (process.standardError as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        let stderrText = String(data: stderrData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard process.terminationStatus == 0 else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: process.terminationStatus,
+                description: stderrText.isEmpty ? "Polecenie hdiutil attach zakończyło się błędem." : stderrText
+            )
+        }
+
+        guard let stdout = String(data: stdoutData, encoding: .utf8) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się odczytać wyniku hdiutil attach."
+            )
+        }
+
+        let lines = stdout
+            .split(separator: "\n")
+            .map(String.init)
+        for line in lines {
+            let fields = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
+            guard fields.count >= 3 else { continue }
+            let device = fields[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let mountPath = fields[2].trimmingCharacters(in: .whitespacesAndNewlines)
+            if device.hasPrefix("/dev/") && mountPath.hasPrefix("/Volumes/") {
+                return (device: device, mountPath: mountPath)
+            }
+        }
+
+        throw HelperExecutionError.failed(
+            stage: stage.key,
+            exitCode: -1,
+            description: "Nie udało się ustalić punktu montowania ISO Windows."
+        )
+    }
+
+    private func resolveWindowsSourcesDirectory(in mountURL: URL) -> URL {
+        let lower = mountURL.appendingPathComponent("sources")
+        if fileManager.fileExists(atPath: lower.path) {
+            return lower
+        }
+
+        let upper = mountURL.appendingPathComponent("Sources")
+        return upper
+    }
+
+    private func resolveWindowsInstallWimInfo(in sourcesDirectory: URL) -> (path: String, relativePath: String, size: Int64)? {
+        let candidates = [
+            sourcesDirectory.appendingPathComponent("install.wim"),
+            sourcesDirectory.appendingPathComponent("INSTALL.WIM")
+        ]
+
+        for candidate in candidates {
+            guard fileManager.fileExists(atPath: candidate.path),
+                  let size = fileSize(at: candidate.path),
+                  let mountPath = windowsActiveSourceMountPath,
+                  candidate.path.hasPrefix(mountPath + "/") else {
+                continue
+            }
+
+            let relative = String(candidate.path.dropFirst((mountPath + "/").count))
+            return (candidate.path, relative, size)
+        }
+
+        return nil
+    }
+
+    private func resolveWindowsInstallEsdInfo(in sourcesDirectory: URL) -> String? {
+        let candidates = [
+            sourcesDirectory.appendingPathComponent("install.esd"),
+            sourcesDirectory.appendingPathComponent("INSTALL.ESD")
+        ]
+
+        for candidate in candidates where fileManager.fileExists(atPath: candidate.path) {
+            return candidate.path
+        }
+
+        return nil
+    }
+
+    private func findWindowsOversizedFiles(in sourceURL: URL, excludedFilePath: String?) throws -> [String] {
+        let enumerator = fileManager.enumerator(
+            at: sourceURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        )
+
+        var oversized: [String] = []
+        while let next = enumerator?.nextObject() as? URL {
+            let values = try next.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values.isRegularFile == true,
+                  let fileSize = values.fileSize else {
+                continue
+            }
+
+            guard Int64(fileSize) > Self.windowsFAT32LimitBytes else {
+                continue
+            }
+
+            if let excludedFilePath, next.path == excludedFilePath {
+                continue
+            }
+
+            oversized.append(next.path)
+        }
+
+        return oversized
+    }
+
+    private func computeWindowsCopyPayloadBytes(in sourceURL: URL, excludedFilePath: String?) throws -> Int64 {
+        let enumerator = fileManager.enumerator(
+            at: sourceURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+            errorHandler: { _, _ in true }
+        )
+
+        var totalBytes: Int64 = 0
+        while let next = enumerator?.nextObject() as? URL {
+            guard let values = try? next.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                  values.isRegularFile == true,
+                  let fileSize = values.fileSize else {
+                continue
+            }
+
+            if let excludedFilePath, next.path == excludedFilePath {
+                continue
+            }
+
+            totalBytes += Int64(fileSize)
+        }
+
+        return totalBytes
+    }
+
+    private func resolveExecutablePath(named executable: String) -> String? {
+        let fm = fileManager
+        let fixedSearchRoots = [
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/opt/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin"
+        ]
+
+        for root in fixedSearchRoots {
+            let candidate = URL(fileURLWithPath: root).appendingPathComponent(executable).path
+            if fm.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        if let pathEnv = ProcessInfo.processInfo.environment["PATH"], !pathEnv.isEmpty {
+            for root in pathEnv.split(separator: ":").map(String.init) {
+                let candidate = URL(fileURLWithPath: root).appendingPathComponent(executable).path
+                if fm.isExecutableFile(atPath: candidate) {
+                    return candidate
+                }
+            }
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+        process.arguments = [executable]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let outputData = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        guard let output = String(data: outputData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty else {
+            return nil
+        }
+
+        return output
+    }
+
+    private func fileSize(at path: String) -> Int64? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? NSNumber else {
+            return nil
+        }
+
+        return size.int64Value
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift
@@ -22,19 +22,11 @@ extension HelperWorkflowExecutor {
         }
         let sourceUEFIStatus = evaluateWindowsUEFIStatus(in: sourceURL)
 
-        guard sourceUEFIStatus.hasBootEntry else {
+        guard sourceUEFIStatus.hasCompatibleEFI else {
             throw HelperExecutionError.failed(
                 stage: stage.key,
                 exitCode: -1,
-                description: "W obrazie źródłowym nie znaleziono wymaganych plików UEFI (EFI/BOOT/BOOTX64.EFI lub EFI/BOOT/BOOTAA64.EFI)."
-            )
-        }
-
-        guard sourceUEFIStatus.hasMicrosoftBootDirectory else {
-            throw HelperExecutionError.failed(
-                stage: stage.key,
-                exitCode: -1,
-                description: "W obrazie źródłowym nie znaleziono katalogu EFI/Microsoft/Boot."
+                description: "W obrazie źródłowym nie znaleziono wymaganych markerów UEFI (katalog EFI oraz co najmniej jeden plik: bootmgr.efi, EFI/Microsoft/Boot/cdboot.efi, EFI/BOOT/BOOTX64.EFI, EFI/BOOT/BOOTAA64.EFI)."
             )
         }
 
@@ -88,24 +80,40 @@ extension HelperWorkflowExecutor {
     }
 
     func prepareWindowsSourceMountPath(stage: WorkflowStage) throws -> String {
-        if let mounted = request.windowsMountedSourcePath,
-           !mounted.isEmpty,
-           fileManager.fileExists(atPath: mounted),
-           (
-                fileManager.fileExists(atPath: URL(fileURLWithPath: mounted).appendingPathComponent("sources").path)
-                || fileManager.fileExists(atPath: URL(fileURLWithPath: mounted).appendingPathComponent("Sources").path)
-           ) {
+        let requestedMountPath = request.windowsMountedSourcePath?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let resolvedMountPath = resolveMountedPathForSourceImage(sourceImagePath: request.sourceAppPath),
+           isWindowsSourceMountReusable(resolvedMountPath) {
             windowsMountedByHelper = false
             windowsMountedImageDevice = nil
+            let reusedFromRequest = requestedMountPath.map { normalizedPath($0) == normalizedPath(resolvedMountPath) } ?? false
+            let reuseLog: String
+            if reusedFromRequest {
+                reuseLog = "Windows source mount reused from analysis: \(resolvedMountPath)"
+            } else {
+                reuseLog = "Windows source mount reused after source-image verification (requestMount=\(requestedMountPath ?? "brak"), verifiedMount=\(resolvedMountPath))."
+            }
             emitProgress(
                 stageKey: stage.key,
                 titleKey: stage.titleKey,
                 percent: latestPercent,
                 statusKey: stage.statusKey,
-                logLine: "Windows source mount reused from analysis: \(mounted)",
+                logLine: reuseLog,
                 shouldAdvancePercent: false
             )
-            return mounted
+            return resolvedMountPath
+        }
+
+        if let requestedMountPath, !requestedMountPath.isEmpty {
+            emitProgress(
+                stageKey: stage.key,
+                titleKey: stage.titleKey,
+                percent: latestPercent,
+                statusKey: stage.statusKey,
+                logLine: "Windows source mount from analysis ignored: does not match selected ISO source (\(requestedMountPath)).",
+                shouldAdvancePercent: false
+            )
         }
 
         let attachResult = try attachWindowsSourceISO(stage: stage)
@@ -179,6 +187,63 @@ extension HelperWorkflowExecutor {
             exitCode: -1,
             description: "Nie udało się ustalić punktu montowania ISO Windows."
         )
+    }
+
+    private func resolveMountedPathForSourceImage(sourceImagePath: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+        process.arguments = ["info", "-plist"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let outputData = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        guard let plist = try? PropertyListSerialization.propertyList(from: outputData, options: [], format: nil) as? [String: Any],
+              let images = plist["images"] as? [[String: Any]] else {
+            return nil
+        }
+
+        let normalizedSourcePath = normalizedPath(sourceImagePath)
+        for image in images {
+            guard let imagePath = image["image-path"] as? String,
+                  normalizedPath(imagePath) == normalizedSourcePath else {
+                continue
+            }
+
+            guard let entities = image["system-entities"] as? [[String: Any]],
+                  let mountPoint = entities.compactMap({ $0["mount-point"] as? String }).first else {
+                continue
+            }
+
+            return mountPoint
+        }
+
+        return nil
+    }
+
+    private func isWindowsSourceMountReusable(_ mountPath: String) -> Bool {
+        guard fileManager.fileExists(atPath: mountPath) else { return false }
+        let mountURL = URL(fileURLWithPath: mountPath)
+        let lowerSources = mountURL.appendingPathComponent("sources").path
+        let upperSources = mountURL.appendingPathComponent("Sources").path
+        return fileManager.fileExists(atPath: lowerSources) || fileManager.fileExists(atPath: upperSources)
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
     }
 
     private func resolveWindowsSourcesDirectory(in mountURL: URL) -> URL {

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
@@ -119,6 +119,11 @@ extension HelperWorkflowExecutor {
         }
 
         let rsyncPlan = resolveRsyncExecutionPlan()
+        windowsRsyncProgressMode = rsyncPlan.mode
+        windowsLegacyRsyncCurrentFilePath = nil
+        windowsLegacyRsyncCurrentFileSizeBytes = 0
+        windowsLegacyRsyncCompletedBytes = 0
+        windowsLegacyRsyncToCheckUsesProcessedCount = nil
         var createArguments = rsyncPlan.arguments
 
         if windowsShouldSplitWim, let relativeWimPath = windowsInstallWimRelativePath {
@@ -326,6 +331,10 @@ extension HelperWorkflowExecutor {
             process.executableURL = URL(fileURLWithPath: executable)
             process.arguments = arguments
         }
+        var env = ProcessInfo.processInfo.environment
+        env["LC_ALL"] = "C"
+        env["LANG"] = "C"
+        process.environment = env
 
         let pipe = Pipe()
         process.standardOutput = pipe

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    func buildWindowsWorkflowStages(using _: PreparedWorkflowContext) throws -> [WorkflowStage] {
+        var stages: [WorkflowStage] = [
+            WorkflowStage(
+                key: "windows_prepare_source",
+                titleKey: HelperWorkflowLocalizationKeys.windowsPrepareSourceTitle,
+                statusKey: HelperWorkflowLocalizationKeys.windowsPrepareSourceStatus,
+                startPercent: 10,
+                endPercent: 30,
+                executable: "/usr/bin/true",
+                arguments: [],
+                parseToolPercent: false
+            ),
+            WorkflowStage(
+                key: "windows_prepare_target",
+                titleKey: HelperWorkflowLocalizationKeys.windowsPrepareTargetTitle,
+                statusKey: HelperWorkflowLocalizationKeys.windowsPrepareTargetStatus,
+                startPercent: 30,
+                endPercent: 40,
+                executable: "/usr/bin/true",
+                arguments: [],
+                parseToolPercent: false
+            ),
+            WorkflowStage(
+                key: "windows_create_media",
+                titleKey: HelperWorkflowLocalizationKeys.windowsCreateMediaTitle,
+                statusKey: HelperWorkflowLocalizationKeys.windowsCreateMediaStatus,
+                startPercent: 40,
+                endPercent: 80,
+                executable: "/usr/bin/true",
+                arguments: [],
+                parseToolPercent: true
+            )
+        ]
+
+        stages.append(
+            WorkflowStage(
+                key: "windows_split_wim",
+                titleKey: HelperWorkflowLocalizationKeys.windowsSplitWimTitle,
+                statusKey: HelperWorkflowLocalizationKeys.windowsSplitWimStatus,
+                startPercent: 80,
+                endPercent: 95,
+                executable: "/usr/bin/true",
+                arguments: [],
+                parseToolPercent: true
+            )
+        )
+
+        stages.append(
+            WorkflowStage(
+                key: "windows_verify_media",
+                titleKey: HelperWorkflowLocalizationKeys.windowsVerifyMediaTitle,
+                statusKey: HelperWorkflowLocalizationKeys.windowsVerifyMediaStatus,
+                startPercent: 95,
+                endPercent: 98,
+                executable: "/usr/bin/true",
+                arguments: [],
+                parseToolPercent: false
+            )
+        )
+
+        return stages
+    }
+
+    func shouldSkipWindowsStage(_ stage: WorkflowStage) -> Bool {
+        guard request.workflowKind == .windows else { return false }
+        return stage.key == "windows_split_wim" && !windowsShouldSplitWim
+    }
+
+    func runWindowsCreateMediaStage(_ stage: WorkflowStage) throws {
+        let sourceMountPath = try ensureWindowsSourceMountPathForCopy(stage: stage)
+        let targetVolumePath = try ensureWindowsTargetMountPathForCopy(stage: stage)
+        let sourceCanonicalPath = URL(fileURLWithPath: sourceMountPath).resolvingSymlinksInPath().path
+        let targetCanonicalPath = URL(fileURLWithPath: targetVolumePath).resolvingSymlinksInPath().path
+
+        if sourceCanonicalPath == targetCanonicalPath {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nieprawidłowa konfiguracja kopiowania: źródło i cel wskazują na ten sam katalog (\(sourceCanonicalPath))."
+            )
+        }
+
+        guard isWindowsSourceDirectoryStructureValid(sourceCanonicalPath) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Źródło kopiowania nie jest poprawnym katalogiem obrazu Windows: \(sourceCanonicalPath)."
+            )
+        }
+
+        guard isWindowsMountedDirectoryUsable(targetCanonicalPath) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Katalog docelowy nośnika USB nie istnieje lub nie jest katalogiem: \(targetCanonicalPath)."
+            )
+        }
+
+        guard let sourceDevice = deviceIdentifierForMountPath(sourceCanonicalPath),
+              let targetDevice = deviceIdentifierForMountPath(targetCanonicalPath) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się ustalić identyfikatorów urządzeń dla kopiowania (source=\(sourceCanonicalPath), target=\(targetCanonicalPath))."
+            )
+        }
+
+        let sourceWholeDisk = try extractWholeDiskName(from: sourceDevice)
+        let targetWholeDisk = try extractWholeDiskName(from: targetDevice)
+        if sourceWholeDisk == targetWholeDisk {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nośnik źródłowy i docelowy wskazują na to samo urządzenie (\(sourceWholeDisk)). Wybierz inny dysk docelowy USB."
+            )
+        }
+
+        let rsyncPlan = resolveRsyncExecutionPlan()
+        var createArguments = rsyncPlan.arguments
+
+        if windowsShouldSplitWim, let relativeWimPath = windowsInstallWimRelativePath {
+            createArguments.append("--exclude=/\(relativeWimPath)")
+        }
+
+        createArguments.append("\(sourceCanonicalPath)/")
+        createArguments.append("\(targetCanonicalPath)/")
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows copy command: \(rsyncPlan.executable) \(createArguments.joined(separator: " ")) [sourceDevice=\(sourceDevice), targetDevice=\(targetDevice), mode=\(rsyncPlan.mode)]",
+            shouldAdvancePercent: false
+        )
+
+        try runWindowsStreamingStageCommand(
+            stage: stage,
+            executable: rsyncPlan.executable,
+            arguments: createArguments
+        )
+    }
+
+    func runWindowsSplitWimStage(_ stage: WorkflowStage) throws {
+        guard windowsShouldSplitWim else { return }
+        guard let installWimPath = windowsInstallWimPath,
+              let wimlibPath = windowsWimlibExecutablePath else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Brak danych wymaganych do podziału install.wim."
+            )
+        }
+
+        let targetVolumePath = windowsPreparedTargetVolumePath ?? "/Volumes/\(request.targetLabel)"
+        let relativeWimPath = windowsInstallWimRelativePath ?? "sources/install.wim"
+        let sourcesSubdirectory = (relativeWimPath as NSString).deletingLastPathComponent
+        let targetSplitPath = URL(fileURLWithPath: targetVolumePath)
+            .appendingPathComponent(sourcesSubdirectory)
+            .appendingPathComponent("install.swm")
+            .path
+
+        try runWindowsStreamingStageCommand(
+            stage: stage,
+            executable: wimlibPath,
+            arguments: ["split", installWimPath, targetSplitPath, "3800"]
+        )
+    }
+
+    private func ensureWindowsSourceMountPathForCopy(stage: WorkflowStage) throws -> String {
+        if let currentPath = windowsActiveSourceMountPath,
+           isWindowsMountedDirectoryUsable(currentPath) {
+            return currentPath
+        }
+
+        let attachResult = try attachWindowsSourceISO(stage: stage)
+        windowsMountedByHelper = true
+        windowsMountedImageDevice = attachResult.device
+        windowsActiveSourceMountPath = attachResult.mountPath
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows source remounted before copy: \(attachResult.mountPath)",
+            shouldAdvancePercent: false
+        )
+
+        return attachResult.mountPath
+    }
+
+    private func ensureWindowsTargetMountPathForCopy(stage: WorkflowStage) throws -> String {
+        if let currentPath = windowsPreparedTargetVolumePath,
+           isWindowsMountedDirectoryUsable(currentPath) {
+            return currentPath
+        }
+
+        let wholeDisk = try extractWholeDiskName(from: request.targetBSDName)
+        guard let remountedPath = resolveMountedVolumePathForWholeDisk(wholeDisk),
+              isWindowsMountedDirectoryUsable(remountedPath) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie znaleziono zamontowanego woluminu docelowego USB przed kopiowaniem."
+            )
+        }
+
+        windowsPreparedTargetVolumePath = remountedPath
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows target path refreshed before copy: \(remountedPath)",
+            shouldAdvancePercent: false
+        )
+        return remountedPath
+    }
+
+    private func isWindowsMountedDirectoryUsable(_ path: String) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private func isWindowsSourceDirectoryStructureValid(_ sourcePath: String) -> Bool {
+        let sourceURL = URL(fileURLWithPath: sourcePath)
+        let sourcesLower = sourceURL.appendingPathComponent("sources").path
+        let sourcesUpper = sourceURL.appendingPathComponent("Sources").path
+        return isWindowsMountedDirectoryUsable(sourcePath)
+            && (fileManager.fileExists(atPath: sourcesLower) || fileManager.fileExists(atPath: sourcesUpper))
+    }
+
+    private func deviceIdentifierForMountPath(_ mountPath: String) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+        process.arguments = ["info", "-plist", mountPath]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let data = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        guard !data.isEmpty,
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dictionary = plist as? [String: Any],
+              let deviceIdentifier = dictionary["DeviceIdentifier"] as? String,
+              !deviceIdentifier.isEmpty else {
+            return nil
+        }
+
+        return deviceIdentifier
+    }
+
+    private func resolveRsyncExecutionPlan() -> (executable: String, arguments: [String], mode: String) {
+        let candidates = [
+            "/opt/homebrew/bin/rsync",
+            "/usr/local/bin/rsync",
+            "/opt/local/bin/rsync",
+            "/usr/bin/rsync"
+        ]
+
+        for candidate in candidates where fileManager.isExecutableFile(atPath: candidate) {
+            if supportsRsyncProgress2(executable: candidate) {
+                return (candidate, ["-a", "--info=progress2,name0"], "progress2")
+            }
+            return (candidate, ["-a", "-h", "--progress"], "legacy-progress")
+        }
+
+        return ("/usr/bin/rsync", ["-a", "-h", "--progress"], "legacy-progress-fallback")
+    }
+
+    private func supportsRsyncProgress2(executable: String) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = ["--version"]
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return false
+        }
+
+        let data = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        guard let output = String(data: data, encoding: .utf8)?.lowercased() else {
+            return false
+        }
+
+        // macOS ships ancient rsync 2.6.9 (openrsync-compatible usage) without --info=progress2.
+        if output.contains("version 2.6.9") || output.contains("protocol version 29") {
+            return false
+        }
+
+        return true
+    }
+
+    private func runWindowsStreamingStageCommand(
+        stage: WorkflowStage,
+        executable: String,
+        arguments: [String]
+    ) throws {
+        let process = Process()
+        if let requesterUID = request.requesterUID, requesterUID > 0 {
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = ["asuser", "\(requesterUID)", executable] + arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: executable)
+            process.arguments = arguments
+        }
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        stateQueue.sync {
+            activeProcess = process
+        }
+
+        var buffer = Data()
+
+        do {
+            try process.run()
+        } catch {
+            stateQueue.sync {
+                activeProcess = nil
+            }
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się uruchomić polecenia \(executable): \(error.localizedDescription)"
+            )
+        }
+
+        let handle = pipe.fileHandleForReading
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                break
+            }
+            buffer.append(chunk)
+            drainBufferedOutputLines(from: &buffer) { line in
+                handleOutputLine(line, stage: stage)
+            }
+        }
+
+        if !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !line.isEmpty {
+            handleOutputLine(line, stage: stage)
+        }
+
+        process.waitUntilExit()
+
+        stateQueue.sync {
+            activeProcess = nil
+        }
+
+        try throwIfCancelled()
+
+        guard process.terminationStatus == 0 else {
+            var description = "Polecenie \(executable) zakończyło się błędem (kod \(process.terminationStatus))."
+            if let lastLine = lastStageOutputLine {
+                description += " Ostatni komunikat: \(lastLine)"
+            }
+            if !arguments.isEmpty {
+                description += " Args: \(arguments.joined(separator: " "))"
+            }
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: process.terminationStatus,
+                description: description
+            )
+        }
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 extension HelperWorkflowExecutor {
-    private static let windowsUnmountBusyPromptMarker = "windows_unmount_busy_prompt"
+    private static let windowsUnmountForcePromptMarker = "windows_unmount_force_prompt"
 
     func shouldDeferCleanupForWindowsUnmountPrompt(failedStage: String, description: String) -> Bool {
         guard request.workflowKind == .windows else { return false }
         guard failedStage == "windows_prepare_target" else { return false }
         guard !request.windowsForceUnmount else { return false }
-        return description.lowercased().contains(Self.windowsUnmountBusyPromptMarker)
+        return description.lowercased().contains(Self.windowsUnmountForcePromptMarker)
     }
 
     func runWindowsPrepareTargetStage(_ stage: WorkflowStage) throws {
@@ -32,7 +32,7 @@ extension HelperWorkflowExecutor {
             let retryCount = 3
             let totalAttempts = retryCount + 1
 
-            var unmounted = false
+            var lastFailure: (exitCode: Int32, lastLine: String?, isBusyFailure: Bool)?
             for attempt in 1...totalAttempts {
                 let unmountStatus = try runWindowsUnmountCommand(
                     stage: stage,
@@ -40,41 +40,39 @@ extension HelperWorkflowExecutor {
                 )
 
                 if unmountStatus.success {
-                    unmounted = true
                     break
                 }
 
-                if unmountStatus.isBusyFailure, attempt <= retryCount {
+                lastFailure = (
+                    exitCode: unmountStatus.exitCode,
+                    lastLine: unmountStatus.lastLine,
+                    isBusyFailure: unmountStatus.isBusyFailure
+                )
+
+                if attempt <= retryCount {
                     emitProgress(
                         stageKey: stage.key,
                         titleKey: stage.titleKey,
                         percent: latestPercent,
                         statusKey: stage.statusKey,
-                        logLine: "Windows unmount retry \(attempt)/\(retryCount): nośnik zajęty, ponawiam za \(retryDelaySeconds)s.",
+                        logLine: "Windows unmount retry \(attempt)/\(retryCount): odmontowanie nieudane (kod \(unmountStatus.exitCode)), ponawiam za \(retryDelaySeconds)s.",
                         shouldAdvancePercent: false
                     )
                     try waitWindowsUnmountRetryDelay(seconds: retryDelaySeconds)
                     continue
                 }
-
-                if unmountStatus.isBusyFailure {
-                    let description = "Nie udało się odmontować nośnika, ponieważ jest używany przez inny proces. \(Self.windowsUnmountBusyPromptMarker)"
-                    throw HelperExecutionError.failed(stage: stage.key, exitCode: unmountStatus.exitCode, description: description)
-                }
-
-                var description = "Nie udało się odmontować nośnika (kod \(unmountStatus.exitCode))."
-                if let line = unmountStatus.lastLine {
-                    description += " Ostatni komunikat: \(line)"
-                }
-                throw HelperExecutionError.failed(stage: stage.key, exitCode: unmountStatus.exitCode, description: description)
             }
 
-            guard unmounted else {
-                throw HelperExecutionError.failed(
-                    stage: stage.key,
-                    exitCode: -1,
-                    description: "Nie udało się odmontować nośnika USB."
-                )
+            if let failure = lastFailure {
+                var description = "Nie udało się odmontować nośnika przed formatowaniem. \(Self.windowsUnmountForcePromptMarker)"
+                description += " Kod: \(failure.exitCode)."
+                if failure.isBusyFailure {
+                    description += " Wykryto sygnał zajętego urządzenia."
+                }
+                if let line = failure.lastLine {
+                    description += " Ostatni komunikat: \(line)"
+                }
+                throw HelperExecutionError.failed(stage: stage.key, exitCode: failure.exitCode, description: description)
             }
         }
 

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
@@ -1,0 +1,303 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    private static let windowsUnmountBusyPromptMarker = "windows_unmount_busy_prompt"
+
+    func shouldDeferCleanupForWindowsUnmountPrompt(failedStage: String, description: String) -> Bool {
+        guard request.workflowKind == .windows else { return false }
+        guard failedStage == "windows_prepare_target" else { return false }
+        guard !request.windowsForceUnmount else { return false }
+        return description.lowercased().contains(Self.windowsUnmountBusyPromptMarker)
+    }
+
+    func runWindowsPrepareTargetStage(_ stage: WorkflowStage) throws {
+        let wholeDisk = try extractWholeDiskName(from: request.targetBSDName)
+        let targetDevice = "/dev/\(wholeDisk)"
+
+        if request.windowsForceUnmount {
+            let forcedUnmountStatus = try runWindowsUnmountCommand(
+                stage: stage,
+                arguments: ["unmountDisk", "force", targetDevice]
+            )
+
+            guard forcedUnmountStatus.success else {
+                var description = "Wymuszone odmontowanie nośnika nie powiodło się (kod \(forcedUnmountStatus.exitCode))."
+                if let line = forcedUnmountStatus.lastLine {
+                    description += " Ostatni komunikat: \(line)"
+                }
+                throw HelperExecutionError.failed(stage: stage.key, exitCode: forcedUnmountStatus.exitCode, description: description)
+            }
+        } else {
+            let retryDelaySeconds = 2
+            let retryCount = 3
+            let totalAttempts = retryCount + 1
+
+            var unmounted = false
+            for attempt in 1...totalAttempts {
+                let unmountStatus = try runWindowsUnmountCommand(
+                    stage: stage,
+                    arguments: ["unmountDisk", targetDevice]
+                )
+
+                if unmountStatus.success {
+                    unmounted = true
+                    break
+                }
+
+                if unmountStatus.isBusyFailure, attempt <= retryCount {
+                    emitProgress(
+                        stageKey: stage.key,
+                        titleKey: stage.titleKey,
+                        percent: latestPercent,
+                        statusKey: stage.statusKey,
+                        logLine: "Windows unmount retry \(attempt)/\(retryCount): nośnik zajęty, ponawiam za \(retryDelaySeconds)s.",
+                        shouldAdvancePercent: false
+                    )
+                    try waitWindowsUnmountRetryDelay(seconds: retryDelaySeconds)
+                    continue
+                }
+
+                if unmountStatus.isBusyFailure {
+                    let description = "Nie udało się odmontować nośnika, ponieważ jest używany przez inny proces. \(Self.windowsUnmountBusyPromptMarker)"
+                    throw HelperExecutionError.failed(stage: stage.key, exitCode: unmountStatus.exitCode, description: description)
+                }
+
+                var description = "Nie udało się odmontować nośnika (kod \(unmountStatus.exitCode))."
+                if let line = unmountStatus.lastLine {
+                    description += " Ostatni komunikat: \(line)"
+                }
+                throw HelperExecutionError.failed(stage: stage.key, exitCode: unmountStatus.exitCode, description: description)
+            }
+
+            guard unmounted else {
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Nie udało się odmontować nośnika USB."
+                )
+            }
+        }
+
+        try runWindowsFormatCommand(stage: stage, wholeDisk: wholeDisk)
+        let mountPath = try waitForWindowsTargetVolumeMountPath(
+            stage: stage,
+            wholeDisk: wholeDisk,
+            preferredVolumeName: request.targetLabel
+        )
+        windowsPreparedTargetVolumePath = mountPath
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows target prepared: disk=\(wholeDisk), label=\(request.targetLabel), mountPath=\(mountPath)",
+            shouldAdvancePercent: false
+        )
+    }
+
+    private func runWindowsUnmountCommand(stage: WorkflowStage, arguments: [String]) throws -> (success: Bool, exitCode: Int32, isBusyFailure: Bool, lastLine: String?) {
+        let process = Process()
+        if let requesterUID = request.requesterUID, requesterUID > 0 {
+            process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            process.arguments = ["asuser", "\(requesterUID)", "/usr/sbin/diskutil"] + arguments
+        } else {
+            process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+            process.arguments = arguments
+        }
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        stateQueue.sync {
+            activeProcess = process
+        }
+
+        var buffer = Data()
+        var isBusyFailure = false
+        var lastLine: String?
+
+        do {
+            try process.run()
+        } catch {
+            stateQueue.sync {
+                activeProcess = nil
+            }
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie udało się uruchomić polecenia /usr/sbin/diskutil: \(error.localizedDescription)"
+            )
+        }
+
+        let handle = pipe.fileHandleForReading
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                break
+            }
+            buffer.append(chunk)
+            drainBufferedOutputLines(from: &buffer) { line in
+                lastStageOutputLine = line
+                lastLine = line
+                if isWindowsUnmountBusyLine(line) {
+                    isBusyFailure = true
+                }
+                emitProgress(
+                    stageKey: stage.key,
+                    titleKey: stage.titleKey,
+                    percent: latestPercent,
+                    statusKey: stage.statusKey,
+                    logLine: line,
+                    shouldAdvancePercent: false
+                )
+            }
+        }
+
+        if !buffer.isEmpty,
+           let line = String(data: buffer, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !line.isEmpty {
+            lastStageOutputLine = line
+            lastLine = line
+            if isWindowsUnmountBusyLine(line) {
+                isBusyFailure = true
+            }
+            emitProgress(
+                stageKey: stage.key,
+                titleKey: stage.titleKey,
+                percent: latestPercent,
+                statusKey: stage.statusKey,
+                logLine: line,
+                shouldAdvancePercent: false
+            )
+        }
+
+        process.waitUntilExit()
+        let exitCode = process.terminationStatus
+
+        stateQueue.sync {
+            activeProcess = nil
+        }
+
+        try throwIfCancelled()
+
+        return (
+            success: exitCode == 0,
+            exitCode: exitCode,
+            isBusyFailure: isBusyFailure,
+            lastLine: lastLine
+        )
+    }
+
+    private func runWindowsFormatCommand(stage: WorkflowStage, wholeDisk: String) throws {
+        _ = try runSimpleCommand(
+            executable: "/usr/sbin/diskutil",
+            arguments: ["eraseDisk", "MS-DOS", request.targetLabel, "MBRFormat", "/dev/\(wholeDisk)"],
+            stageKey: stage.key,
+            stageTitleKey: stage.titleKey,
+            statusKey: stage.statusKey
+        )
+    }
+
+    private func waitWindowsUnmountRetryDelay(seconds: Int) throws {
+        guard seconds > 0 else { return }
+        for _ in 0..<(seconds * 10) {
+            try throwIfCancelled()
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+    }
+
+    private func waitForWindowsTargetVolumeMountPath(
+        stage: WorkflowStage,
+        wholeDisk: String,
+        preferredVolumeName: String
+    ) throws -> String {
+        let preferredMountPath = "/Volumes/\(preferredVolumeName)"
+
+        for _ in 0..<70 {
+            if let resolvedMountPath = resolveMountedVolumePathForWholeDisk(wholeDisk),
+               isExistingDirectory(atPath: resolvedMountPath) {
+                return resolvedMountPath
+            }
+
+            if isExistingDirectory(atPath: preferredMountPath),
+               isMountPathBackedByWholeDisk(preferredMountPath, wholeDisk: wholeDisk) {
+                return preferredMountPath
+            }
+            try throwIfCancelled()
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        throw HelperExecutionError.failed(
+            stage: stage.key,
+            exitCode: -1,
+            description: "Nie znaleziono zamontowanego woluminu USB po formatowaniu dla urządzenia \(wholeDisk)."
+        )
+    }
+
+    func resolveMountedVolumePathForWholeDisk(_ wholeDisk: String) -> String? {
+        guard let info = diskutilPlist(arguments: ["list", "-plist", "/dev/\(wholeDisk)"]),
+              let partitions = info["Partitions"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for partition in partitions {
+            if let mountPoint = partition["MountPoint"] as? String,
+               !mountPoint.isEmpty {
+                return mountPoint
+            }
+        }
+        return nil
+    }
+
+    private func isMountPathBackedByWholeDisk(_ mountPath: String, wholeDisk: String) -> Bool {
+        guard let info = diskutilPlist(arguments: ["info", "-plist", mountPath]),
+              let deviceIdentifier = info["DeviceIdentifier"] as? String else {
+            return false
+        }
+        return deviceIdentifier.hasPrefix(wholeDisk)
+    }
+
+    private func diskutilPlist(arguments: [String]) -> [String: Any]? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+        process.arguments = arguments
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            return nil
+        }
+
+        let data = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
+        guard !data.isEmpty,
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dictionary = plist as? [String: Any] else {
+            return nil
+        }
+
+        return dictionary
+    }
+
+    private func isExistingDirectory(atPath path: String) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    private func isWindowsUnmountBusyLine(_ line: String) -> Bool {
+        let lowered = line.lowercased()
+        return lowered.contains("at least one volume could not be unmounted")
+            || lowered.contains("unmount was dissented by pid")
+            || lowered.contains("resource busy")
+            || lowered.contains("device busy")
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 struct WindowsUEFIStatus {
-    let hasBootEntry: Bool
-    let hasMicrosoftBootDirectory: Bool
+    let hasEFIDirectory: Bool
+    let hasAcceptedBootMarker: Bool
+
+    var hasCompatibleEFI: Bool {
+        hasEFIDirectory && hasAcceptedBootMarker
+    }
 }
 
 extension HelperWorkflowExecutor {
@@ -29,19 +33,11 @@ extension HelperWorkflowExecutor {
         }
 
         let uefiStatus = evaluateWindowsUEFIStatus(in: targetURL)
-        guard uefiStatus.hasBootEntry else {
+        guard uefiStatus.hasCompatibleEFI else {
             throw HelperExecutionError.failed(
                 stage: stage.key,
                 exitCode: -1,
-                description: "Na nośniku USB nie znaleziono wymaganych plików UEFI (EFI/BOOT/BOOTX64.EFI lub EFI/BOOT/BOOTAA64.EFI)."
-            )
-        }
-
-        guard uefiStatus.hasMicrosoftBootDirectory else {
-            throw HelperExecutionError.failed(
-                stage: stage.key,
-                exitCode: -1,
-                description: "Na nośniku USB nie znaleziono katalogu EFI/Microsoft/Boot."
+                description: "Na nośniku USB nie znaleziono wymaganych markerów UEFI (katalog EFI oraz co najmniej jeden plik: bootmgr.efi, EFI/Microsoft/Boot/cdboot.efi, EFI/BOOT/BOOTX64.EFI, EFI/BOOT/BOOTAA64.EFI)."
             )
         }
 
@@ -88,7 +84,16 @@ extension HelperWorkflowExecutor {
     }
 
     func evaluateWindowsUEFIStatus(in rootURL: URL) -> WindowsUEFIStatus {
+        let hasEFIDirectory = fileManager.fileExists(atPath: rootURL.appendingPathComponent("EFI").path)
+            || fileManager.fileExists(atPath: rootURL.appendingPathComponent("efi").path)
+
         let bootCandidates = [
+            "bootmgr.efi",
+            "BOOTMGR.EFI",
+            "EFI/Microsoft/Boot/cdboot.efi",
+            "efi/microsoft/boot/cdboot.efi",
+            "EFI/Microsoft/Boot/CDBOOT.EFI",
+            "efi/microsoft/boot/CDBOOT.EFI",
             "EFI/BOOT/BOOTX64.EFI",
             "EFI/BOOT/BOOTAA64.EFI",
             "efi/boot/bootx64.efi",
@@ -99,23 +104,19 @@ extension HelperWorkflowExecutor {
             "EFI/BOOT/bootaa64.efi"
         ]
 
-        let hasBootEntry = bootCandidates.contains { candidate in
+        let hasAcceptedBootMarker = bootCandidates.contains { candidate in
             fileManager.fileExists(atPath: rootURL.appendingPathComponent(candidate).path)
         }
 
-        let hasMicrosoftBootDirectory = fileManager.fileExists(atPath: rootURL.appendingPathComponent("EFI/Microsoft/Boot").path)
-            || fileManager.fileExists(atPath: rootURL.appendingPathComponent("efi/microsoft/boot").path)
-
         return WindowsUEFIStatus(
-            hasBootEntry: hasBootEntry,
-            hasMicrosoftBootDirectory: hasMicrosoftBootDirectory
+            hasEFIDirectory: hasEFIDirectory,
+            hasAcceptedBootMarker: hasAcceptedBootMarker
         )
     }
 
     func detachWindowsMountedSourceIfNeeded() {
         let explicitDevice = windowsMountedImageDevice?.trimmingCharacters(in: .whitespacesAndNewlines)
         let explicitMountPath = windowsActiveSourceMountPath?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let requestMountPath = request.windowsMountedSourcePath?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         var detachTargets: [String] = []
         if let explicitDevice, !explicitDevice.isEmpty {
@@ -123,9 +124,6 @@ extension HelperWorkflowExecutor {
         }
         if let explicitMountPath, !explicitMountPath.isEmpty {
             detachTargets.append(explicitMountPath)
-        }
-        if let requestMountPath, !requestMountPath.isEmpty {
-            detachTargets.append(requestMountPath)
         }
 
         let uniqueTargets = Array(Set(detachTargets))

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+struct WindowsUEFIStatus {
+    let hasBootEntry: Bool
+    let hasMicrosoftBootDirectory: Bool
+}
+
+extension HelperWorkflowExecutor {
+    func runWindowsVerifyMediaStage(_ stage: WorkflowStage) throws {
+        let targetPath = windowsPreparedTargetVolumePath ?? "/Volumes/\(request.targetLabel)"
+        let targetURL = URL(fileURLWithPath: targetPath)
+
+        guard fileManager.fileExists(atPath: targetPath) else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Nie znaleziono zamontowanego woluminu docelowego po formatowaniu: \(targetPath)."
+            )
+        }
+
+        let bootWimFound = fileManager.fileExists(atPath: targetURL.appendingPathComponent("sources/boot.wim").path)
+            || fileManager.fileExists(atPath: targetURL.appendingPathComponent("Sources/boot.wim").path)
+        guard bootWimFound else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Na nośniku USB nie znaleziono pliku sources/boot.wim."
+            )
+        }
+
+        let uefiStatus = evaluateWindowsUEFIStatus(in: targetURL)
+        guard uefiStatus.hasBootEntry else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Na nośniku USB nie znaleziono wymaganych plików UEFI (EFI/BOOT/BOOTX64.EFI lub EFI/BOOT/BOOTAA64.EFI)."
+            )
+        }
+
+        guard uefiStatus.hasMicrosoftBootDirectory else {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Na nośniku USB nie znaleziono katalogu EFI/Microsoft/Boot."
+            )
+        }
+
+        if windowsShouldSplitWim {
+            let swmFound = fileManager.fileExists(atPath: targetURL.appendingPathComponent("sources/install.swm").path)
+                || fileManager.fileExists(atPath: targetURL.appendingPathComponent("Sources/install.swm").path)
+            guard swmFound else {
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Nie znaleziono pliku install.swm po podziale WIM."
+                )
+            }
+        } else if windowsInstallWimPath != nil {
+            let wimFound = fileManager.fileExists(atPath: targetURL.appendingPathComponent("sources/install.wim").path)
+                || fileManager.fileExists(atPath: targetURL.appendingPathComponent("Sources/install.wim").path)
+            guard wimFound else {
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Nie znaleziono pliku install.wim po kopiowaniu nośnika."
+                )
+            }
+        } else if windowsHasInstallESD {
+            let esdFound = fileManager.fileExists(atPath: targetURL.appendingPathComponent("sources/install.esd").path)
+                || fileManager.fileExists(atPath: targetURL.appendingPathComponent("Sources/install.esd").path)
+            guard esdFound else {
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Nie znaleziono pliku install.esd po kopiowaniu nośnika."
+                )
+            }
+        }
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows media validation completed successfully.",
+            shouldAdvancePercent: false
+        )
+    }
+
+    func evaluateWindowsUEFIStatus(in rootURL: URL) -> WindowsUEFIStatus {
+        let bootCandidates = [
+            "EFI/BOOT/BOOTX64.EFI",
+            "EFI/BOOT/BOOTAA64.EFI",
+            "efi/boot/bootx64.efi",
+            "efi/boot/bootaa64.efi",
+            "efi/boot/BOOTX64.EFI",
+            "efi/boot/BOOTAA64.EFI",
+            "EFI/BOOT/bootx64.efi",
+            "EFI/BOOT/bootaa64.efi"
+        ]
+
+        let hasBootEntry = bootCandidates.contains { candidate in
+            fileManager.fileExists(atPath: rootURL.appendingPathComponent(candidate).path)
+        }
+
+        let hasMicrosoftBootDirectory = fileManager.fileExists(atPath: rootURL.appendingPathComponent("EFI/Microsoft/Boot").path)
+            || fileManager.fileExists(atPath: rootURL.appendingPathComponent("efi/microsoft/boot").path)
+
+        return WindowsUEFIStatus(
+            hasBootEntry: hasBootEntry,
+            hasMicrosoftBootDirectory: hasMicrosoftBootDirectory
+        )
+    }
+
+    func detachWindowsMountedSourceIfNeeded() {
+        let explicitDevice = windowsMountedImageDevice?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let explicitMountPath = windowsActiveSourceMountPath?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let requestMountPath = request.windowsMountedSourcePath?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var detachTargets: [String] = []
+        if let explicitDevice, !explicitDevice.isEmpty {
+            detachTargets.append(explicitDevice)
+        }
+        if let explicitMountPath, !explicitMountPath.isEmpty {
+            detachTargets.append(explicitMountPath)
+        }
+        if let requestMountPath, !requestMountPath.isEmpty {
+            detachTargets.append(requestMountPath)
+        }
+
+        let uniqueTargets = Array(Set(detachTargets))
+        for target in uniqueTargets {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+            process.arguments = ["detach", target, "-force"]
+            process.standardOutput = Pipe()
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+                emitProgress(
+                    stageKey: "windows_cleanup_temp",
+                    titleKey: HelperWorkflowLocalizationKeys.windowsCleanupTempTitle,
+                    percent: latestPercent,
+                    statusKey: HelperWorkflowLocalizationKeys.windowsCleanupTempStatus,
+                    logLine: "Windows cleanup: detached source image target=\(target), exit=\(process.terminationStatus)",
+                    shouldAdvancePercent: false
+                )
+            } catch {
+                emitProgress(
+                    stageKey: "windows_cleanup_temp",
+                    titleKey: HelperWorkflowLocalizationKeys.windowsCleanupTempTitle,
+                    percent: latestPercent,
+                    statusKey: HelperWorkflowLocalizationKeys.windowsCleanupTempStatus,
+                    logLine: "Windows cleanup warning: detach \(target) failed: \(error.localizedDescription)",
+                    shouldAdvancePercent: false
+                )
+            }
+        }
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift
@@ -2,6 +2,21 @@ import Foundation
 
 extension HelperWorkflowExecutor {
     func extractWindowsWimSplitProgressPercent(from line: String) -> Double? {
-        extractPercent(from: line)
+        guard let progressRegex = try? NSRegularExpression(
+            pattern: #"\(([0-9]{1,3})%\)\s+written\b"#,
+            options: [.caseInsensitive]
+        ) else {
+            return nil
+        }
+
+        let range = NSRange(line.startIndex..<line.endIndex, in: line)
+        guard let match = progressRegex.firstMatch(in: line, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let percentRange = Range(match.range(at: 1), in: line),
+              let percent = Double(line[percentRange]) else {
+            return nil
+        }
+
+        return min(max(percent, 0), 100)
     }
 }

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension HelperWorkflowExecutor {
+    func extractWindowsWimSplitProgressPercent(from line: String) -> Double? {
+        extractPercent(from: line)
+    }
+}


### PR DESCRIPTION
This PR delivers a dedicated end-to-end Windows USB creation workflow, moving Windows handling to a first-class path in both the app and privileged helper. It introduces Windows-specific orchestration, stage execution, and progress mapping so Windows media creation follows a tailored pipeline instead of shared generic logic, with consistent UI status reporting from analysis to completion.

Scope included in this Windows-focused workflow:
- Windows-specific workflow routing in analysis and installation flow integration.
- Dedicated Windows helper stages for source preparation, validation, copy/split operations, and target preparation.
- Windows-specific progress parsing and app-side stage/status mapping for creation progress UI.
- Supporting reliability updates required by this workflow (mount reuse verification, EFI marker validation alignment, and force-unmount recovery signaling).
- Localization/key updates required to present Windows workflow states and outcomes.
