### PR TITLE
fix: validate (.)app macOS installers

### DIFF
--- a/macUSB/Features/Analysis/AnalysisLogic.swift
+++ b/macUSB/Features/Analysis/AnalysisLogic.swift
@@ -189,6 +189,65 @@ final class AnalysisLogic: ObservableObject {
         updates()
         isSynchronizingDriveSelection = false
     }
+
+    private func isValidMacOSInstaller(at url: URL) -> Bool {
+        let fileManager = FileManager.default
+        
+        // check for createinstallmedia (as a file, just in case..)
+        let createinstallmedia = url.appendingPathComponent("Contents/Resources/createinstallmedia")
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: createinstallmedia.path, isDirectory: &isDirectory) {
+            if !isDirectory.boolValue {
+                return true
+            }
+        }
+        
+        // check for InstallESD.dmg, in case of older installers
+        let installESD = url.appendingPathComponent("Contents/SharedSupport/InstallESD.dmg")
+        if fileManager.fileExists(atPath: installESD.path) {
+            return true
+        }
+        
+        // check bundle identifier
+        let infoPlist = url.appendingPathComponent("Contents/Info.plist")
+        guard let dict = NSDictionary(contentsOf: infoPlist) as? [String: Any],
+              let bundleID = dict["CFBundleIdentifier"] as? String else {
+            return false
+        }
+        
+        // list of valid app bundle IDS/prefixes, corresponding to installers
+        let installerIDs = [
+            "com.apple.InstallAssistant",
+            "com.apple.InstallOSX",
+            "com.apple.InstallMacOSX"
+        ]
+        
+        if installerIDs.contains(where: { bundleID.hasPrefix($0) }) {
+            return true
+        }
+        
+        return false
+    }
+ 
+    func isValidInstallerApp(_ url: URL) -> Bool {
+        let ext = url.pathExtension.lowercased()
+
+        if ext == "app" {
+            guard isValidMacOSInstaller(at: url) else {
+                DispatchQueue.main.async {
+                    self.recognizedVersion = String(localized: "Nie rozpoznano instalatora")
+                    self.isSystemDetected = false
+                    self.showUnsupportedMessage = true
+                    self.sourceAppURL = nil
+                    self.isAnalyzing = false
+                    self.detectedSystemIcon = nil
+                }
+                return false
+            }
+        }
+        
+        return true
+    }
 }
 
 extension AnalysisLogic {

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicAnalysisFlow.swift
@@ -36,6 +36,7 @@ extension AnalysisLogic {
     func startAnalysis() {
         cancelActiveImageAnalysisRun(reason: "Start nowej analizy")
         guard let url = selectedFileUrl else { return }
+        guard isValidInstallerApp(url) else { return }
         self.stage("Analiza pliku — start")
         self.log("Rozpoczynam analizę pliku")
         self.log("Źródło pliku do odczytu wersji: \(url.path)")

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicFileSelection.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicFileSelection.swift
@@ -63,6 +63,14 @@ extension AnalysisLogic {
         DispatchQueue.main.async {
             let ext = url.pathExtension.lowercased()
             self.log("Wybrano plik w formacie .\(ext). Resetuję stan i przygotowuję analizę.")
+            if ext == "app" && !self.isValidInstallerApp(url) {
+                self.selectedFilePath = ""
+                self.selectedFileUrl = nil
+                self.recognizedVersion = String(localized: "Nie rozpoznano instalatora")
+                self.isSystemDetected = false
+                self.showUnsupportedMessage = true
+                return
+            }
             if ext == "dmg" || ext == "app" || ext == "iso" || ext == "cdr" {
                 self.cancelActiveImageAnalysisRun(reason: "Zmiana wybranego pliku podczas analizy")
                 let previousMountedPath = self.mountedDMGPath
@@ -103,6 +111,15 @@ extension AnalysisLogic {
             return
         }
 
+        if ext == "app" && !isValidInstallerApp(url) {
+            self.selectedFilePath = ""
+            self.selectedFileUrl = nil
+            self.recognizedVersion = String(localized: "Nie rozpoznano instalatora")
+            self.isSystemDetected = false
+            self.showUnsupportedMessage = true
+            return
+        }
+
         processDroppedURL(url)
         DispatchQueue.main.async { [weak self] in
             self?.startAnalysis()
@@ -120,6 +137,14 @@ extension AnalysisLogic {
             if $0 == .OK, let url = p.url {
                 let ext = url.pathExtension.lowercased()
                 guard ext == "dmg" || ext == "iso" || ext == "cdr" || ext == "app" else { return }
+                if ext == "app" && !self.isValidInstallerApp(url) {
+                    self.selectedFilePath = ""
+                    self.selectedFileUrl = nil
+                    self.recognizedVersion = String(localized: "Nie rozpoznano instalatora")
+                    self.isSystemDetected = false
+                    self.showUnsupportedMessage = true
+                    return
+                }
                 self.cancelActiveImageAnalysisRun(reason: "Wybrano nowy plik źródłowy")
                 let previousMountedPath = self.mountedDMGPath
                 withAnimation {


### PR DESCRIPTION
Previously, installer bundles had no validation and any .app file was wrongly marked as valid (as reported by the analysis). This PR fixes that, by implementing the following process:

- `isValidMacOSInstaller()` checks for:
   - `Contents/Resources/createinstallmedia`
   - `Contents/SharedSupport/InstallESD.dmg` (case of older installers)
   - matching bundle IDs: `com.apple.InstallAssistant.*`, `com.apple.InstallOSX`, `com.apple.InstallMacOSX`

If there's no `createinstallmedia` nor `InstallESD.dmg`, furthermore no `Info.plist`(or an invalid/empty one), the bundle is invalid.