### PR TITLE
Secure helper trust and auto-update feedback

### DIFF
--- a/docs/reference/design/DESIGN_SYSTEM.md
+++ b/docs/reference/design/DESIGN_SYSTEM.md
@@ -10,6 +10,7 @@ Core contract:
 - consistent panel/docked surface semantics,
 - consistent hierarchy of status cards,
 - consistent CTA behavior and bottom action bars,
+- neutral in-app toast surfaces for transient status changes,
 - consistent inactive/active visual behavior across windows and states.
 
 ## Required UI Primitives
@@ -22,6 +23,7 @@ Use wrappers from `LiquidGlassCompatibility.swift`:
 
 Use spacing/radius tokens from `MacUSBDesignTokens`.
 Use `BottomActionBar` with `safeAreaInset(edge: .bottom)` for bottom action zones.
+Use global in-app toasts only for transient, non-blocking state changes; they should use a neutral native SwiftUI glass surface on systems that support Liquid Glass and a neutral fallback surface on older macOS versions.
 
 ## Window/Layout Contract
 

--- a/docs/reference/features/helper/HELPER.md
+++ b/docs/reference/features/helper/HELPER.md
@@ -133,7 +133,7 @@ Contract invariants:
 - Entry point: `bootstrapIfNeededAtStartup`.
 - After successful non-interactive ensure-ready, app compares current app fingerprint (`CFBundleShortVersionString` + `CFBundleVersion`) with last successful helper-repair fingerprint stored in `UserDefaults`.
 - If fingerprint changed, or no previous fingerprint exists (upgrade from older app versions), app runs automatic full helper repair in background.
-- Successful automatic repair updates stored fingerprint and remains visible only in logs.
+- Successful automatic repair updates stored fingerprint, remains visible in logs, and shows a short in-app toast at the bottom of the main window.
 - Failed automatic repair presents one warning `NSAlert` with guidance to run `Tools → Repair helper` manually.
 
 ### Hard-Repair Flow

--- a/docs/reference/features/helper/HELPER.md
+++ b/docs/reference/features/helper/HELPER.md
@@ -79,6 +79,10 @@ High-level model:
 Core invariant:
 - No terminal fallback privileged path.
 - Privileged operations must run through `SMAppService` plus launchd helper and XPC.
+- The XPC channel is mutually code-signing-gated:
+  - the daemon listener accepts only the signed macUSB app for the active build configuration,
+  - the app-side connection trusts only the signed macUSB helper for the active build configuration.
+  - Code-signing requirement failures must stop privileged work before helper service methods run.
 
 ---
 
@@ -122,7 +126,7 @@ Contract invariants:
 - Entry point: `HelperServiceManager` ensure-ready path.
 - Checks app location and helper service status.
 - Handles status states (`enabled`, `requiresApproval`, `notRegistered`, `notFound`).
-- Performs health validation via XPC.
+- Performs health validation via XPC after configuring app-side helper code-signing requirements.
 - Uses controlled recovery when enabled service is unhealthy.
 
 ### Startup Auto-Repair Flow (version/build change)
@@ -135,6 +139,7 @@ Contract invariants:
 ### Hard-Repair Flow
 - Triggered from Tools menu repair action.
 - Full reset sequence: unregister, stabilization delay, teardown validation, register, health-check.
+- `register`/`unregister` remain `SMAppService` lifecycle operations; trust verification is confirmed by the XPC health-check after registration.
 - Includes bounded retry/backoff for transient registration/health race conditions.
 - Produces detailed progress logs for diagnostics.
 - UI surface uses `NSAlert`:
@@ -172,8 +177,10 @@ App-side helper integration:
 
 - `macUSB/Shared/Services/Helper/HelperIPC.swift`
   - app-side IPC contracts and compatibility decode logic.
+- `macUSB/Shared/Services/Helper/HelperConnectionSecurityPolicy.swift`
+  - app-side helper code-signing requirement, trust-failure diagnostics, and user-facing trust-failure text.
 - `macUSB/Shared/Services/Helper/PrivilegedOperationClient.swift`
-  - XPC connection handling and app-facing helper calls.
+  - XPC connection handling, app-side helper trust requirement setup, and app-facing helper calls.
 - `macUSB/Shared/Services/Helper/HelperServiceManager.swift`
   - central state/facade for helper lifecycle.
 - `macUSB/Shared/Services/Helper/HelperService/HelperServiceBootstrap.swift`
@@ -194,7 +201,9 @@ App-side helper integration:
 Daemon helper runtime:
 
 - `macUSBHelper/main.swift`
-  - listener bootstrap entry only.
+  - listener bootstrap entry only, including listener-side trust requirement configuration before `resume()`.
+- `macUSBHelper/Security/HelperConnectionSecurityPolicy.swift`
+  - daemon-side trusted-client code-signing requirement and XPC trust logging.
 - `macUSBHelper/IPC/HelperIPC.swift`
   - daemon-side IPC contracts and payload types.
 - `macUSBHelper/Service/PrivilegedHelperService.swift`
@@ -254,6 +263,7 @@ Diagnostics should allow answering:
 - Which phase failed.
 - What status the helper had at that moment.
 - Whether XPC health passed or failed.
+- Whether app-helper code-signing trust validation was configured and whether XPC rejected the connection for a requirement mismatch.
 - Whether recovery was attempted and with what outcome.
 - Whether startup auto-repair was triggered by app fingerprint change or by missing previous fingerprint.
 
