### PR TITLE
Keep Windows installation summary within fixed height

### DIFF
--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -60,6 +60,7 @@ Windows source trust boundary:
 
 Windows automatic configuration card:
 - card is visible only for recognized desktop Windows 10 64-bit and Windows 11 images; Windows 10 32-bit, Windows 10 ARM, and Windows Server do not show this card,
+- when the card appears together with the configurable BIOS/UEFI selector, the generic process-duration card is omitted to keep the fixed-height summary within the visible area,
 - state is session-only and keyed to the selected ISO path plus file identity when available,
 - Windows 10 64-bit and Windows 11 offer automatic BitLocker device-encryption prevention, privacy data-collection opt-out, Wi-Fi/network setup skip, Microsoft-account requirement bypass, local-account options, and language/region transfer from the current Mac,
 - only Windows 11 offers the combined TPM 2.0/Secure Boot/RAM hardware-bypass option,

--- a/macUSB/Features/Installation/UniversalInstallationView.swift
+++ b/macUSB/Features/Installation/UniversalInstallationView.swift
@@ -134,6 +134,17 @@ struct UniversalInstallationView: View {
         guard isWindowsWorkflow, windowsAutounattendConfiguration.hasSelectedOption else { return false }
         return !windowsAutounattendConfiguration.canStartWorkflow
     }
+    private var shouldShowProcessDurationCard: Bool {
+        guard windowsAutounattendVersion != nil,
+              let windowsBootModeCardStyle else {
+            return true
+        }
+
+        if case .configurable = windowsBootModeCardStyle {
+            return false
+        }
+        return true
+    }
     private var shouldBlockStartAction: Bool {
         windowsPrerequisiteShouldBlockStart
             || windowsAutounattendShouldBlockStart
@@ -342,11 +353,13 @@ struct UniversalInstallationView: View {
                             }
                         }
 
-                        StatusCard(tone: .neutral, density: .compact) {
-                            HStack(alignment: .center, spacing: 15) {
-                                Image(systemName: "clock").font(sectionIconFont).foregroundColor(.secondary).frame(width: MacUSBDesignTokens.iconColumnWidth)
-                                Text("Cały proces może potrwać kilka minut.").font(.subheadline).foregroundColor(.secondary)
-                                Spacer()
+                        if shouldShowProcessDurationCard {
+                            StatusCard(tone: .neutral, density: .compact) {
+                                HStack(alignment: .center, spacing: 15) {
+                                    Image(systemName: "clock").font(sectionIconFont).foregroundColor(.secondary).frame(width: MacUSBDesignTokens.iconColumnWidth)
+                                    Text("Cały proces może potrwać kilka minut.").font(.subheadline).foregroundColor(.secondary)
+                                    Spacer()
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The Windows installation summary omits the generic process-duration card when automatic Windows configuration and the configurable BIOS/UEFI selector are displayed together. This keeps the summary within the fixed 550 × 750 window.