### PR TITLE
Animate downloader and USB creation stages

### DIFF
--- a/docs/reference/design/DESIGN_SYSTEM.md
+++ b/docs/reference/design/DESIGN_SYSTEM.md
@@ -59,7 +59,8 @@ The downloader prerequisite warning action is the reference implementation for c
 
 - When a running process advances, the completed stage and the newly active stage must update in one shared `easeInOut` animation lasting `0.24` seconds.
 - Keep stage-row identity stable and key the animation to the complete set of visual stage states, so progress and speed updates do not retrigger the list transition.
-- Replace the visual contents of a stage card with a symmetric opacity plus subtle `0.98` scale transition. The containing stage list must animate the corresponding height changes so the active card collapses as the next card expands.
+- Pending and completed stage cards remain at `0.98` scale, while the active stage uses `1.0` scale.
+- Replace the visual contents of a stage card with a symmetric opacity transition. The active card additionally scales between `0.98` and `1.0` during entry and exit, and the containing stage list animates the corresponding height changes so the active card collapses as the next card expands.
 - Animation remains presentation-only. Do not delay, reorder, or merge workflow events to accommodate it.
 
 The downloader and USB creation process screens share this stage-transition behavior.

--- a/docs/reference/design/DESIGN_SYSTEM.md
+++ b/docs/reference/design/DESIGN_SYSTEM.md
@@ -55,6 +55,15 @@ The downloader options for Public Beta visibility and showing all available vers
 
 The downloader prerequisite warning action is the reference implementation for conditional button visibility.
 
+### Sequential process stages
+
+- When a running process advances, the completed stage and the newly active stage must update in one shared `easeInOut` animation lasting `0.24` seconds.
+- Keep stage-row identity stable and key the animation to the complete set of visual stage states, so progress and speed updates do not retrigger the list transition.
+- Replace the visual contents of a stage card with a symmetric opacity plus subtle `0.98` scale transition. The containing stage list must animate the corresponding height changes so the active card collapses as the next card expands.
+- Animation remains presentation-only. Do not delay, reorder, or merge workflow events to accommodate it.
+
+The downloader and USB creation process screens share this stage-transition behavior.
+
 ## Copy and Tone
 
 - User-facing copy should remain concise, calm, and Apple-like.

--- a/docs/reference/features/downloader/DOWNLOADER.md
+++ b/docs/reference/features/downloader/DOWNLOADER.md
@@ -257,6 +257,7 @@ List screen:
   - show all versions,
   - show macOS Public Beta versions (session-only and off by default),
   - DEBUG retain-files toggle (Debug only).
+- after a confirmed download action, the list screen and process screen transition in one shared `easeInOut` animation lasting `0.24` seconds, using symmetric opacity and subtle `0.98` scale transitions consistent with process-stage motion; the animation is presentation-only and does not delay workflow startup.
 
 Process screen:
 - stage cards with three visual states:
@@ -264,6 +265,7 @@ Process screen:
   - active (accent-highlighted through the shared Liquid Glass-compatible active surface),
   - completed (green check state).
 - pending and completed cards remain at `0.98` scale, while the active card uses `1.0`; advancing to the next stage animates the completed and newly active cards together with the shared stage-transition motion, and frequent progress and speed updates do not retrigger this transition.
+- when the workflow reaches a terminal state, the stage list and download summary transition in one shared `easeInOut` animation lasting `0.24` seconds, using the same symmetric opacity and subtle `0.98` scale motion as the list-to-process transition.
 - active download stage shows:
   - percent above progress bar,
   - speed label and transfer,

--- a/docs/reference/features/downloader/DOWNLOADER.md
+++ b/docs/reference/features/downloader/DOWNLOADER.md
@@ -263,7 +263,7 @@ Process screen:
   - pending,
   - active (accent-highlighted through the shared Liquid Glass-compatible active surface),
   - completed (green check state).
-- advancing to the next stage animates the completed and newly active cards together with the shared stage-transition motion; frequent progress and speed updates do not retrigger this transition.
+- pending and completed cards remain at `0.98` scale, while the active card uses `1.0`; advancing to the next stage animates the completed and newly active cards together with the shared stage-transition motion, and frequent progress and speed updates do not retrigger this transition.
 - active download stage shows:
   - percent above progress bar,
   - speed label and transfer,