@@ -265,6 +275,7 @@ Diagnostics should allow answering:
 - Runtime helper invariants are identical across build configurations.
 - Any debug convenience path must not alter production helper semantics.
 - DEBUG and Release must use isolated helper identity tuples (`bundle id`, daemon plist name, daemon label, mach service) to avoid BTM/TCC cross-environment collisions.
+- DEBUG and Release also use isolated XPC code-signing requirements matching those identity tuples.
 
 ---
 

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A10000012F00000100000055 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000056 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendConfiguration.swift */; };
 		A10000012F00000100000057 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000058 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift */; };
 		A10000012F00000100000059 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000005A /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendValidation.swift */; };
+		A10000012F0000010000005C /* Security/HelperConnectionSecurityPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000005B /* Security/HelperConnectionSecurityPolicy.swift */; };
 		B10000012F00000100000001 /* macUSB/Resources/Sounds/burn_complete.aif in Resources */ = {isa = PBXBuildFile; fileRef = B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */; };
 		C10000012F00000100000001 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */; };
 		D10000012F00000100000001 /* macUSB/Resources/Icons/Linux/Distros in Resources */ = {isa = PBXBuildFile; fileRef = D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */; };
@@ -130,6 +131,7 @@
 		A10000012F00000100000056 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendConfiguration.swift; sourceTree = "<group>"; };
 		A10000012F00000100000058 /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift; sourceTree = "<group>"; };
 		A10000012F0000010000005A /* Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendValidation.swift; sourceTree = "<group>"; };
+		A10000012F0000010000005B /* Security/HelperConnectionSecurityPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Security/HelperConnectionSecurityPolicy.swift; sourceTree = "<group>"; };
 		B10000012F00000100000002 /* macUSB/Resources/Sounds/burn_complete.aif */ = {isa = PBXFileReference; lastKnownFileType = audio.aiff; path = macUSB/Resources/Sounds/burn_complete.aif; sourceTree = "<group>"; };
 		C10000012F00000100000002 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift; sourceTree = "<group>"; };
 		D10000012F00000100000002 /* macUSB/Resources/Icons/Linux/Distros */ = {isa = PBXFileReference; lastKnownFileType = folder; path = macUSB/Resources/Icons/Linux/Distros; sourceTree = "<group>"; };
@@ -254,6 +256,7 @@
 				Shared/Localization/HelperWorkflowLocalizationKeys.swift,
 				Shared/Models/Models.swift,
 				Shared/Services/FullDiskAccessPermissionManager.swift,
+				Shared/Services/Helper/HelperConnectionSecurityPolicy.swift,
 				Shared/Services/Helper/HelperIPC.swift,
 				Shared/Services/Helper/HelperService/HelperServiceBootstrap.swift,
 				Shared/Services/Helper/HelperService/HelperServiceDiagnostics.swift,
@@ -345,6 +348,7 @@
 				Shared/Localization/HelperWorkflowLocalizationKeys.swift,
 				Shared/Models/Models.swift,
 				Shared/Services/FullDiskAccessPermissionManager.swift,
+				Shared/Services/Helper/HelperConnectionSecurityPolicy.swift,
 				Shared/Services/Helper/HelperIPC.swift,
 				Shared/Services/Helper/HelperService/HelperServiceBootstrap.swift,
 				Shared/Services/Helper/HelperService/HelperServiceDiagnostics.swift,
@@ -469,6 +473,7 @@
 			isa = PBXGroup;
 			children = (
 				A10000012F00000100000006 /* main.swift */,
+				A10000012F0000010000005B /* Security/HelperConnectionSecurityPolicy.swift */,
 				A10000012F00000100000021 /* IPC/HelperIPC.swift */,
 				A10000012F00000100000022 /* Service/PrivilegedHelperService.swift */,
 				A10000012F00000100000023 /* Service/HelperListenerDelegate.swift */,
@@ -712,6 +717,7 @@
 			files = (
 				C10000012F00000100000001 /* ../macUSB/Shared/Localization/HelperWorkflowLocalizationKeys.swift in Sources */,
 				A10000012F00000100000001 /* main.swift in Sources */,
+				A10000012F0000010000005C /* Security/HelperConnectionSecurityPolicy.swift in Sources */,
 				A10000012F00000100000031 /* IPC/HelperIPC.swift in Sources */,
 				A10000012F00000100000032 /* Service/PrivilegedHelperService.swift in Sources */,
 				A10000012F00000100000033 /* Service/HelperListenerDelegate.swift in Sources */,
@@ -906,7 +912,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;
@@ -929,7 +935,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.3;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macUSB.debug;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -962,7 +968,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;
@@ -985,7 +991,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 2.3;
+				MARKETING_VERSION = 2.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kruszoneq.macUSB;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 				Shared/Services/UpdateChecker.swift,
 				Shared/Services/USBDriveLogic.swift,
 				Shared/Services/Windows/WindowsToolchainProbeService.swift,
+				Shared/UI/AppToastCenter.swift,
 				Shared/UI/BottomActionBar.swift,
 				Shared/UI/DesignTokens.swift,
 				Shared/UI/LiquidGlassCompatibility.swift,
@@ -367,6 +368,7 @@
 				Shared/Services/SystemSleepBlocker.swift,
 				Shared/Services/UpdateChecker.swift,
 				Shared/Services/Windows/WindowsToolchainProbeService.swift,
+				Shared/UI/AppToastCenter.swift,
 				Shared/UI/BottomActionBar.swift,
 				Shared/UI/DesignTokens.swift,
 				Shared/UI/LiquidGlassCompatibility.swift,
@@ -912,7 +914,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 31;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;
@@ -968,7 +970,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 31;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 27NC66L8P2;
 				ENABLE_APP_SANDBOX = NO;

--- a/macUSB/App/ContentView.swift
+++ b/macUSB/App/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var path = NavigationPath()
     @EnvironmentObject private var languageManager: LanguageManager
     @State private var pendingDebugNavigationWorkItem: DispatchWorkItem?
+    @ObservedObject private var appToastCenter = AppToastCenter.shared
 
     private var debugMountPointURL: URL {
         FileManager.default.temporaryDirectory.appendingPathComponent("macUSB_debug_mount_point")
@@ -102,6 +103,9 @@ struct ContentView: View {
         }
         // Sztywny rozmiar kontentu
         .frame(width: MacUSBDesignTokens.windowWidth, height: MacUSBDesignTokens.windowHeight)
+        .overlay {
+            AppToastOverlay(toast: appToastCenter.toast)
+        }
         // Podpięcie konfiguratora okna
         .background(WindowConfigurator())
         // Wstrzyknięcie języka

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -42684,6 +42684,334 @@
         }
       }
     },
