### PR TITLE
Fix macOS beta detection and use the macOS 27 catalog

### DIFF
--- a/docs/reference/features/downloader/DOWNLOADER.md
+++ b/docs/reference/features/downloader/DOWNLOADER.md
@@ -112,7 +112,7 @@ Discovery pipeline (`MacOSCatalogService`, orchestrated by `MacOSDownloaderLogic
   - detach nested images before parent images using a standard retry followed by forced detach,
   - report detach exhaustion as a discovery failure for that candidate and retain the temporary directory rather than removing an active mount point,
   - remove unique temporary mount and metadata-extraction directories only after all owned images are confirmed detached.
-2. Download the stable Apple catalog and Public Beta catalogs for macOS 27, 26, and 15 from `swscan.apple.com` on every discovery.
+2. Download the merged stable Apple catalog for macOS 27, 26, and 15 and the corresponding Public Beta catalogs from `swscan.apple.com` on every discovery.
 3. Parse InstallAssistant candidates from products metadata.
 4. Parse `.dist` metadata from Apple distribution hosts.
 5. Treat the source catalog as the release-channel authority: entries from the stable catalog are stable, while entries unique to Public Beta catalogs are Public Beta regardless of prerelease wording in distribution metadata; when the same product ID is present in both channels, the stable catalog takes precedence.

--- a/docs/reference/features/downloader/DOWNLOADER.md
+++ b/docs/reference/features/downloader/DOWNLOADER.md
@@ -115,7 +115,7 @@ Discovery pipeline (`MacOSCatalogService`, orchestrated by `MacOSDownloaderLogic
 2. Download the stable Apple catalog and Public Beta catalogs for macOS 27, 26, and 15 from `swscan.apple.com` on every discovery.
 3. Parse InstallAssistant candidates from products metadata.
 4. Parse `.dist` metadata from Apple distribution hosts.
-5. Keep non-prerelease entries from stable and prerelease entries from beta catalogs.
+5. Treat the source catalog as the release-channel authority: entries from the stable catalog are stable, while entries unique to Public Beta catalogs are Public Beta regardless of prerelease wording in distribution metadata; when the same product ID is present in both channels, the stable catalog takes precedence.
 6. Deduplicate by normalized identity within each release channel and across overlapping Public Beta catalogs.
 7. Enrich legacy official entries from Apple Support list.
 8. Probe installer sizes (catalog-prefill + network probe fallback).

--- a/macUSB/Features/Downloader/Logic/Discovery/MacOSDiscoveryConstants.swift
+++ b/macUSB/Features/Downloader/Logic/Discovery/MacOSDiscoveryConstants.swift
@@ -33,7 +33,7 @@ extension MacOSCatalogService {
     }
 
     enum Constants {
-        static let stableCatalogURL = URL(string: "https://swscan.apple.com/content/catalogs/others/index-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz")!
+        static let stableCatalogURL = URL(string: "https://swscan.apple.com/content/catalogs/others/index-27-26-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz")!
         static let publicBetaCatalogURLs = [
             URL(string: "https://swscan.apple.com/content/catalogs/others/index-27beta-27-26-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz")!,
             URL(string: "https://swscan.apple.com/content/catalogs/others/index-26beta-26-15-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz")!,

--- a/macUSB/Features/Downloader/Logic/Discovery/MacOSDiscoveryDistributionParser.swift
+++ b/macUSB/Features/Downloader/Logic/Discovery/MacOSDiscoveryDistributionParser.swift
@@ -15,14 +15,6 @@ extension MacOSCatalogService {
 
         if version.isEmpty { return nil }
         if build.isEmpty { build = "N/A" }
-        let prerelease = isPrerelease(name: name, version: version, build: build)
-        if candidate.releaseChannel == .stable, prerelease {
-            return nil
-        }
-        if candidate.releaseChannel != .stable, !prerelease {
-            return nil
-        }
-
         let family = normalizeFamilyName(from: name)
         return MacOSInstallerEntry(
             id: "\(candidate.releaseChannel.rawValue)|\(family)|\(name)|\(version)|\(build)",
@@ -75,14 +67,5 @@ extension MacOSCatalogService {
             return "macOS Golden Gate"
         }
         return family
-    }
-
-    func isPrerelease(name: String, version: String, build: String) -> Bool {
-        let text = "\(name) \(version) \(build)".lowercased()
-        return text.contains("beta")
-            || text.contains("seed")
-            || text.contains("release candidate")
-            || text.contains(" rc")
-            || text.contains("preview")
     }
 }


### PR DESCRIPTION
This updates macOS installer discovery to classify beta-only releases by their Apple catalog source instead of relying on prerelease wording in distribution metadata. Stable product IDs continue to take precedence, and stable discovery now uses Apple's merged macOS 27 catalog so future Golden Gate releases can transition correctly between beta and stable channels.