### PR TITLE
Fix Windows target volume resolution

### DIFF
--- a/docs/reference/core/FILE_STRUCTURE.md
+++ b/docs/reference/core/FILE_STRUCTURE.md
@@ -114,7 +114,7 @@
 - `macUSBHelper/Service/*`
 - `macUSBHelper/Workflow/*`
 - `macUSBHelper/Workflow/Linux/*` — Linux raw-copy stage builder, parser, and disk ops.
-- `macUSBHelper/Workflow/Windows/*` — Windows ISO-copy stage builder, boot-mode-aware source/target validation, progress parsing, and verification.
+- `macUSBHelper/Workflow/Windows/*` — Windows ISO-copy stage builder, exact formatted-target partition and mount-point resolution, boot-mode-aware source/target validation, progress parsing, and verification.
 - `macUSBHelper/Workflow/Windows/MacUSBoot/*` — BIOS-only macUSBoot artifact validation, Disk Arbitration guard, raw-disk layout validation, transaction, disk operations, and orchestration.
 - `macUSBHelper/DownloaderAssembly/*`
 - `macUSBHelper/Rosetta/HelperRosettaInstaller.swift` — fixed-command, root-only Rosetta installer with bounded diagnostics.

--- a/docs/reference/features/helper/HELPER.md
+++ b/docs/reference/features/helper/HELPER.md
@@ -168,6 +168,7 @@ Contract invariants:
 - Automatic local-account creation writes the generated local account `Name` separately from the user-facing `DisplayName`. The helper validates `Name` as non-empty ASCII letters/digits, max 20 characters, and not `NONE`; `DisplayName` is non-empty, max 256 characters, not `NONE`, and contains only letters, digits, and spaces.
 - Mac language/region transfer receives app-side validated Windows locale tags, writes `Microsoft-Windows-International-Core` in `oobeSystem`, and uses the language tag as `InputLocale` so Windows selects its default keyboard for that language.
 - Every Windows request must include `windowsBootMode`; the service rejects requests without it before creating an executor.
+- After Windows target formatting, helper resolves the FAT32 partition from the exact requested whole disk, mounts that partition by device identifier when needed, and validates its partition identifier, exact parent whole disk, mount point, and volume UUID before every target-writing or target-verification stage. Volume labels remain presentation metadata and are not target paths.
 - Windows media copy runs only the system-provided `/usr/bin/rsync` with explicit recursive/link/time preservation. The privileged helper does not execute user-managed Homebrew or MacPorts `rsync` binaries and does not request POSIX ownership metadata for the FAT32 target.
 - BIOS mode appends `windows_install_macusboot` after `windows_verify_media` and before cleanup. UEFI retains the existing stage graph.
 - The BIOS stage validates the pinned bundled artifact and the target MBR gap, installs StageTwo at LBA 1...5 before MBR boot code, synchronizes and reads back each write, then verifies the full protected range. It blocks Disk Arbitration auto-mounts, ignores cancellation while active, and performs exactly one final `mountDisk` attempt after releasing raw-device ownership.
@@ -262,6 +263,8 @@ Daemon helper runtime:
   - Windows `Autounattend.xml` configuration helpers, XML generation, and XML validation.
 - `macUSBHelper/Workflow/Windows/HelperWorkflowWindowsBootValidation.swift`
   - boot-mode-aware, case-insensitive BIOS/UEFI source and target marker validation.
+- `macUSBHelper/Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift`
+  - exact whole-disk, FAT32 partition, mount-point, and volume-UUID resolution for the formatted Windows target.
 - `macUSBHelper/Workflow/Windows/MacUSBoot/*`
   - macUSBoot artifact/parser, MBR-gap validation, exclusive raw-device I/O, Disk Arbitration guard, diskutil operations, write transaction, and stage orchestration.
 - `macUSBHelper/DownloaderAssembly/DownloaderAssemblyExecutor.swift`

--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -128,6 +128,7 @@ Windows summary pre-start prerequisites:
 - Windows automatic configuration may set `OOBE/HideWirelessSetupInOOBE` to `true` when Wi-Fi/network setup skip is enabled.
 - Windows automatic local-account creation writes both `Name` and `DisplayName` for `Microsoft-Windows-Shell-Setup/UserAccounts/LocalAccounts/LocalAccount`; `DisplayName` preserves the user-entered display name, while `Name` is generated without spaces or special characters and limited to 20 ASCII letters/digits.
 - Windows target format must be `MS-DOS (FAT32)` + `MBR`.