+    "app.toast.helper_auto_update.completed.message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Hilfsprogramm wurde aktualisiert und ist einsatzbereit."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The helper tool has been updated and is ready to use."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La herramienta auxiliar se ha actualizado y está lista para usarse."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "L’outil d’assistance a été mis à jour et est prêt à être utilisé."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lo strumento helper è stato aggiornato ed è pronto all’uso."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーツールはアップデートされ、使用できる状態です。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Narzędzie pomocnicze zostało zaktualizowane i jest gotowe do pracy."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A ferramenta auxiliar foi atualizada e está pronta para uso."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вспомогательный инструмент обновлен и готов к работе."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı araç güncellendi ve kullanıma hazır."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Допоміжний інструмент оновлено й він готовий до роботи."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Công cụ trợ giúp đã được cập nhật và sẵn sàng sử dụng."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "辅助工具已更新并可供使用。"
+          }
+        }
+      }
+    },
+    "app.toast.helper_auto_update.completed.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erfolgreich"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Success"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correcto"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opération réussie"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Operazione riuscita"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sukces"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sucesso"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успешно"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Başarılı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успішно"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thành công"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成功"
+          }
+        }
+      }
+    },
+    "app.toast.helper_auto_update.running.message": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Hilfsprogramm wird aktualisiert…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Updating the helper tool…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizando la herramienta auxiliar…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour de l’outil d’assistance en cours…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento dello strumento helper in corso…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルパーツールをアップデート中…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trwa aktualizacja narzędzia pomocniczego…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizando a ferramenta auxiliar…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выполняется обновление вспомогательного инструмента…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yardımcı araç güncelleniyor…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Триває оновлення допоміжного інструмента…"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Đang cập nhật công cụ trợ giúp…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新辅助工具…"
+          }
+        }
+      }
+    },
+    "app.toast.helper_auto_update.running.title": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisierung"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualización"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mise à jour"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiornamento"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アップデート"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualizacja"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualização"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновление"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Güncelleme"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновлення"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cập nhật"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        }
+      }
+    },
     "checksum.analysis.trigger": {
       "localizations": {
         "de": {

--- a/macUSB/Resources/Localizable.xcstrings
+++ b/macUSB/Resources/Localizable.xcstrings
@@ -7918,6 +7918,88 @@
         }
       }
     },
