### PR TITLE
fix: resolve Full Disk Access detection on macOS 27

### DIFF
--- a/macUSB/Shared/Services/FullDiskAccessPermissionManager.swift
+++ b/macUSB/Shared/Services/FullDiskAccessPermissionManager.swift
@@ -90,28 +90,36 @@ final class FullDiskAccessPermissionManager {
     }
 
     private func evaluateFullDiskAccess() -> Bool {
+        // High-reliability FDA probe targets (macOS 10.15 through macOS 27+)
+        let testPaths = [
+            "/Library/Preferences/com.apple.TimeMachine.plist",
+            NSHomeDirectory() + "/Library/Safari/Bookmarks.plist",
+            NSHomeDirectory() + "/Library/Safari/History.db",
+            NSHomeDirectory() + "/Library/Containers/com.apple.Safari/Data/Library/Safari/Bookmarks.plist"
+        ]
+
+        for path in testPaths {
+            if FileManager.default.isReadableFile(atPath: path) {
+                return true
+            }
+            if let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: path)) {
+                try? handle.close()
+                return true
+            }
+        }
+
+        // Legacy check for older macOS releases where reading TCC.db directly was permitted
         let tccDatabaseURL = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Application Support/com.apple.TCC/TCC.db", isDirectory: false)
 
-        guard FileManager.default.fileExists(atPath: tccDatabaseURL.path) else {
-            return false
-        }
-
-        do {
-            let handle = try FileHandle(forReadingFrom: tccDatabaseURL)
-            defer {
+        if FileManager.default.fileExists(atPath: tccDatabaseURL.path) {
+            if let handle = try? FileHandle(forReadingFrom: tccDatabaseURL) {
                 try? handle.close()
+                return true
             }
-
-            if #available(macOS 10.15.4, *) {
-                _ = try handle.read(upToCount: 1)
-            } else {
-                _ = handle.readData(ofLength: 1)
-            }
-            return true
-        } catch {
-            return false
         }
+
+        return false
     }
 
     private func presentStartupPrompt(completion: @escaping () -> Void) {


### PR DESCRIPTION
### Problem
On macOS 27 (Golden Gate Developer Preview), direct reading of the system TCC database (`~/Library/Application Support/com.apple.TCC/TCC.db`) returns a permission error even when Full Disk Access has been granted. This causes `macUSB` to throw a false negative FDA warning on launch.

### Solution
- Replaced direct `TCC.db` reading in `FullDiskAccessPermissionManager.swift` with a multi-path FDA read accessibility probe (evaluating protected paths like `/Library/Preferences/com.apple.TimeMachine.plist` and `~/Library/Safari/Bookmarks.plist`).
- Retained legacy `TCC.db` fallback checks for older macOS versions.
- Fully backwards-compatible with macOS 14.6+ and macOS 15.

### Other Notes:
I am the one who created the issue. I completely understand you not wanting to install the beta and troubleshoot. Here is a fix that worked on my local machine if you wanna take a look at it! 