+- After formatting, the helper resolves the Windows target from the exact selected whole-disk identifier through `AllDisksAndPartitions`, validates the FAT32 child partition, its exact `ParentWholeDisk`, mount point, and volume UUID, and uses that verified mount point for copy, WIM split, answer-file generation, and media verification. The user-facing volume label must never be used to address the target path.
 - Windows target volume labels are selected from the detected family:
   - desktop: `WINXP-MU`, `WINVS-MU`, `WIN7-MU`, `WIN8-MU`, `WIN81-MU`, `WIN10-MU`, or `WIN11-MU`,
   - server: `SRV03-MU`, `SRV08-MU`, `SRV12-MU`, `SRV16-MU`, `SRV19-MU`, `SRV22-MU`, or `SRV25-MU`,

--- a/macUSB.xcodeproj/project.pbxproj
+++ b/macUSB.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		A10000012F00000100000049 /* Workflow/Windows/HelperWorkflowWindowsStages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */; };
 		A10000012F0000010000004B /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */; };
 		A10000012F0000010000004D /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */; };
+		A10000012F0000010000005D /* Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F0000010000005E /* Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift */; };
 		A10000012F0000010000004F /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */; };
 		A10000012F00000100000051 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */; };
 		A10000012F00000100000053 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */; };
@@ -137,6 +138,7 @@
 		A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsStages.swift; sourceTree = "<group>"; };
 		A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift; sourceTree = "<group>"; };
 		A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift; sourceTree = "<group>"; };
+		A10000012F0000010000005E /* Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift; sourceTree = "<group>"; };
 		A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift; sourceTree = "<group>"; };
 		A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift; sourceTree = "<group>"; };
 		A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				A10000012F0000010000004A /* Workflow/Windows/HelperWorkflowWindowsStages.swift */,
 				A10000012F0000010000004C /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift */,
 				A10000012F0000010000004E /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift */,
+				A10000012F0000010000005E /* Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift */,
 				A10000012F00000100000050 /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift */,
 				A10000012F00000100000052 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift */,
 				A10000012F00000100000054 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift */,
@@ -811,6 +814,7 @@
 				A10000012F00000100000049 /* Workflow/Windows/HelperWorkflowWindowsStages.swift in Sources */,
 				A10000012F0000010000004B /* Workflow/Windows/HelperWorkflowWindowsSourceLogic.swift in Sources */,
 				A10000012F0000010000004D /* Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift in Sources */,
+				A10000012F0000010000005D /* Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift in Sources */,
 				A10000012F0000010000004F /* Workflow/Windows/HelperWorkflowWindowsCopyProgressParsing.swift in Sources */,
 				A10000012F00000100000051 /* Workflow/Windows/HelperWorkflowWindowsWimSplitProgressParsing.swift in Sources */,
 				A10000012F00000100000053 /* Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift in Sources */,