+    "Nie można zweryfikować helpera macUSB": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB kann den Helper nicht verifizieren"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB Can’t Verify the Helper"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB no puede verificar el helper"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB ne peut pas vérifier l’assistant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB non può verificare l’helper"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB はヘルパーを検証できません"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie można zweryfikować helpera macUSB"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O macUSB não consegue verificar o auxiliar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB не может проверить вспомогательную программу"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB yardımcıyı doğrulayamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB не може перевірити допоміжний інструмент"
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB không thể xác minh trình trợ giúp"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 无法验证辅助工具"
+          }
+        }
+      }
+    },
     "finish.eject.success.description": {
       "extractionState": "stale",
       "localizations": {
@@ -17110,6 +17192,88 @@
           "stringUnit": {
             "state": "translated",
             "value": "macUSB by Kruszoneq"
+          }
+        }
+      }
+    },
+    "macUSB nie może potwierdzić, że komunikuje się z zaufanym, podpisanym helperem. Operacja została przerwana. Uruchom aktualną aplikację macUSB z katalogu Applications, a następnie wybierz Narzędzia → Napraw helpera.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB kann nicht bestätigen, dass es mit einem vertrauenswürdigen, signierten Helper kommuniziert. Der Vorgang wurde gestoppt. Öffne die aktuelle macUSB App aus dem Ordner „Programme“ und wähle anschließend Werkzeuge → Helper reparieren."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB can’t confirm that it is communicating with a trusted, signed helper. The operation was stopped. Open the current macUSB app from the Applications folder, then choose Tools → Repair Helper."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB no puede confirmar que se esté comunicando con un helper firmado y de confianza. La operación se detuvo. Abre la app macUSB actual desde la carpeta Aplicaciones y luego elige Herramientas → Reparar helper."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB ne peut pas confirmer qu’il communique avec un assistant signé et de confiance. L’opération a été arrêtée. Ouvrez l’app macUSB actuelle depuis le dossier Applications, puis choisissez Outils → Réparer l’assistant."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB non può confermare che stia comunicando con un helper firmato e attendibile. L’operazione è stata interrotta. Apri l’app macUSB corrente dalla cartella Applicazioni, quindi scegli Strumenti → Ripara helper."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB は、信頼された署名済みヘルパーと通信していることを確認できません。操作は停止されました。現在の macUSB アプリを「アプリケーション」フォルダから開き、ツール → ヘルパーを修復 を選択してください。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB nie może potwierdzić, że komunikuje się z zaufanym, podpisanym helperem. Operacja została przerwana. Uruchom aktualną aplikację macUSB z katalogu Applications, a następnie wybierz Narzędzia → Napraw helpera."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O macUSB não consegue confirmar que está se comunicando com um auxiliar assinado e confiável. A operação foi interrompida. Abra o app macUSB atual pela pasta Aplicativos e escolha Ferramentas → Reparar helper."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB не может подтвердить, что обменивается данными с доверенной подписанной вспомогательной программой. Операция остановлена. Откройте актуальное приложение macUSB из папки «Программы», затем выберите Инструменты → Восстановить helper."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB, güvenilir ve imzalı bir yardımcıyla iletişim kurduğunu doğrulayamıyor. İşlem durduruldu. Güncel macUSB uygulamasını Uygulamalar klasöründen açın, ardından Araçlar → Yardımcıyı düzelt’i seçin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB не може підтвердити, що обмінюється даними з довіреним підписаним допоміжним інструментом. Операцію зупинено. Відкрийте актуальну програму macUSB з папки «Програми», а потім виберіть Інструменти → Виправити помічника."
+          }
+        },
+        "vi": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB không thể xác nhận rằng ứng dụng đang giao tiếp với một trình trợ giúp tin cậy, đã được ký. Thao tác đã dừng. Mở ứng dụng macUSB hiện tại từ thư mục Ứng dụng, rồi chọn Công cụ → Sửa chữa trình trợ giúp."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macUSB 无法确认它正在与受信任且已签名的辅助工具通信。操作已停止。请从“应用程序”文件夹打开当前的 macUSB App，然后选择工具 → 修复辅助工具。"
           }
         }
       }

