### PR TITLE
Adjust USB capacity requirements

### DIFF
--- a/docs/reference/features/analysis/LINUX_ANALYSIS_FLOW.md
+++ b/docs/reference/features/analysis/LINUX_ANALYSIS_FLOW.md
@@ -129,9 +129,13 @@ Raw `.img` Linux force sets Linux workflow state without distro recognition:
 
 Required USB capacity is computed from source file size:
 
-- source size `<= 6_000_000_000` bytes -> `8 GB`,
-- source size `> 6_000_000_000` and `<= 14_000_000_000` bytes -> `16 GB`,
-- source size `> 14_000_000_000` bytes -> `32 GB`.
+- source size `<= 900_000_000` bytes -> `1 GB`,
+- source size `> 900_000_000` and `<= 1_800_000_000` bytes -> `2 GB`,
+- source size `> 1_800_000_000` and `<= 3_600_000_000` bytes -> `4 GB`,
+- source size `> 3_600_000_000` and `<= 7_300_000_000` bytes -> `8 GB`,
+- source size `> 7_300_000_000` and `<= 14_700_000_000` bytes -> `16 GB`,
+- source size `> 14_700_000_000` and `<= 29_400_000_000` bytes -> `32 GB`,
+- source size `> 29_400_000_000` bytes -> `64 GB`.
 
 If source size cannot be resolved from file metadata, fallback capacity is `16 GB`.
 

--- a/docs/reference/features/analysis/WINDOWS_ANALYSIS_FLOW.md
+++ b/docs/reference/features/analysis/WINDOWS_ANALYSIS_FLOW.md
@@ -181,9 +181,13 @@ Current workflow gating:
 
 Required USB capacity is computed from selected Windows source file size:
 
-- source size `<= 6_000_000_000` bytes -> `8 GB`,
-- source size `> 6_000_000_000` and `<= 14_000_000_000` bytes -> `16 GB`,
-- source size `> 14_000_000_000` bytes -> `32 GB`.
+- source size `<= 900_000_000` bytes -> `1 GB`,
+- source size `> 900_000_000` and `<= 1_800_000_000` bytes -> `2 GB`,
+- source size `> 1_800_000_000` and `<= 3_600_000_000` bytes -> `4 GB`,
+- source size `> 3_600_000_000` and `<= 7_300_000_000` bytes -> `8 GB`,
+- source size `> 7_300_000_000` and `<= 14_700_000_000` bytes -> `16 GB`,
+- source size `> 14_700_000_000` and `<= 29_400_000_000` bytes -> `32 GB`,
+- source size `> 29_400_000_000` bytes -> `64 GB`.
 
 If source size cannot be resolved from file metadata, fallback capacity is `16 GB`.
 

--- a/docs/reference/features/usb/USB_VALIDATION_AND_CAPACITY.md
+++ b/docs/reference/features/usb/USB_VALIDATION_AND_CAPACITY.md
@@ -4,15 +4,21 @@
 
 Before installer recognition completes, required size in UI is unresolved (`-- GB`).
 
-Thresholds:
+macOS thresholds:
 - major version `<= 14`: UI `16 GB`, technical threshold `15_000_000_000` bytes
 - major version `>= 15`: UI `32 GB`, technical threshold `28_000_000_000` bytes
-- Linux source size `<= 6_000_000_000` bytes: UI `8 GB`, technical threshold `6_000_000_000` bytes
-- Linux source size `> 6_000_000_000` and `<= 14_000_000_000` bytes: UI `16 GB`, technical threshold `15_000_000_000` bytes
-- Linux source size `> 14_000_000_000` bytes: UI `32 GB`, technical threshold `28_000_000_000` bytes
-- Windows source size `<= 6_000_000_000` bytes: UI `8 GB`, technical threshold `6_000_000_000` bytes
-- Windows source size `> 6_000_000_000` and `<= 14_000_000_000` bytes: UI `16 GB`, technical threshold `15_000_000_000` bytes
-- Windows source size `> 14_000_000_000` bytes: UI `32 GB`, technical threshold `28_000_000_000` bytes
+
+Linux and Windows use the same source-image thresholds. Apply the first matching upper limit:
+
+- source size up to `900_000_000` bytes: UI `1 GB`, technical threshold `900_000_000` bytes
+- source size up to `1_800_000_000` bytes: UI `2 GB`, technical threshold `1_800_000_000` bytes
+- source size up to `3_600_000_000` bytes: UI `4 GB`, technical threshold `3_600_000_000` bytes
+- source size up to `7_300_000_000` bytes: UI `8 GB`, technical threshold `7_300_000_000` bytes
+- source size up to `14_700_000_000` bytes: UI `16 GB`, technical threshold `14_700_000_000` bytes
+- source size up to `29_400_000_000` bytes: UI `32 GB`, technical threshold `29_400_000_000` bytes
+- source size up to `58_800_000_000` bytes: UI `64 GB`, technical threshold `58_800_000_000` bytes
+
+Sources above `58_800_000_000` bytes currently remain in the top `64 GB` class.
 
 Fallback for Linux and Windows source-size resolution:
 - if source image size cannot be resolved, required capacity falls back to `16 GB` (instead of unresolved `-- GB`).

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicSourceCapacityPolicy.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicSourceCapacityPolicy.swift
@@ -11,13 +11,25 @@ extension AnalysisLogic {
     private static let sourceCapacityFallbackGB: Int = 16
 
     func requiredUSBCapacityGBForImageSourceSize(_ fileSizeBytes: Int64) -> Int {
-        if fileSizeBytes > 14_000_000_000 {
+        if fileSizeBytes > 29_400_000_000 {
+            return 64
+        }
+        if fileSizeBytes > 14_700_000_000 {
             return 32
         }
-        if fileSizeBytes > 6_000_000_000 {
+        if fileSizeBytes > 7_300_000_000 {
             return 16
         }
-        return 8
+        if fileSizeBytes > 3_600_000_000 {
+            return 8
+        }
+        if fileSizeBytes > 1_800_000_000 {
+            return 4
+        }
+        if fileSizeBytes > 900_000_000 {
+            return 2
+        }
+        return 1
     }
 
     func resolveImageSourceFileSizeBytes(for sourceURL: URL) -> (bytes: Int64, source: String)? {

--- a/macUSB/Features/Analysis/Logic/AnalysisLogicUsbDrives.swift
+++ b/macUSB/Features/Analysis/Logic/AnalysisLogicUsbDrives.swift
@@ -5,12 +5,20 @@ extension AnalysisLogic {
     private var requiredUSBCapacityBytes: Int? {
         guard let requiredGB = requiredUSBCapacityGB else { return nil }
         switch requiredGB {
+        case 1:
+            return 900_000_000
+        case 2:
+            return 1_800_000_000
+        case 4:
+            return 3_600_000_000
         case 8:
-            return 6_000_000_000
+            return 7_300_000_000
         case 16:
-            return 15_000_000_000
+            return 14_700_000_000
         case 32:
-            return 28_000_000_000
+            return 29_400_000_000
+        case 64:
+            return 58_800_000_000
         default:
             return requiredGB * 1_000_000_000
         }


### PR DESCRIPTION
This change adds shared USB capacity tiers from 1 GB to 64 GB for Windows and Linux images based on source image size. Smaller images can use lower-capacity USB drives.