--- a/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
+++ b/macUSBHelper/Workflow/HelperWorkflowExecutor.swift
@@ -24,7 +24,9 @@ final class HelperWorkflowExecutor {
     var windowsShouldSplitWim = false
     var windowsHasInstallESD = false
     var windowsWimlibExecutablePath: String?
+    var windowsPreparedTargetPartitionBSDName: String?
     var windowsPreparedTargetVolumePath: String?
+    var windowsPreparedTargetVolumeUUID: String?
     var windowsCopyStageTotalBytes: Int64?
     var windowsRsyncProgressMode: String?
     var windowsLegacyRsyncCurrentFilePath: String?

--- a/macUSBHelper/Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift
+++ b/macUSBHelper/Workflow/Windows/Autounattend/HelperWorkflowWindowsAutounattendGenerator.swift
@@ -7,7 +7,7 @@ extension HelperWorkflowExecutor {
             return
         }
 
-        let targetVolumePath = windowsPreparedTargetVolumePath ?? "/Volumes/\(request.targetLabel)"
+        let targetVolumePath = try requireWindowsPreparedTargetVolumePath(stage: stage)
         let targetURL = URL(fileURLWithPath: targetVolumePath)
         guard fileManager.fileExists(atPath: targetURL.path) else {
             throw HelperExecutionError.failed(

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsStages.swift
@@ -194,7 +194,7 @@ extension HelperWorkflowExecutor {
             )
         }
 
-        let targetVolumePath = windowsPreparedTargetVolumePath ?? "/Volumes/\(request.targetLabel)"
+        let targetVolumePath = try requireWindowsPreparedTargetVolumePath(stage: stage)
         let relativeWimPath = windowsInstallWimRelativePath ?? "sources/install.wim"
         let sourcesSubdirectory = (relativeWimPath as NSString).deletingLastPathComponent
         let targetSplitPath = URL(fileURLWithPath: targetVolumePath)
@@ -233,31 +233,7 @@ extension HelperWorkflowExecutor {
     }
 
     private func ensureWindowsTargetMountPathForCopy(stage: WorkflowStage) throws -> String {
-        if let currentPath = windowsPreparedTargetVolumePath,
-           isWindowsMountedDirectoryUsable(currentPath) {
-            return currentPath
-        }
-
-        let wholeDisk = try extractWholeDiskName(from: request.targetBSDName)
-        guard let remountedPath = resolveMountedVolumePathForWholeDisk(wholeDisk),
-              isWindowsMountedDirectoryUsable(remountedPath) else {
-            throw HelperExecutionError.failed(
-                stage: stage.key,
-                exitCode: -1,
-                description: "Nie znaleziono zamontowanego woluminu docelowego USB przed kopiowaniem."
-            )
-        }
-
-        windowsPreparedTargetVolumePath = remountedPath
-        emitProgress(
-            stageKey: stage.key,
-            titleKey: stage.titleKey,
-            percent: latestPercent,
-            statusKey: stage.statusKey,
-            logLine: "Windows target path refreshed before copy: \(remountedPath)",
-            shouldAdvancePercent: false
-        )
-        return remountedPath
+        try requireWindowsPreparedTargetVolumePath(stage: stage)
     }
 
     private func isWindowsMountedDirectoryUsable(_ path: String) -> Bool {

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift
@@ -4,14 +4,14 @@ struct WindowsTargetVolumeResolution {
     let wholeDiskBSDName: String
     let partitionBSDName: String
     let mountPath: String
-    let volumeUUID: String?
+    let volumeUUID: String
 }
 
 private struct WindowsTargetPartitionState {
     let wholeDiskBSDName: String
     let partitionBSDName: String
     let mountPath: String?
-    let volumeUUID: String?
+    let volumeUUID: String
 }
 
 extension HelperWorkflowExecutor {
@@ -117,7 +117,7 @@ extension HelperWorkflowExecutor {
             titleKey: stage.titleKey,
             percent: latestPercent,
             statusKey: stage.statusKey,
-            logLine: "Windows target path refreshed: disk=\(wholeDisk), partition=\(target.partitionBSDName), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID ?? "none")",
+            logLine: "Windows target path refreshed: disk=\(wholeDisk), partition=\(target.partitionBSDName), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID)",
             shouldAdvancePercent: false
         )
         return target.mountPath
@@ -144,12 +144,15 @@ extension HelperWorkflowExecutor {
             }
 
             let mountPath = (info["MountPoint"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
-            let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !volumeUUID.isEmpty else {
+                return nil
+            }
             return WindowsTargetPartitionState(
                 wholeDiskBSDName: parentWholeDisk,
                 partitionBSDName: resolvedPartition,
                 mountPath: mountPath?.isEmpty == false ? mountPath : nil,
-                volumeUUID: volumeUUID?.isEmpty == false ? volumeUUID : nil
+                volumeUUID: volumeUUID
             )
         }
     }
@@ -178,7 +181,10 @@ extension HelperWorkflowExecutor {
             return nil
         }
 
-        let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !volumeUUID.isEmpty else {
+            return nil
+        }
         if let expectedVolumeUUID,
            volumeUUID != expectedVolumeUUID {
             return nil
@@ -188,7 +194,7 @@ extension HelperWorkflowExecutor {
             wholeDiskBSDName: parentWholeDisk,
             partitionBSDName: partitionBSDName,
             mountPath: resolvedMountPath,
-            volumeUUID: volumeUUID?.isEmpty == false ? volumeUUID : nil
+            volumeUUID: volumeUUID
         )
     }
 

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsTargetResolution.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+struct WindowsTargetVolumeResolution {
+    let wholeDiskBSDName: String
+    let partitionBSDName: String
+    let mountPath: String
+    let volumeUUID: String?
+}
+
+private struct WindowsTargetPartitionState {
+    let wholeDiskBSDName: String
+    let partitionBSDName: String
+    let mountPath: String?
+    let volumeUUID: String?
+}
+
+extension HelperWorkflowExecutor {
+    func waitForWindowsTargetVolume(
+        stage: WorkflowStage,
+        wholeDisk: String
+    ) throws -> WindowsTargetVolumeResolution {
+        var mountAttempts = Set<String>()
+
+        for _ in 0..<70 {
+            let candidates = windowsTargetPartitionStates(on: wholeDisk)
+            if candidates.count > 1 {
+                let partitions = candidates.map(\.partitionBSDName).sorted().joined(separator: ",")
+                throw HelperExecutionError.failed(
+                    stage: stage.key,
+                    exitCode: -1,
+                    description: "Wykryto więcej niż jedną partycję FAT32 na docelowym urządzeniu \(wholeDisk): \(partitions)."
+                )
+            }
+
+            if let target = candidates.first {
+                if let mountPath = target.mountPath,
+                   isExistingWindowsTargetDirectory(atPath: mountPath) {
+                    return WindowsTargetVolumeResolution(
+                        wholeDiskBSDName: target.wholeDiskBSDName,
+                        partitionBSDName: target.partitionBSDName,
+                        mountPath: mountPath,
+                        volumeUUID: target.volumeUUID
+                    )
+                }
+
+                if mountAttempts.insert(target.partitionBSDName).inserted {
+                    let exitCode = try runSimpleCommand(
+                        executable: "/usr/sbin/diskutil",
+                        arguments: ["mount", "/dev/\(target.partitionBSDName)"],
+                        stageKey: stage.key,
+                        stageTitleKey: stage.titleKey,
+                        statusKey: stage.statusKey,
+                        failOnNonZeroExit: false
+                    )
+                    emitProgress(
+                        stageKey: stage.key,
+                        titleKey: stage.titleKey,
+                        percent: latestPercent,
+                        statusKey: stage.statusKey,
+                        logLine: "Windows target mount requested: disk=\(wholeDisk), partition=\(target.partitionBSDName), exitCode=\(exitCode)",
+                        shouldAdvancePercent: false
+                    )
+                }
+            }
+
+            try throwIfCancelled()
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+
+        throw HelperExecutionError.failed(
+            stage: stage.key,
+            exitCode: -1,
+            description: "Nie znaleziono zamontowanej partycji FAT32 urządzenia docelowego \(wholeDisk) po formatowaniu."
+        )
+    }
+
+    func requireWindowsPreparedTargetVolumePath(stage: WorkflowStage) throws -> String {
+        let wholeDisk = try extractWholeDiskName(from: request.targetBSDName)
+
+        if let currentPath = windowsPreparedTargetVolumePath,
+           let target = validatedWindowsTargetVolume(
+               atMountPath: currentPath,
+               expectedWholeDisk: wholeDisk,
+               expectedPartition: windowsPreparedTargetPartitionBSDName,
+               expectedVolumeUUID: windowsPreparedTargetVolumeUUID
+           ) {
+            windowsPreparedTargetPartitionBSDName = target.partitionBSDName
+            windowsPreparedTargetVolumePath = target.mountPath
+            windowsPreparedTargetVolumeUUID = target.volumeUUID
+            return target.mountPath
+        }
+
+        let target = try waitForWindowsTargetVolume(stage: stage, wholeDisk: wholeDisk)
+        if let expectedPartition = windowsPreparedTargetPartitionBSDName,
+           target.partitionBSDName != expectedPartition {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Partycja docelowa Windows zmieniła identyfikator z \(expectedPartition) na \(target.partitionBSDName)."
+            )
+        }
+        if let expectedVolumeUUID = windowsPreparedTargetVolumeUUID,
+           target.volumeUUID != expectedVolumeUUID {
+            throw HelperExecutionError.failed(
+                stage: stage.key,
+                exitCode: -1,
+                description: "Wolumin docelowy Windows zmienił UUID podczas wykonywania procesu."
+            )
+        }
+
+        windowsPreparedTargetPartitionBSDName = target.partitionBSDName
+        windowsPreparedTargetVolumePath = target.mountPath
+        windowsPreparedTargetVolumeUUID = target.volumeUUID
+
+        emitProgress(
+            stageKey: stage.key,
+            titleKey: stage.titleKey,
+            percent: latestPercent,
+            statusKey: stage.statusKey,
+            logLine: "Windows target path refreshed: disk=\(wholeDisk), partition=\(target.partitionBSDName), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID ?? "none")",
+            shouldAdvancePercent: false
+        )
+        return target.mountPath
+    }
+
+    private func windowsTargetPartitionStates(on wholeDisk: String) -> [WindowsTargetPartitionState] {
+        guard let list = runDiskutilPlistCommand(arguments: ["list", "-plist", "/dev/\(wholeDisk)"]),
+              let disks = list["AllDisksAndPartitions"] as? [[String: Any]],
+              let targetDisk = disks.first(where: { ($0["DeviceIdentifier"] as? String) == wholeDisk }),
+              let partitions = targetDisk["Partitions"] as? [[String: Any]] else {
+            return []
+        }
+
+        return partitions.compactMap { partition in
+            guard let partitionBSDName = partition["DeviceIdentifier"] as? String,
+                  let info = runDiskutilPlistCommand(arguments: ["info", "-plist", "/dev/\(partitionBSDName)"]),
+                  let resolvedPartition = info["DeviceIdentifier"] as? String,
+                  resolvedPartition == partitionBSDName,
+                  let parentWholeDisk = info["ParentWholeDisk"] as? String,
+                  parentWholeDisk == wholeDisk,
+                  (info["WholeDisk"] as? Bool) == false,
+                  isWindowsFATTargetPartition(info) else {
+                return nil
+            }
+
+            let mountPath = (info["MountPoint"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return WindowsTargetPartitionState(
+                wholeDiskBSDName: parentWholeDisk,
+                partitionBSDName: resolvedPartition,
+                mountPath: mountPath?.isEmpty == false ? mountPath : nil,
+                volumeUUID: volumeUUID?.isEmpty == false ? volumeUUID : nil
+            )
+        }
+    }
+
+    private func validatedWindowsTargetVolume(
+        atMountPath mountPath: String,
+        expectedWholeDisk: String,
+        expectedPartition: String?,
+        expectedVolumeUUID: String?
+    ) -> WindowsTargetVolumeResolution? {
+        guard isExistingWindowsTargetDirectory(atPath: mountPath),
+              let info = runDiskutilPlistCommand(arguments: ["info", "-plist", mountPath]),
+              let partitionBSDName = info["DeviceIdentifier"] as? String,
+              expectedPartition == nil || partitionBSDName == expectedPartition,
+              let parentWholeDisk = info["ParentWholeDisk"] as? String,
+              parentWholeDisk == expectedWholeDisk,
+              (info["WholeDisk"] as? Bool) == false,
+              isWindowsFATTargetPartition(info) else {
+            return nil
+        }
+
+        let resolvedMountPath = (info["MountPoint"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let resolvedMountPath,
+              !resolvedMountPath.isEmpty,
+              resolvedMountPath == mountPath else {
+            return nil
+        }
+
+        let volumeUUID = (info["VolumeUUID"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let expectedVolumeUUID,
+           volumeUUID != expectedVolumeUUID {
+            return nil
+        }
+
+        return WindowsTargetVolumeResolution(
+            wholeDiskBSDName: parentWholeDisk,
+            partitionBSDName: partitionBSDName,
+            mountPath: resolvedMountPath,
+            volumeUUID: volumeUUID?.isEmpty == false ? volumeUUID : nil
+        )
+    }
+
+    private func isWindowsFATTargetPartition(_ info: [String: Any]) -> Bool {
+        let content = (info["Content"] as? String)?.uppercased()
+        let filesystemType = (info["FilesystemType"] as? String)?.lowercased()
+        return content == "DOS_FAT_32" && filesystemType == "msdos"
+    }
+
+    private func isExistingWindowsTargetDirectory(atPath path: String) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+}

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
@@ -87,7 +87,7 @@ extension HelperWorkflowExecutor {
             titleKey: stage.titleKey,
             percent: latestPercent,
             statusKey: stage.statusKey,
-            logLine: "Windows target prepared: disk=\(wholeDisk), partition=\(target.partitionBSDName), label=\(request.targetLabel), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID ?? "none")",
+            logLine: "Windows target prepared: disk=\(wholeDisk), partition=\(target.partitionBSDName), label=\(request.targetLabel), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID)",
             shouldAdvancePercent: false
         )
     }

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsUnmountLogic.swift
@@ -77,19 +77,17 @@ extension HelperWorkflowExecutor {
         }
 
         try runWindowsFormatCommand(stage: stage, wholeDisk: wholeDisk)
-        let mountPath = try waitForWindowsTargetVolumeMountPath(
-            stage: stage,
-            wholeDisk: wholeDisk,
-            preferredVolumeName: request.targetLabel
-        )
-        windowsPreparedTargetVolumePath = mountPath
+        let target = try waitForWindowsTargetVolume(stage: stage, wholeDisk: wholeDisk)
+        windowsPreparedTargetPartitionBSDName = target.partitionBSDName
+        windowsPreparedTargetVolumePath = target.mountPath
+        windowsPreparedTargetVolumeUUID = target.volumeUUID
 
         emitProgress(
             stageKey: stage.key,
             titleKey: stage.titleKey,
             percent: latestPercent,
             statusKey: stage.statusKey,
-            logLine: "Windows target prepared: disk=\(wholeDisk), label=\(request.targetLabel), mountPath=\(mountPath)",
+            logLine: "Windows target prepared: disk=\(wholeDisk), partition=\(target.partitionBSDName), label=\(request.targetLabel), mountPath=\(target.mountPath), volumeUUID=\(target.volumeUUID ?? "none")",
             shouldAdvancePercent: false
         )
     }
@@ -205,90 +203,6 @@ extension HelperWorkflowExecutor {
             try throwIfCancelled()
             Thread.sleep(forTimeInterval: 0.1)
         }
-    }
-
-    private func waitForWindowsTargetVolumeMountPath(
-        stage: WorkflowStage,
-        wholeDisk: String,
-        preferredVolumeName: String
-    ) throws -> String {
-        let preferredMountPath = "/Volumes/\(preferredVolumeName)"
-
-        for _ in 0..<70 {
-            if let resolvedMountPath = resolveMountedVolumePathForWholeDisk(wholeDisk),
-               isExistingDirectory(atPath: resolvedMountPath) {
-                return resolvedMountPath
-            }
-
-            if isExistingDirectory(atPath: preferredMountPath),
-               isMountPathBackedByWholeDisk(preferredMountPath, wholeDisk: wholeDisk) {
-                return preferredMountPath
-            }
-            try throwIfCancelled()
-            Thread.sleep(forTimeInterval: 0.1)
-        }
-
-        throw HelperExecutionError.failed(
-            stage: stage.key,
-            exitCode: -1,
-            description: "Nie znaleziono zamontowanego woluminu USB po formatowaniu dla urządzenia \(wholeDisk)."
-        )
-    }
-
-    func resolveMountedVolumePathForWholeDisk(_ wholeDisk: String) -> String? {
-        guard let info = diskutilPlist(arguments: ["list", "-plist", "/dev/\(wholeDisk)"]),
-              let partitions = info["Partitions"] as? [[String: Any]] else {
-            return nil
-        }
-
-        for partition in partitions {
-            if let mountPoint = partition["MountPoint"] as? String,
-               !mountPoint.isEmpty {
-                return mountPoint
-            }
-        }
-        return nil
-    }
-
-    private func isMountPathBackedByWholeDisk(_ mountPath: String, wholeDisk: String) -> Bool {
-        guard let info = diskutilPlist(arguments: ["info", "-plist", mountPath]),
-              let deviceIdentifier = info["DeviceIdentifier"] as? String else {
-            return false
-        }
-        return deviceIdentifier.hasPrefix(wholeDisk)
-    }
-
-    private func diskutilPlist(arguments: [String]) -> [String: Any]? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
-        process.arguments = arguments
-        process.standardOutput = Pipe()
-        process.standardError = Pipe()
-
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            return nil
-        }
-
-        let data = (process.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile() ?? Data()
-        guard !data.isEmpty,
-              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
-              let dictionary = plist as? [String: Any] else {
-            return nil
-        }
-
-        return dictionary
-    }
-
-    private func isExistingDirectory(atPath path: String) -> Bool {
-        var isDirectory = ObjCBool(false)
-        return fileManager.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
     }
 
     private func isWindowsUnmountBusyLine(_ line: String) -> Bool {

--- a/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
+++ b/macUSBHelper/Workflow/Windows/HelperWorkflowWindowsValidationLogic.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension HelperWorkflowExecutor {
     func runWindowsVerifyMediaStage(_ stage: WorkflowStage) throws {
-        let targetPath = windowsPreparedTargetVolumePath ?? "/Volumes/\(request.targetLabel)"
+        let targetPath = try requireWindowsPreparedTargetVolumePath(stage: stage)
         let targetURL = URL(fileURLWithPath: targetPath)
 
         guard fileManager.fileExists(atPath: targetPath) else {


### PR DESCRIPTION
This fixes Windows media creation when another mounted volume already uses the generated target label. The helper now resolves the formatted FAT32 partition from the exact selected whole disk, validates its partition identity, parent disk, mount point, and volume UUID before each target stage, and mounts the exact partition when necessary. User-facing volume labels are no longer used as target paths, so mount-point suffixes such as `WIN10-MU 1` do not interrupt media creation or redirect operations to another volume.