--- a/macUSB/Shared/Services/Helper/HelperConnectionSecurityPolicy.swift
+++ b/macUSB/Shared/Services/Helper/HelperConnectionSecurityPolicy.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum HelperConnectionSecurityPolicy {
+    static let trustVerificationFailureMarker = "macusb_helper_trust_verification_failed"
+    private static let teamIdentifier = "27NC66L8P2"
+
+    #if DEBUG
+    static let expectedHelperBundleIdentifier = "com.kruszoneq.macusb.helper.debug"
+    #else
+    static let expectedHelperBundleIdentifier = "com.kruszoneq.macusb.helper"
+    #endif
+
+    static let trustedHelperRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamIdentifier)\" and identifier \"\(expectedHelperBundleIdentifier)\""
+
+    static var localizedFailureTitle: String {
+        String(localized: "Nie można zweryfikować helpera macUSB")
+    }
+
+    static var localizedFailureMessage: String {
+        String(localized: "macUSB nie może potwierdzić, że komunikuje się z zaufanym, podpisanym helperem. Operacja została przerwana. Uruchom aktualną aplikację macUSB z katalogu Applications, a następnie wybierz Narzędzia → Napraw helpera.")
+    }
+
+    static func configure(_ connection: NSXPCConnection, machServiceName: String) {
+        AppLogging.info(
+            "Rozpoczynam konfigurację weryfikacji podpisu helpera XPC: machService=\(machServiceName), expectedHelperBundleID=\(expectedHelperBundleIdentifier).",
+            category: "HelperService"
+        )
+
+        connection.setCodeSigningRequirement(trustedHelperRequirement)
+
+        AppLogging.info(
+            "Weryfikacja podpisu helpera XPC skonfigurowana: machService=\(machServiceName), status=OK.",
+            category: "HelperService"
+        )
+    }
+
+    static func isCodeSigningRequirementFailure(_ error: Error) -> Bool {
+        var currentError: NSError? = error as NSError
+        while let nsError = currentError {
+            if nsError.domain == NSCocoaErrorDomain,
+               nsError.code == NSXPCConnectionCodeSigningRequirementFailure {
+                return true
+            }
+            currentError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return false
+    }
+
+    static func isTrustVerificationFailureMessage(_ message: String) -> Bool {
+        message.contains(trustVerificationFailureMarker)
+    }
+
+    static func diagnosticSummary(for error: Error) -> String {
+        let nsError = error as NSError
+        var details = [
+            "domain=\(nsError.domain)",
+            "code=\(nsError.code)"
+        ]
+
+        if let debugDescription = nsError.userInfo["NSDebugDescription"] as? String,
+           !debugDescription.isEmpty {
+            details.append("debug=\(debugDescription)")
+        }
+
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+            details.append("underlying=\(underlyingError.domain):\(underlyingError.code)")
+        }
+
+        return details.joined(separator: ", ")
+    }
+
+    static func diagnosticFailureDescription(for error: Error) -> String {
+        "\(localizedFailureMessage) [\(trustVerificationFailureMarker), \(diagnosticSummary(for: error))]"
+    }
+}

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceBootstrap.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceBootstrap.swift
@@ -57,6 +57,9 @@ extension HelperServiceManager {
             reportHelperServiceEvent(
                 "Auto-aktualizacja helpera: wykryto zmianę wersji/builda aplikacji lub brak poprzedniego fingerprintu (stary=\(previousDescription), nowy=\(currentFingerprint))."
             )
+            Task { @MainActor in
+                AppToastCenter.shared.showHelperAutoUpdateRunning()
+            }
 
             performFullRepairFromMenu { ready, message in
                 if ready {
@@ -64,6 +67,9 @@ extension HelperServiceManager {
                     self.reportHelperServiceEvent(
                         "Auto-aktualizacja helpera zakończona sukcesem dla fingerprintu \(currentFingerprint)."
                     )
+                    Task { @MainActor in
+                        AppToastCenter.shared.showHelperAutoUpdateCompleted(visibleFor: 5)
+                    }
                     completion(true)
                     return
                 }
@@ -73,6 +79,7 @@ extension HelperServiceManager {
                     "Auto-aktualizacja helpera zakończona błędem: \(details)."
                 )
                 DispatchQueue.main.async {
+                    AppToastCenter.shared.dismiss()
                     self.presentAutomaticHelperUpdateFailureAlert()
                 }
                 completion(false)

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceDiagnostics.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceDiagnostics.swift
@@ -96,6 +96,32 @@ extension HelperServiceManager {
         alert.addButton(withTitle: String(localized: "Rozumiem"))
         presentAlert(alert)
     }
+    func presentHelperTrustVerificationFailureAlert() {
+        DispatchQueue.main.async {
+            guard self.helperTrustVerificationAlertWindow == nil else { return }
+
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = HelperConnectionSecurityPolicy.localizedFailureTitle
+            alert.informativeText = HelperConnectionSecurityPolicy.localizedFailureMessage
+            alert.addButton(withTitle: String(localized: "OK"))
+
+            let clearWindow: (NSApplication.ModalResponse) -> Void = { _ in
+                self.helperTrustVerificationAlertWindow = nil
+            }
+
+            if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+                self.helperTrustVerificationAlertWindow = alert.window
+                alert.beginSheetModal(for: window, completionHandler: clearWindow)
+            } else {
+                self.helperTrustVerificationAlertWindow = alert.window
+                clearWindow(alert.runModal())
+            }
+        }
+    }
+    func isHelperTrustVerificationFailureMessage(_ message: String) -> Bool {
+        HelperConnectionSecurityPolicy.isTrustVerificationFailureMessage(message)
+    }
     func isOperationNotPermitted(_ error: Error) -> Bool {
         let nsError = error as NSError
         if nsError.code == Int(EPERM) || nsError.code == 1 {

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceEnsureReadyFlow.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceEnsureReadyFlow.swift
@@ -150,7 +150,10 @@ extension HelperServiceManager {
                     "Rejestracja helpera z uruchomienia Xcode została zablokowana przez system (Operation not permitted).",
                     category: "Installation"
                 )
-                PrivilegedOperationClient.shared.queryHealth(withTimeout: 1.2) { ok, details in
+                PrivilegedOperationClient.shared.queryHealth(
+                    withTimeout: 1.2,
+                    presentsTrustFailureAlert: interactive
+                ) { ok, details in
                     if ok {
                         self.reportHelperServiceEvent("Health XPC po błędzie register() jest poprawny.")
                         completion(true, nil)
@@ -213,7 +216,10 @@ extension HelperServiceManager {
         completion: @escaping (Bool, String?) -> Void
     ) {
         reportHelperServiceEvent("Rozpoczynam weryfikację health XPC helpera.")
-        PrivilegedOperationClient.shared.queryHealth { ok, details in
+        PrivilegedOperationClient.shared.queryHealth(
+            withTimeout: 5,
+            presentsTrustFailureAlert: interactive
+        ) { ok, details in
             if ok {
                 self.reportHelperServiceEvent("Health XPC: OK (\(details)).")
                 completion(true, nil)
@@ -234,7 +240,10 @@ extension HelperServiceManager {
             self.reportHelperServiceEvent("Zresetowano połączenie XPC. Ponawiam health-check.")
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-                PrivilegedOperationClient.shared.queryHealth { retryOK, retryDetails in
+                PrivilegedOperationClient.shared.queryHealth(
+                    withTimeout: 5,
+                    presentsTrustFailureAlert: interactive
+                ) { retryOK, retryDetails in
                     if retryOK {
                         self.reportHelperServiceEvent("Health XPC po resecie: OK (\(retryDetails)).")
                         completion(true, nil)
@@ -273,7 +282,10 @@ extension HelperServiceManager {
                             return
                         }
 
-                        PrivilegedOperationClient.shared.queryHealth { recovered, recoveredDetails in
+                        PrivilegedOperationClient.shared.queryHealth(
+                            withTimeout: 5,
+                            presentsTrustFailureAlert: interactive
+                        ) { recovered, recoveredDetails in
                             if recovered {
                                 self.reportHelperServiceEvent("Health XPC po odzyskiwaniu: OK (\(recoveredDetails)).")
                                 completion(true, nil)
@@ -339,7 +351,10 @@ extension HelperServiceManager {
         }
 
         if isRunningFromXcodeSession() && isOperationNotPermitted(error) {
-            PrivilegedOperationClient.shared.queryHealth(withTimeout: 1.2) { ok, details in
+            PrivilegedOperationClient.shared.queryHealth(
+                withTimeout: 1.2,
+                presentsTrustFailureAlert: interactive
+            ) { ok, details in
                 if ok {
                     self.reportHelperServiceEvent("W sesji Xcode recovery zablokowany, ale helper odpowiada przez XPC.")
                     completion(true, nil)

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceRepairFlow.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceRepairFlow.swift
@@ -285,7 +285,10 @@ extension HelperServiceManager {
         maxAttempts: Int,
         completion: @escaping EnsureCompletion
     ) {
-        PrivilegedOperationClient.shared.queryHealth(withTimeout: 2.4) { ok, details in
+        PrivilegedOperationClient.shared.queryHealth(
+            withTimeout: 2.4,
+            presentsTrustFailureAlert: true
+        ) { ok, details in
             self.coordinationQueue.async {
                 let finalStatus = service.status
                 if ok, finalStatus == .enabled {

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceRepairUI.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceRepairUI.swift
@@ -53,6 +53,11 @@ extension HelperServiceManager {
     func finishRepairPresentation(success: Bool, message: String) {
         appendRepairTechnicalLogLine(message)
         dismissRepairProgressAlertIfNeeded()
+        if !success, isHelperTrustVerificationFailureMessage(message) {
+            presentHelperTrustVerificationFailureAlert()
+            setRepairProgressSink(nil)
+            return
+        }
         presentRepairSummaryAlert(success: success, message: message)
         setRepairProgressSink(nil)
     }

--- a/macUSB/Shared/Services/Helper/HelperService/HelperServiceStatusUI.swift
+++ b/macUSB/Shared/Services/Helper/HelperService/HelperServiceStatusUI.swift
@@ -21,6 +21,8 @@ extension HelperServiceManager {
 
                     if snapshot.isHealthy {
                         self.presentHealthyStatusAlert(detailsText: snapshot.detailedText)
+                    } else if self.isHelperTrustVerificationFailureMessage(snapshot.detailedText) {
+                        self.presentHelperTrustVerificationFailureAlert()
                     } else if snapshot.serviceStatus == .requiresApproval {
                         self.presentApprovalRequiredStatusAlert(detailsText: snapshot.detailedText)
                     } else {
@@ -79,7 +81,10 @@ extension HelperServiceManager {
             #endif
         }
 
-        PrivilegedOperationClient.shared.queryHealth(withTimeout: statusHealthTimeout) { ok, details in
+        PrivilegedOperationClient.shared.queryHealth(
+            withTimeout: statusHealthTimeout,
+            presentsTrustFailureAlert: true
+        ) { ok, details in
             let xpcHealthValue = ok ? String(localized: "OK") : String(localized: "BŁĄD")
             let lines: [String] = [
                 serviceStatusLine,

--- a/macUSB/Shared/Services/Helper/HelperServiceManager.swift
+++ b/macUSB/Shared/Services/Helper/HelperServiceManager.swift
@@ -31,6 +31,7 @@ final class HelperServiceManager: NSObject {
     weak var statusCheckAlertParentWindow: NSWindow?
     var statusCheckAlertWindow: NSWindow?
     var didPresentStartupApprovalPrompt = false
+    var helperTrustVerificationAlertWindow: NSWindow?
     let repairLogFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm:ss"

--- a/macUSB/Shared/Services/Helper/PrivilegedOperationClient.swift
+++ b/macUSB/Shared/Services/Helper/PrivilegedOperationClient.swift
@@ -55,7 +55,7 @@ final class PrivilegedOperationClient: NSObject {
             }
         }
 
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: true, onError: { message in
             failStart(message)
         }) else {
             failStart(String(localized: "Nie udało się uzyskać połączenia XPC z helperem."))
@@ -115,7 +115,7 @@ final class PrivilegedOperationClient: NSObject {
     }
 
     func cancelWorkflow(_ workflowID: String, completion: @escaping (Bool, String?) -> Void) {
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: true, onError: { message in
             DispatchQueue.main.async {
                 completion(false, message)
             }
@@ -165,7 +165,7 @@ final class PrivilegedOperationClient: NSObject {
             }
         }
 
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: true, onError: { message in
             failStart(message)
         }) else {
             failStart(String(localized: "Nie udało się uzyskać połączenia XPC z helperem."))
@@ -222,7 +222,7 @@ final class PrivilegedOperationClient: NSObject {
     }
 
     func cancelDownloaderAssembly(_ workflowID: String, completion: @escaping (Bool, String?) -> Void = { _, _ in }) {
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: true, onError: { message in
             DispatchQueue.main.async {
                 completion(false, message)
             }
@@ -251,7 +251,7 @@ final class PrivilegedOperationClient: NSObject {
             }
         }
 
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: true, onError: { message in
             fail(message)
         }) else {
             fail(String(localized: "Nie udało się uzyskać połączenia XPC z helperem."))
@@ -296,6 +296,14 @@ final class PrivilegedOperationClient: NSObject {
     }
 
     func queryHealth(withTimeout timeout: TimeInterval, completion: @escaping (Bool, String) -> Void) {
+        queryHealth(withTimeout: timeout, presentsTrustFailureAlert: false, completion: completion)
+    }
+
+    func queryHealth(
+        withTimeout timeout: TimeInterval,
+        presentsTrustFailureAlert: Bool,
+        completion: @escaping (Bool, String) -> Void
+    ) {
         let stateLock = NSLock()
         var didFinish = false
         let finishOnce: (_ ok: Bool, _ details: String) -> Void = { ok, details in
@@ -318,7 +326,7 @@ final class PrivilegedOperationClient: NSObject {
             }
         }
 
-        guard let proxy = helperProxy(onError: { message in
+        guard let proxy = helperProxy(presentsTrustFailureAlert: presentsTrustFailureAlert, onError: { message in
             failHealth(message)
         }) else {
             failHealth(String(localized: "Nie udało się utworzyć proxy XPC helpera."))
@@ -370,10 +378,23 @@ final class PrivilegedOperationClient: NSObject {
         existingConnection?.invalidate()
     }
 
-    private func helperProxy(onError: @escaping (String) -> Void) -> PrivilegedHelperToolXPCProtocol? {
+    private func helperProxy(
+        presentsTrustFailureAlert: Bool = false,
+        onError: @escaping (String) -> Void
+    ) -> PrivilegedHelperToolXPCProtocol? {
         let connection = ensureConnection()
         let proxy = connection.remoteObjectProxyWithErrorHandler { error in
             DispatchQueue.main.async {
+                if HelperConnectionSecurityPolicy.isCodeSigningRequirementFailure(error) {
+                    AppLogging.error(
+                        "Weryfikacja podpisu helpera XPC nie powiodła się: \(HelperConnectionSecurityPolicy.diagnosticSummary(for: error)).",
+                        category: "HelperService"
+                    )
+                    if presentsTrustFailureAlert {
+                        HelperServiceManager.shared.presentHelperTrustVerificationFailureAlert()
+                    }
+                }
+
                 let message = String(
                     format: String(localized: "Błąd połączenia z helperem: %@"),
                     self.diagnosticErrorDescription(for: error)
@@ -401,6 +422,10 @@ final class PrivilegedOperationClient: NSObject {
         let newConnection = NSXPCConnection(
             machServiceName: HelperServiceManager.machServiceName,
             options: .privileged
+        )
+        HelperConnectionSecurityPolicy.configure(
+            newConnection,
+            machServiceName: HelperServiceManager.machServiceName
         )
         newConnection.remoteObjectInterface = NSXPCInterface(with: PrivilegedHelperToolXPCProtocol.self)
         newConnection.exportedInterface = NSXPCInterface(with: PrivilegedHelperClientXPCProtocol.self)
@@ -466,6 +491,10 @@ final class PrivilegedOperationClient: NSObject {
     }
 
     private func diagnosticErrorDescription(for error: Error) -> String {
+        if HelperConnectionSecurityPolicy.isCodeSigningRequirementFailure(error) {
+            return HelperConnectionSecurityPolicy.diagnosticFailureDescription(for: error)
+        }
+
         let nsError = error as NSError
         var details: [String] = ["domain=\(nsError.domain)", "code=\(nsError.code)"]
 

--- a/macUSB/Shared/UI/AppToastCenter.swift
+++ b/macUSB/Shared/UI/AppToastCenter.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import Combine
+
+@MainActor
+final class AppToastCenter: ObservableObject {
+    static let shared = AppToastCenter()
+
+    @Published private(set) var toast: AppToast?
+
+    private var dismissWorkItem: DispatchWorkItem?
+
+    private init() {}
+
+    func showHelperAutoUpdateRunning() {
+        dismissWorkItem?.cancel()
+        withAnimation(.easeInOut(duration: 0.28)) {
+            toast = AppToast(
+                state: .running,
+                titleKey: "app.toast.helper_auto_update.running.title",
+                messageKey: "app.toast.helper_auto_update.running.message"
+            )
+        }
+    }
+
+    func showHelperAutoUpdateCompleted(visibleFor duration: TimeInterval = 5) {
+        dismissWorkItem?.cancel()
+        withAnimation(.easeInOut(duration: 0.28)) {
+            toast = AppToast(
+                state: .completed,
+                titleKey: "app.toast.helper_auto_update.completed.title",
+                messageKey: "app.toast.helper_auto_update.completed.message"
+            )
+        }
+        scheduleDismiss(after: duration)
+    }
+
+    func dismiss() {
+        dismissWorkItem?.cancel()
+        dismissWorkItem = nil
+        withAnimation(.easeInOut(duration: 0.26)) {
+            toast = nil
+        }
+    }
+
+    private func scheduleDismiss(after duration: TimeInterval) {
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor in
+                self?.dismiss()
+            }
+        }
+        dismissWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration, execute: workItem)
+    }
+}
+
+struct AppToast: Equatable {
+    enum State: Equatable {
+        case running
+        case completed
+    }
+
+    let state: State
+    let titleKey: String
+    let messageKey: String
+}
+
+struct AppToastOverlay: View {
+    let toast: AppToast?
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            if let toast {
+                AppToastView(toast: toast)
+                    .padding(.horizontal, MacUSBDesignTokens.contentHorizontalPadding)
+                    .padding(.bottom, MacUSBDesignTokens.dockedBarMinHeight + 12)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .allowsHitTesting(false)
+        .animation(.easeInOut(duration: 0.28), value: toast)
+    }
+}
+
+private struct AppToastView: View {
+    let toast: AppToast
+
+    var body: some View {
+        HStack(spacing: 12) {
+            statusIcon
+                .frame(width: 22, height: 22)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(LocalizedStringKey(toast.titleKey))
+                    .font(.headline)
+                    .lineLimit(1)
+
+                Text(LocalizedStringKey(toast.messageKey))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: 470, alignment: .leading)
+        .appToastSurface()
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch toast.state {
+        case .running:
+            ProgressView()
+                .controlSize(.small)
+        case .completed:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+private struct AppToastSurfaceModifier: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        let radius = MacUSBDesignTokens.panelCornerRadius(for: currentVisualMode())
+        let shape = RoundedRectangle(cornerRadius: radius, style: .continuous)
+
+        if #available(macOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(false), in: shape)
+        } else {
+            content
+                .background(
+                    shape.fill(
+                        colorScheme == .dark
+                            ? Color.white.opacity(0.075)
+                            : Color.black.opacity(0.040)
+                    )
+                )
+                .overlay(
+                    shape.stroke(
+                        colorScheme == .dark
+                            ? Color.white.opacity(0.12)
+                            : Color.black.opacity(0.10),
+                        lineWidth: 0.5
+                    )
+                )
+                .shadow(color: Color.black.opacity(colorScheme == .dark ? 0.22 : 0.12), radius: 18, y: 8)
+        }
+    }
+}
+
+private extension View {
+    func appToastSurface() -> some View {
+        modifier(AppToastSurfaceModifier())
+    }
+}

--- a/macUSBHelper/Security/HelperConnectionSecurityPolicy.swift
+++ b/macUSBHelper/Security/HelperConnectionSecurityPolicy.swift
@@ -1,0 +1,47 @@
+import Foundation
+import os.log
+
+enum HelperConnectionSecurityPolicy {
+    private static let teamIdentifier = "27NC66L8P2"
+
+    #if DEBUG
+    static let expectedClientBundleIdentifier = "com.kruszoneq.macUSB.debug"
+    #else
+    static let expectedClientBundleIdentifier = "com.kruszoneq.macUSB"
+    #endif
+
+    static let trustedClientRequirement =
+        "anchor apple generic and certificate leaf[subject.OU] = \"\(teamIdentifier)\" and identifier \"\(expectedClientBundleIdentifier)\""
+
+    private static let trustLog = OSLog(subsystem: "com.kruszoneq.macusb.helper", category: "XPCTrust")
+
+    static func configure(_ listener: NSXPCListener, machServiceName: String) {
+        os_log(
+            "Configuring XPC client trust requirement: machService=%{public}@ expectedClientBundleID=%{public}@",
+            log: trustLog,
+            type: .default,
+            machServiceName,
+            expectedClientBundleIdentifier
+        )
+
+        listener.setConnectionCodeSigningRequirement(trustedClientRequirement)
+
+        os_log(
+            "XPC client trust requirement configured: machService=%{public}@ status=OK",
+            log: trustLog,
+            type: .default,
+            machServiceName
+        )
+    }
+
+    static func logAcceptedConnection(_ connection: NSXPCConnection) {
+        os_log(
+            "Accepted XPC connection prevalidated by code signing requirement: pid=%{public}d euid=%{public}d expectedClientBundleID=%{public}@",
+            log: trustLog,
+            type: .default,
+            connection.processIdentifier,
+            connection.effectiveUserIdentifier,
+            expectedClientBundleIdentifier
+        )
+    }
+}

--- a/macUSBHelper/Service/HelperListenerDelegate.swift
+++ b/macUSBHelper/Service/HelperListenerDelegate.swift
@@ -2,6 +2,8 @@ import Foundation
 
 final class HelperListenerDelegate: NSObject, NSXPCListenerDelegate {
     func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        HelperConnectionSecurityPolicy.logAcceptedConnection(newConnection)
+
         let service = PrivilegedHelperService()
         service.connection = newConnection
 

--- a/macUSBHelper/main.swift
+++ b/macUSBHelper/main.swift
@@ -7,6 +7,7 @@ private let machServiceName = "com.kruszoneq.macusb.helper.debug"
 private let machServiceName = "com.kruszoneq.macusb.helper"
 #endif
 private let listener = NSXPCListener(machServiceName: machServiceName)
+HelperConnectionSecurityPolicy.configure(listener, machServiceName: machServiceName)
 listener.delegate = delegate
 listener.resume()
 dispatchMain()


### PR DESCRIPTION
This change hardens the macUSB privileged helper connection by enforcing mutual code-signing requirements on the app-helper XPC channel, ensuring privileged helper work only proceeds after both sides trust the expected signed counterpart. It also improves the startup helper auto-update flow by showing a neutral in-app toast while repair is running, transitioning to a completion toast when the helper is ready, and preserving the existing failure alert behavior.

- Adds app-side and daemon-side XPC trust policies for the signed helper/client identity.
- Surfaces helper trust failures with localized user-facing guidance and diagnostic details.
- Shows localized helper auto-update progress and completion toasts in the main app window.
- Updates helper and design reference documentation for the new trust verification and toast behavior.