--- a/docs/reference/features/downloader/DOWNLOADER.md
+++ b/docs/reference/features/downloader/DOWNLOADER.md
@@ -263,6 +263,7 @@ Process screen:
   - pending,
   - active (accent-highlighted through the shared Liquid Glass-compatible active surface),
   - completed (green check state).
+- advancing to the next stage animates the completed and newly active cards together with the shared stage-transition motion; frequent progress and speed updates do not retrigger this transition.
 - active download stage shows:
   - percent above progress bar,
   - speed label and transfer,

--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -113,7 +113,7 @@ Windows summary pre-start prerequisites:
 - Privileged operations must run through helper (`SMAppService + XPC`).
 - No terminal fallback privileged execution path.
 - Stage progression shown in UI must remain deterministic.
-- Each helper-reported stage change animates the completed and newly active progress cards together with the shared stage-transition motion. The animation is presentation-only and does not delay or reorder helper events.
+- Pending and completed progress cards remain at `0.98` scale, while the active card uses `1.0`. Each helper-reported stage change animates the completed and newly active cards together with the shared stage-transition motion. The animation is presentation-only and does not delay or reorder helper events.
 - Every Windows helper request must contain `windowsBootMode`; a missing mode is rejected before stage execution.
 - Linux raw-copy must target whole-disk device, never a partition node.
 - Windows workflow must copy installer files 1:1 from ISO payload (no UEFI fallback file synthesis).

--- a/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
+++ b/docs/reference/features/usb/USB_CREATION_WORKFLOWS.md
@@ -113,6 +113,7 @@ Windows summary pre-start prerequisites:
 - Privileged operations must run through helper (`SMAppService + XPC`).
 - No terminal fallback privileged execution path.
 - Stage progression shown in UI must remain deterministic.
+- Each helper-reported stage change animates the completed and newly active progress cards together with the shared stage-transition motion. The animation is presentation-only and does not delay or reorder helper events.
 - Every Windows helper request must contain `windowsBootMode`; a missing mode is rejected before stage execution.
 - Linux raw-copy must target whole-disk device, never a partition node.
 - Windows workflow must copy installer files 1:1 from ISO payload (no UEFI fallback file synthesis).

--- a/macUSB/Features/Downloader/Logic/Download/MacOSDownloadState.swift
+++ b/macUSB/Features/Downloader/Logic/Download/MacOSDownloadState.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 
-enum DownloadStageVisualState {
+enum DownloadStageVisualState: Hashable {
     case pending
     case active
     case completed

--- a/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
+++ b/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
@@ -32,55 +32,70 @@ extension MacOSDownloaderWindowShellView {
                         }
                     }
 
-                    if downloadFlowModel.isFinished {
-                        downloadSummaryView
-                    } else {
-                        if let networkWarningMessage = downloadFlowModel.networkWarningMessage,
-                           !networkWarningMessage.isEmpty {
-                            StatusCard(tone: .warning, density: .compact) {
-                                HStack(alignment: .top, spacing: 10) {
-                                    Image(systemName: "exclamationmark.triangle.fill")
-                                        .font(.title3)
-                                        .foregroundStyle(.orange)
+                    ZStack(alignment: .topLeading) {
+                        if downloadFlowModel.isFinished {
+                            downloadSummaryView
+                                .transition(downloaderScreenTransition)
+                        } else {
+                            VStack(
+                                alignment: .leading,
+                                spacing: MacUSBDesignTokens.sectionGroupSpacing
+                            ) {
+                                if let networkWarningMessage = downloadFlowModel.networkWarningMessage,
+                                   !networkWarningMessage.isEmpty {
+                                    StatusCard(tone: .warning, density: .compact) {
+                                        HStack(alignment: .top, spacing: 10) {
+                                            Image(systemName: "exclamationmark.triangle.fill")
+                                                .font(.title3)
+                                                .foregroundStyle(.orange)
 
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(String(localized: "Połączenie internetowe zostało utracone"))
-                                            .font(.subheadline.weight(.semibold))
-                                        Text(networkWarningMessage)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
+                                            VStack(alignment: .leading, spacing: 4) {
+                                                Text(String(localized: "Połączenie internetowe zostało utracone"))
+                                                    .font(.subheadline.weight(.semibold))
+                                                Text(networkWarningMessage)
+                                                    .font(.caption)
+                                                    .foregroundStyle(.secondary)
+                                            }
+                                            Spacer(minLength: 0)
+                                        }
                                     }
-                                    Spacer(minLength: 0)
                                 }
-                            }
-                        }
 
-                        if !downloadFlowModel.suppressInlineFailureMessage,
-                           let failureMessage = downloadFlowModel.failureMessage,
-                           !failureMessage.isEmpty {
-                            StatusCard(tone: .warning, density: .compact) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(String(localized: "Nie udało się dokończyć pobierania"))
-                                        .font(.subheadline.weight(.semibold))
-                                    Text(failureMessage)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
+                                if !downloadFlowModel.suppressInlineFailureMessage,
+                                   let failureMessage = downloadFlowModel.failureMessage,
+                                   !failureMessage.isEmpty {
+                                    StatusCard(tone: .warning, density: .compact) {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text(String(localized: "Nie udało się dokończyć pobierania"))
+                                                .font(.subheadline.weight(.semibold))
+                                            Text(failureMessage)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                    }
                                 }
-                            }
-                        }
 
-                        downloadStageSectionDivider
+                                downloadStageSectionDivider
 
-                        VStack(spacing: 10) {
-                            ForEach(MontereyDownloadFlowStage.allCases, id: \.self) { stage in
-                                downloadStageRow(for: stage)
+                                VStack(spacing: 10) {
+                                    ForEach(MontereyDownloadFlowStage.allCases, id: \.self) { stage in
+                                        downloadStageRow(for: stage)
+                                    }
+                                }
+                                .animation(
+                                    MacUSBDesignTokens.stageTransitionAnimation,
+                                    value: downloadStageMotionStates
+                                )
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .transition(downloaderScreenTransition)
                         }
-                        .animation(
-                            MacUSBDesignTokens.stageTransitionAnimation,
-                            value: downloadStageMotionStates
-                        )
                     }
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                    .animation(
+                        MacUSBDesignTokens.stageTransitionAnimation,
+                        value: downloadFlowModel.isFinished
+                    )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
+++ b/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
@@ -195,7 +195,8 @@ extension MacOSDownloaderWindowShellView {
             }
         }
         .id(stageState)
-        .transition(MacUSBDesignTokens.stageCardTransition)
+        .scaleEffect(MacUSBDesignTokens.stageScale(isActive: stageState == .active))
+        .transition(MacUSBDesignTokens.stageCardTransition(isActive: stageState == .active))
     }
 
     private var downloadStageMotionStates: [DownloadStageVisualState] {

--- a/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
+++ b/macUSB/Features/Downloader/UI/MacOSDownloaderProcessView.swift
@@ -76,6 +76,10 @@ extension MacOSDownloaderWindowShellView {
                                 downloadStageRow(for: stage)
                             }
                         }
+                        .animation(
+                            MacUSBDesignTokens.stageTransitionAnimation,
+                            value: downloadStageMotionStates
+                        )
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -110,84 +114,92 @@ extension MacOSDownloaderWindowShellView {
     func downloadStageRow(for stage: MontereyDownloadFlowStage) -> some View {
         let stageState = downloadFlowModel.visualState(for: stage)
 
-        switch stageState {
-        case .pending:
-            StatusCard(tone: .subtle, density: .compact) {
-                HStack(spacing: 12) {
-                    Image(systemName: pendingIconForDownloadStage(stage))
-                        .font(.title3)
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24)
-                    Text(downloadStageTitle(for: stage))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                }
-            }
-
-        case .active:
-            StatusCard(
-                tone: .active,
-                cornerRadius: MacUSBDesignTokens.prominentPanelCornerRadius(for: currentVisualMode())
-            ) {
-                VStack(alignment: .leading, spacing: 10) {
+        Group {
+            switch stageState {
+            case .pending:
+                StatusCard(tone: .subtle, density: .compact) {
                     HStack(spacing: 12) {
-                        Image(systemName: activeIconForDownloadStage(stage))
+                        Image(systemName: pendingIconForDownloadStage(stage))
                             .font(.title3)
-                            .foregroundColor(.accentColor)
+                            .foregroundStyle(.secondary)
                             .frame(width: 24)
                         Text(downloadStageTitle(for: stage))
-                            .font(.headline)
-                        Spacer()
-                        if stage == .downloading {
-                            Text(downloadProgressText())
-                                .font(.title3.monospacedDigit())
-                                .fontWeight(.semibold)
-                                .foregroundColor(.accentColor)
-                        }
-                    }
-
-                    if let description = downloadStageDescription(for: stage) {
-                        Text(description)
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
+                        Spacer()
                     }
+                }
 
-                    if let progress = downloadStageProgress(for: stage) {
-                        ProgressView(value: progress)
-                            .progressViewStyle(.linear)
-                    } else {
-                        ProgressView()
-                            .progressViewStyle(.linear)
-                    }
-
-                    if stage == .downloading {
-                        HStack {
-                            Text(verbatim: downloadSpeedLabelText())
-                                .font(.subheadline.monospacedDigit())
-                                .foregroundStyle(.secondary)
+            case .active:
+                StatusCard(
+                    tone: .active,
+                    cornerRadius: MacUSBDesignTokens.prominentPanelCornerRadius(for: currentVisualMode())
+                ) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 12) {
+                            Image(systemName: activeIconForDownloadStage(stage))
+                                .font(.title3)
+                                .foregroundColor(.accentColor)
+                                .frame(width: 24)
+                            Text(downloadStageTitle(for: stage))
+                                .font(.headline)
                             Spacer()
-                            Text(downloadFlowModel.downloadTransferredText)
-                                .font(.caption.monospacedDigit())
+                            if stage == .downloading {
+                                Text(downloadProgressText())
+                                    .font(.title3.monospacedDigit())
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+
+                        if let description = downloadStageDescription(for: stage) {
+                            Text(description)
+                                .font(.subheadline)
                                 .foregroundStyle(.secondary)
+                        }
+
+                        if let progress = downloadStageProgress(for: stage) {
+                            ProgressView(value: progress)
+                                .progressViewStyle(.linear)
+                        } else {
+                            ProgressView()
+                                .progressViewStyle(.linear)
+                        }
+
+                        if stage == .downloading {
+                            HStack {
+                                Text(verbatim: downloadSpeedLabelText())
+                                    .font(.subheadline.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text(downloadFlowModel.downloadTransferredText)
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }
-            }
 
-        case .completed:
-            StatusCard(tone: .neutral, density: .compact) {
-                HStack(spacing: 12) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.title3)
-                        .foregroundColor(.green)
-                        .frame(width: 24)
-                    Text(downloadStageTitle(for: stage))
-                        .font(.subheadline)
-                    Spacer()
+            case .completed:
+                StatusCard(tone: .neutral, density: .compact) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.title3)
+                            .foregroundColor(.green)
+                            .frame(width: 24)
+                        Text(downloadStageTitle(for: stage))
+                            .font(.subheadline)
+                        Spacer()
+                    }
                 }
             }
         }
+        .id(stageState)
+        .transition(MacUSBDesignTokens.stageCardTransition)
+    }
+
+    private var downloadStageMotionStates: [DownloadStageVisualState] {
+        MontereyDownloadFlowStage.allCases.map(downloadFlowModel.visualState(for:))
     }
 
     func pendingIconForDownloadStage(_ stage: MontereyDownloadFlowStage) -> String {

--- a/macUSB/Features/Downloader/UI/MacOSDownloaderWindowShellView.swift
+++ b/macUSB/Features/Downloader/UI/MacOSDownloaderWindowShellView.swift
@@ -29,11 +29,16 @@ struct MacOSDownloaderWindowShellView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .macUSBPanelSurface(.subtle)
 
-            if let activeDownloadEntry {
-                downloaderProgressSection(for: activeDownloadEntry)
-            } else {
-                installerSelectionSection
+            ZStack(alignment: .topLeading) {
+                if let activeDownloadEntry {
+                    downloaderProgressSection(for: activeDownloadEntry)
+                        .transition(downloaderScreenTransition)
+                } else {
+                    installerSelectionSection
+                        .transition(downloaderScreenTransition)
+                }
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .padding(.horizontal, MacUSBDesignTokens.contentHorizontalPadding)
         .padding(.top, MacUSBDesignTokens.contentVerticalPadding)
@@ -124,6 +129,12 @@ struct MacOSDownloaderWindowShellView: View {
         shouldConfirmCloseDuringDownload
             ? String(localized: "Anuluj")
             : String(localized: "Zamknij")
+    }
+
+    var downloaderScreenTransition: AnyTransition {
+        .opacity.combined(
+            with: .scale(scale: MacUSBDesignTokens.stageTransitionScale)
+        )
     }
 
     var managerDescriptionText: String {
@@ -358,7 +369,9 @@ struct MacOSDownloaderWindowShellView: View {
             )
         }
 
-        activeDownloadEntry = entry
+        withAnimation(MacUSBDesignTokens.stageTransitionAnimation) {
+            activeDownloadEntry = entry
+        }
         downloadFlowModel.start(for: entry, using: logic)
 
         AppLogging.info(

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -293,7 +293,8 @@ struct CreationProgressView: View {
             }
         }
         .id(stageState)
-        .transition(MacUSBDesignTokens.stageCardTransition)
+        .scaleEffect(MacUSBDesignTokens.stageScale(isActive: stageState == .active))
+        .transition(MacUSBDesignTokens.stageCardTransition(isActive: stageState == .active))
     }
 
     private var creationStageMotionStates: [CreationStageVisualState] {

--- a/macUSB/Features/Installation/CreationProgressView.swift
+++ b/macUSB/Features/Installation/CreationProgressView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AppKit
 
-private enum CreationStageVisualState {
+private enum CreationStageVisualState: Hashable {
     case pending
     case active
     case completed
@@ -161,6 +161,10 @@ struct CreationProgressView: View {
                             stageRow(for: stage, at: index)
                         }
                     }
+                    .animation(
+                        MacUSBDesignTokens.stageTransitionAnimation,
+                        value: creationStageMotionStates
+                    )
                 }
                 .padding(.horizontal, MacUSBDesignTokens.contentHorizontalPadding)
                 .padding(.vertical, MacUSBDesignTokens.contentVerticalPadding)
@@ -219,73 +223,81 @@ struct CreationProgressView: View {
     private func stageRow(for stage: CreationStageDescriptor, at index: Int) -> some View {
         let stageState = stateForStage(at: index)
 
-        switch stageState {
-        case .pending:
-            StatusCard(tone: .subtle, density: .compact) {
-                HStack(spacing: 12) {
-                    Image(systemName: pendingIconForStage(stage.key))
-                        .font(sectionIconFont)
-                        .foregroundColor(.secondary)
-                        .frame(width: 24)
-                    Text(LocalizedStringKey(stage.titleKey))
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                    Spacer()
-                }
-            }
-
-        case .active:
-            StatusCard(
-                tone: .active,
-                cornerRadius: MacUSBDesignTokens.prominentPanelCornerRadius(for: currentVisualMode())
-            ) {
-                VStack(alignment: .leading, spacing: 10) {
+        Group {
+            switch stageState {
+            case .pending:
+                StatusCard(tone: .subtle, density: .compact) {
                     HStack(spacing: 12) {
-                        Image(systemName: activeIconForStage(stage.key))
+                        Image(systemName: pendingIconForStage(stage.key))
                             .font(sectionIconFont)
-                            .foregroundColor(.accentColor)
+                            .foregroundColor(.secondary)
                             .frame(width: 24)
                         Text(LocalizedStringKey(stage.titleKey))
-                            .font(.headline)
-                        Spacer()
-                        if shouldShowCopyProgress(for: stage.key) {
-                            Text(copyProgressText())
-                                .font(.title3.monospacedDigit())
-                                .fontWeight(.semibold)
-                                .foregroundColor(.accentColor)
-                        }
-                    }
-                    Text(LocalizedStringKey(effectiveStatusKey(for: stage.key)))
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                    if shouldShowCopyProgress(for: stage.key) {
-                        ProgressView(value: boundedCopyProgressPercent() / 100.0)
-                            .progressViewStyle(.linear)
-                    } else {
-                        ProgressView()
-                            .progressViewStyle(.linear)
-                    }
-                    if shouldShowWriteSpeed(for: stage.key) {
-                        Text(verbatim: writeSpeedLabelText())
-                            .font(.subheadline.monospacedDigit())
+                            .font(.subheadline)
                             .foregroundColor(.secondary)
+                        Spacer()
                     }
                 }
-            }
 
-        case .completed:
-            StatusCard(tone: .neutral, density: .compact) {
-                HStack(spacing: 12) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(sectionIconFont)
-                        .foregroundColor(.green)
-                        .frame(width: 24)
-                    Text(LocalizedStringKey(stage.titleKey))
-                        .font(.subheadline)
-                    Spacer()
+            case .active:
+                StatusCard(
+                    tone: .active,
+                    cornerRadius: MacUSBDesignTokens.prominentPanelCornerRadius(for: currentVisualMode())
+                ) {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 12) {
+                            Image(systemName: activeIconForStage(stage.key))
+                                .font(sectionIconFont)
+                                .foregroundColor(.accentColor)
+                                .frame(width: 24)
+                            Text(LocalizedStringKey(stage.titleKey))
+                                .font(.headline)
+                            Spacer()
+                            if shouldShowCopyProgress(for: stage.key) {
+                                Text(copyProgressText())
+                                    .font(.title3.monospacedDigit())
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                        Text(LocalizedStringKey(effectiveStatusKey(for: stage.key)))
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        if shouldShowCopyProgress(for: stage.key) {
+                            ProgressView(value: boundedCopyProgressPercent() / 100.0)
+                                .progressViewStyle(.linear)
+                        } else {
+                            ProgressView()
+                                .progressViewStyle(.linear)
+                        }
+                        if shouldShowWriteSpeed(for: stage.key) {
+                            Text(verbatim: writeSpeedLabelText())
+                                .font(.subheadline.monospacedDigit())
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+
+            case .completed:
+                StatusCard(tone: .neutral, density: .compact) {
+                    HStack(spacing: 12) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(sectionIconFont)
+                            .foregroundColor(.green)
+                            .frame(width: 24)
+                        Text(LocalizedStringKey(stage.titleKey))
+                            .font(.subheadline)
+                        Spacer()
+                    }
                 }
             }
         }
+        .id(stageState)
+        .transition(MacUSBDesignTokens.stageCardTransition)
+    }
+
+    private var creationStageMotionStates: [CreationStageVisualState] {
+        stageDescriptors.indices.map(stateForStage(at:))
     }
 
     private func stageDescriptor(for stageKey: String) -> CreationStageDescriptor {

--- a/macUSB/Shared/UI/DesignTokens.swift
+++ b/macUSB/Shared/UI/DesignTokens.swift
@@ -26,8 +26,13 @@ enum MacUSBDesignTokens {
         .easeInOut(duration: stageTransitionDuration)
     }
 
-    static var stageCardTransition: AnyTransition {
-        .opacity.combined(with: .scale(scale: stageTransitionScale))
+    static func stageScale(isActive: Bool) -> CGFloat {
+        isActive ? 1 : stageTransitionScale
+    }
+
+    static func stageCardTransition(isActive: Bool) -> AnyTransition {
+        guard isActive else { return .opacity }
+        return .opacity.combined(with: .scale(scale: stageTransitionScale))
     }
 
     static func panelCornerRadius(for mode: VisualSystemMode) -> CGFloat {

--- a/macUSB/Shared/UI/DesignTokens.swift
+++ b/macUSB/Shared/UI/DesignTokens.swift
@@ -19,6 +19,17 @@ enum MacUSBDesignTokens {
 
     static let iconColumnWidth: CGFloat = 32
 
+    static let stageTransitionDuration: Double = 0.24
+    static let stageTransitionScale: CGFloat = 0.98
+
+    static var stageTransitionAnimation: Animation {
+        .easeInOut(duration: stageTransitionDuration)
+    }
+
+    static var stageCardTransition: AnyTransition {
+        .opacity.combined(with: .scale(scale: stageTransitionScale))
+    }
+
     static func panelCornerRadius(for mode: VisualSystemMode) -> CGFloat {
         switch mode {
         case .liquidGlass:


### PR DESCRIPTION
This adds shared fade-and-scale transitions to downloader and USB creation stage cards. It also animates the downloader’s selection-to-process and process-to-summary screen changes.